### PR TITLE
Multi-tab multi-agent workbench (Phase 1)

### DIFF
--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -37,7 +37,12 @@ pub async fn start_agent_run(
     state: State<'_, AppState>,
     request: AgentRunRequest,
 ) -> Result<AgentRun, String> {
-    let run = AgentRun::new(request.goal.clone(), request.agent_id.clone());
+    let run = match request.run_id.clone() {
+        Some(id) if !id.trim().is_empty() => {
+            AgentRun::with_id(id, request.goal.clone(), request.agent_id.clone())
+        }
+        _ => AgentRun::new(request.goal.clone(), request.agent_id.clone()),
+    };
     let run_for_task = run.clone();
     let sink = TauriRunEventSink::new(app);
     let permissions = state.permissions();
@@ -45,7 +50,7 @@ pub async fn start_agent_run(
     let state_for_task = state_handle.clone();
 
     state_handle
-        .reserve_run_if_idle(run.id.clone())
+        .reserve_run(run.id.clone())
         .await
         .map_err(|err| err.to_string())?;
 

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -194,15 +194,17 @@ pub async fn cancel_agent_run(
     run_id: String,
 ) -> Result<(), String> {
     let cancelled = state.cancel_run(&run_id).await;
-    if cancelled {
-        TauriRunEventSink::new(app).emit(
-            &run_id,
-            RunEvent::Lifecycle {
-                status: LifecycleStatus::Cancelled,
-                message: "run cancelled".into(),
+    TauriRunEventSink::new(app).emit(
+        &run_id,
+        RunEvent::Lifecycle {
+            status: LifecycleStatus::Cancelled,
+            message: if cancelled {
+                "run cancelled".into()
+            } else {
+                "run was already terminated".into()
             },
-        );
-    }
+        },
+    );
     Ok(())
 }
 

--- a/src-tauri/src/adapters/tauri/session_state.rs
+++ b/src-tauri/src/adapters/tauri/session_state.rs
@@ -2,24 +2,41 @@ use anyhow::{Result, anyhow};
 use std::{collections::HashMap, env, sync::Arc};
 use tokio::{sync::Mutex, task::JoinHandle};
 
+use crate::{
+    adapters::acp::runner::AcpSession,
+    ports::permission::{PermissionDecision, PermissionDecisionPort},
+};
+
 const MAX_RUNS_ENV: &str = "ACP_WORKBENCH_MAX_RUNS";
 
-fn max_concurrent_runs() -> Option<usize> {
+fn read_max_runs_from_env() -> Option<usize> {
     match env::var(MAX_RUNS_ENV) {
         Ok(raw) => raw.trim().parse::<usize>().ok().filter(|n| *n > 0),
         Err(_) => None,
     }
 }
 
-use crate::{
-    adapters::acp::runner::AcpSession,
-    ports::permission::{PermissionDecision, PermissionDecisionPort},
-};
-
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct AppState {
     runs: Arc<Mutex<HashMap<String, RunSlot>>>,
     permissions: PermissionBroker,
+    max_concurrent_runs: Option<usize>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::with_max_concurrent_runs(read_max_runs_from_env())
+    }
+}
+
+impl AppState {
+    pub fn with_max_concurrent_runs(max_concurrent_runs: Option<usize>) -> Self {
+        Self {
+            runs: Arc::default(),
+            permissions: PermissionBroker::default(),
+            max_concurrent_runs,
+        }
+    }
 }
 
 enum RunSlot {
@@ -42,7 +59,7 @@ impl AppState {
         if runs.contains_key(&run_id) {
             return Err(anyhow!("duplicate run id: {run_id}"));
         }
-        if let Some(limit) = max_concurrent_runs() {
+        if let Some(limit) = self.max_concurrent_runs {
             if runs.len() >= limit {
                 return Err(anyhow!(
                     "concurrent run limit ({limit}) reached; cancel an existing run before starting a new one"
@@ -195,6 +212,33 @@ mod tests {
         assert_eq!(state.active_run_count().await, 1);
         assert!(state.cancel_run("run-b").await);
         assert_eq!(state.active_run_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn reserve_run_respects_injected_concurrent_limit() {
+        let state = AppState::with_max_concurrent_runs(Some(1));
+        state.reserve_run("run-a".into()).await.unwrap();
+        let err = state
+            .reserve_run("run-b".into())
+            .await
+            .expect_err("second run should be rejected by the limit");
+        assert!(err.to_string().contains("concurrent run limit"));
+        assert!(state.cancel_run("run-a").await);
+        state
+            .reserve_run("run-b".into())
+            .await
+            .expect("limit should free up after cancel");
+    }
+
+    #[tokio::test]
+    async fn reserve_run_duplicate_id_is_rejected_before_limit_check() {
+        let state = AppState::with_max_concurrent_runs(Some(2));
+        state.reserve_run("run-a".into()).await.unwrap();
+        let err = state
+            .reserve_run("run-a".into())
+            .await
+            .expect_err("duplicate id must fail");
+        assert!(err.to_string().contains("duplicate run id"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/adapters/tauri/session_state.rs
+++ b/src-tauri/src/adapters/tauri/session_state.rs
@@ -1,6 +1,15 @@
 use anyhow::{Result, anyhow};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, env, sync::Arc};
 use tokio::{sync::Mutex, task::JoinHandle};
+
+const MAX_RUNS_ENV: &str = "ACP_WORKBENCH_MAX_RUNS";
+
+fn max_concurrent_runs() -> Option<usize> {
+    match env::var(MAX_RUNS_ENV) {
+        Ok(raw) => raw.trim().parse::<usize>().ok().filter(|n| *n > 0),
+        Err(_) => None,
+    }
+}
 
 use crate::{
     adapters::acp::runner::AcpSession,
@@ -28,13 +37,24 @@ impl AppState {
         self.permissions.clone()
     }
 
-    pub async fn reserve_run_if_idle(&self, run_id: String) -> Result<()> {
+    pub async fn reserve_run(&self, run_id: String) -> Result<()> {
         let mut runs = self.runs.lock().await;
-        if !runs.is_empty() {
-            return Err(anyhow!("another agent run is already in progress"));
+        if runs.contains_key(&run_id) {
+            return Err(anyhow!("duplicate run id: {run_id}"));
+        }
+        if let Some(limit) = max_concurrent_runs() {
+            if runs.len() >= limit {
+                return Err(anyhow!(
+                    "concurrent run limit ({limit}) reached; cancel an existing run before starting a new one"
+                ));
+            }
         }
         runs.insert(run_id, RunSlot::Reserved);
         Ok(())
+    }
+
+    pub async fn active_run_count(&self) -> usize {
+        self.runs.lock().await.len()
     }
 
     pub async fn attach_run_handle(&self, run_id: &str, handle: JoinHandle<()>) -> Result<()> {
@@ -138,8 +158,44 @@ impl PermissionBroker {
 
 #[cfg(test)]
 mod tests {
-    use super::PermissionBroker;
+    use super::{AppState, PermissionBroker};
     use crate::ports::permission::{PermissionDecision, PermissionDecisionPort};
+
+    #[tokio::test]
+    async fn reserve_run_allows_multiple_distinct_run_ids() {
+        let state = AppState::default();
+        state
+            .reserve_run("run-a".into())
+            .await
+            .expect("first run should reserve");
+        state
+            .reserve_run("run-b".into())
+            .await
+            .expect("second concurrent run should reserve");
+        assert_eq!(state.active_run_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn reserve_run_rejects_duplicate_run_id() {
+        let state = AppState::default();
+        state.reserve_run("run-a".into()).await.unwrap();
+        let err = state
+            .reserve_run("run-a".into())
+            .await
+            .expect_err("duplicate reservation must fail");
+        assert!(err.to_string().contains("duplicate run id"));
+    }
+
+    #[tokio::test]
+    async fn cancel_run_does_not_affect_other_runs() {
+        let state = AppState::default();
+        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-b".into()).await.unwrap();
+        assert!(state.cancel_run("run-a").await);
+        assert_eq!(state.active_run_count().await, 1);
+        assert!(state.cancel_run("run-b").await);
+        assert_eq!(state.active_run_count().await, 0);
+    }
 
     #[tokio::test]
     async fn clearing_one_run_keeps_other_run_permission_waiters() {

--- a/src-tauri/src/domain/run.rs
+++ b/src-tauri/src/domain/run.rs
@@ -10,6 +10,7 @@ pub struct AgentRunRequest {
     pub agent_command: Option<String>,
     pub stdio_buffer_limit_mb: Option<usize>,
     pub auto_allow: Option<bool>,
+    pub run_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -22,10 +23,10 @@ pub struct AgentRun {
 
 impl AgentRun {
     pub fn new(goal: String, agent_id: String) -> Self {
-        Self {
-            id: Uuid::new_v4().to_string(),
-            goal,
-            agent_id,
-        }
+        Self::with_id(Uuid::new_v4().to_string(), goal, agent_id)
+    }
+
+    pub fn with_id(id: String, goal: String, agent_id: String) -> Self {
+        Self { id, goal, agent_id }
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,9 +1,15 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { AgentWorkbenchPage } from "../pages/agent-workbench";
+import { installAgentRuntime } from "../features/agent-run/runtime";
 
 const queryClient = new QueryClient();
 
 export function App() {
+  useEffect(() => {
+    void installAgentRuntime();
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <AgentWorkbenchPage />

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -764,3 +764,132 @@ button:disabled {
     grid-column: 1;
   }
 }
+
+.tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 16px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(23, 25, 21, 0.08);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+.tab-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #20231f;
+  font-size: 13px;
+  max-width: 220px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.tab-item:hover {
+  background: rgba(23, 25, 21, 0.04);
+}
+
+.tab-item--active {
+  background: #fff;
+  border-color: rgba(23, 25, 21, 0.14);
+  box-shadow: 0 1px 3px rgba(23, 25, 21, 0.08);
+}
+
+.tab-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #b8bcb4;
+  flex-shrink: 0;
+}
+
+.tab-status--running {
+  background: #2f8a4a;
+}
+
+.tab-status--awaiting {
+  background: #2e6be6;
+  animation: tab-status-pulse 1.2s ease-in-out infinite;
+}
+
+.tab-status--idle-countdown {
+  background: #e08a1a;
+}
+
+.tab-status--error {
+  background: #c43c3c;
+}
+
+.tab-status--closing {
+  background: #9a9a9a;
+  animation: tab-status-pulse 1s ease-in-out infinite;
+}
+
+@keyframes tab-status-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.tab-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.tab-permission {
+  color: #c4761f;
+  font-size: 12px;
+}
+
+.tab-unread {
+  background: #2e6be6;
+  color: #fff;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  min-width: 18px;
+  text-align: center;
+}
+
+.tab-close {
+  border: none;
+  background: transparent;
+  color: rgba(23, 25, 21, 0.5);
+  padding: 0 4px;
+  font-size: 16px;
+  line-height: 1;
+  border-radius: 4px;
+}
+
+.tab-close:hover {
+  background: rgba(23, 25, 21, 0.08);
+  color: #171915;
+}
+
+.tab-add {
+  border: 1px dashed rgba(23, 25, 21, 0.2);
+  background: transparent;
+  color: rgba(23, 25, 21, 0.6);
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.tab-add:hover {
+  background: rgba(23, 25, 21, 0.04);
+  color: #171915;
+}

--- a/src/entities/message/model.ts
+++ b/src/entities/message/model.ts
@@ -1,4 +1,5 @@
 export type AgentRunRequest = {
+  runId?: string;
   goal: string;
   agentId: string;
   cwd?: string;

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -40,6 +40,7 @@ type WorkbenchState = {
   activeTabId: string;
   addTab: (preset?: Partial<TabState>) => string;
   closeTab: (tabId: string) => string | null;
+  forceCloseTab: (tabId: string) => string | null;
   activateTab: (tabId: string) => void;
   renameTab: (tabId: string, title: string) => void;
   patchTab: (tabId: string, patch: Partial<TabState>) => void;
@@ -54,7 +55,7 @@ type WorkbenchState = {
 };
 
 function createId(prefix: string) {
-  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+  return `${prefix}-${crypto.randomUUID()}`;
 }
 
 function defaultTabTitle(index: number) {
@@ -137,6 +138,25 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
       return state.activeTabId;
     }
 
+    if (state.tabs.length <= 1) {
+      const replacement = createTabState({}, 0);
+      set({ tabs: [replacement], activeTabId: replacement.id });
+      return replacement.id;
+    }
+    const index = state.tabs.findIndex((t) => t.id === tabId);
+    const remaining = state.tabs.filter((t) => t.id !== tabId);
+    let nextActive = state.activeTabId;
+    if (state.activeTabId === tabId) {
+      const neighbor = remaining[index] ?? remaining[index - 1] ?? remaining[0];
+      nextActive = neighbor.id;
+    }
+    set({ tabs: remaining, activeTabId: nextActive });
+    return nextActive;
+  },
+
+  forceCloseTab: (tabId) => {
+    const state = get();
+    if (!state.tabs.some((t) => t.id === tabId)) return state.activeTabId;
     if (state.tabs.length <= 1) {
       const replacement = createTabState({}, 0);
       set({ tabs: [replacement], activeTabId: replacement.id });
@@ -297,6 +317,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
           permissionPending = event.requiresResponse;
         }
 
+        const nextUnread = isActive ? t.unreadCount : t.unreadCount + 1;
         return {
           ...t,
           items: nextItems,
@@ -305,7 +326,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
           error,
           permissionPending,
           idleRemainingSec,
-          unreadCount: isActive ? 0 : t.unreadCount + 1,
+          unreadCount: nextUnread,
         };
       }),
     }));

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -1,15 +1,19 @@
 import { create } from "zustand";
-import type { EventGroup, TimelineItem } from "../../entities/message/model";
+import type { EventGroup, RunEvent, TimelineItem } from "../../entities/message/model";
+import { toTimelineItem } from "../../entities/message/format";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
 
 export type FollowUpQueueItem = {
   id: string;
+  runId: string;
   text: string;
   createdAt: number;
 };
 
-type AgentRunState = {
+export type TabState = {
+  id: string;
+  title: string;
   selectedAgentId: string;
   goal: string;
   cwd: string;
@@ -26,121 +30,307 @@ type AgentRunState = {
   items: TimelineItem[];
   filter: EventGroup | "all";
   error: string | null;
-  setSelectedAgentId: (value: string) => void;
-  setGoal: (value: string) => void;
-  setCwd: (value: string) => void;
-  setCustomCommand: (value: string) => void;
-  setStdioBufferLimitMb: (value: number) => void;
-  setAutoAllow: (value: boolean) => void;
-  setIdleTimeoutSec: (value: number) => void;
-  setIdleRemainingSec: (value: number | null) => void;
-  setActiveRunId: (value: string | null) => void;
-  setSessionActive: (value: boolean) => void;
-  setAwaitingResponse: (value: boolean) => void;
-  setFollowUpDraft: (value: string) => void;
-  enqueueFollowUp: (text: string) => void;
-  removeFollowUp: (id: string) => void;
-  dequeueFollowUp: () => FollowUpQueueItem | undefined;
-  clearFollowUpQueue: () => void;
-  setError: (value: string | null) => void;
-  setFilter: (value: EventGroup | "all") => void;
-  beginRun: () => void;
-  endRun: () => void;
-  resetTimeline: () => void;
-  appendItem: (item: TimelineItem) => void;
+  unreadCount: number;
+  permissionPending: boolean;
+  closing: boolean;
 };
 
-function createQueueId() {
-  return `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+type WorkbenchState = {
+  tabs: TabState[];
+  activeTabId: string;
+  addTab: (preset?: Partial<TabState>) => string;
+  closeTab: (tabId: string) => string | null;
+  activateTab: (tabId: string) => void;
+  renameTab: (tabId: string, title: string) => void;
+  patchTab: (tabId: string, patch: Partial<TabState>) => void;
+  enqueueFollowUp: (tabId: string, text: string) => void;
+  removeFollowUp: (tabId: string, id: string) => void;
+  dequeueFollowUp: (tabId: string) => FollowUpQueueItem | undefined;
+  appendItem: (tabId: string, item: TimelineItem) => void;
+  beginRun: (tabId: string, runId: string) => void;
+  endRun: (tabId: string) => void;
+  markClosing: (tabId: string) => void;
+  dispatchRunEvent: (runId: string, event: RunEvent) => void;
+};
+
+function createId(prefix: string) {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
 }
 
-export const useAgentRunStore = create<AgentRunState>((set, get) => ({
-  selectedAgentId: "claude-code",
-  goal: defaultGoal,
-  cwd: "~/tmp/acp-tauri-agent-workspace",
-  customCommand: "",
-  stdioBufferLimitMb: 50,
-  autoAllow: true,
-  idleTimeoutSec: 60,
-  idleRemainingSec: null,
-  activeRunId: null,
-  sessionActive: false,
-  awaitingResponse: false,
-  followUpDraft: "",
-  followUpQueue: [],
-  items: [],
-  filter: "all",
-  error: null,
-  setSelectedAgentId: (selectedAgentId) => set({ selectedAgentId }),
-  setGoal: (goal) => set({ goal }),
-  setCwd: (cwd) => set({ cwd }),
-  setCustomCommand: (customCommand) => set({ customCommand }),
-  setStdioBufferLimitMb: (stdioBufferLimitMb) => set({ stdioBufferLimitMb }),
-  setAutoAllow: (autoAllow) => set({ autoAllow }),
-  setIdleTimeoutSec: (idleTimeoutSec) => set({ idleTimeoutSec }),
-  setIdleRemainingSec: (idleRemainingSec) => set({ idleRemainingSec }),
-  setActiveRunId: (activeRunId) => set({ activeRunId }),
-  setSessionActive: (sessionActive) => set({ sessionActive }),
-  setAwaitingResponse: (awaitingResponse) => set({ awaitingResponse }),
-  setFollowUpDraft: (followUpDraft) => set({ followUpDraft }),
-  enqueueFollowUp: (text) =>
-    set((state) => ({
-      followUpQueue: [
-        ...state.followUpQueue,
-        { id: createQueueId(), text, createdAt: Date.now() },
-      ],
-    })),
-  removeFollowUp: (id) =>
-    set((state) => ({
-      followUpQueue: state.followUpQueue.filter((item) => item.id !== id),
-    })),
-  dequeueFollowUp: () => {
-    const [next, ...rest] = get().followUpQueue;
-    if (!next) return undefined;
-    set({ followUpQueue: rest });
-    return next;
+function defaultTabTitle(index: number) {
+  return `Tab ${index + 1}`;
+}
+
+export function createTabState(preset: Partial<TabState> = {}, index = 0): TabState {
+  return {
+    id: preset.id ?? createId("tab"),
+    title: preset.title ?? defaultTabTitle(index),
+    selectedAgentId: preset.selectedAgentId ?? "claude-code",
+    goal: preset.goal ?? defaultGoal,
+    cwd: preset.cwd ?? "~/tmp/acp-tauri-agent-workspace",
+    customCommand: preset.customCommand ?? "",
+    stdioBufferLimitMb: preset.stdioBufferLimitMb ?? 50,
+    autoAllow: preset.autoAllow ?? true,
+    idleTimeoutSec: preset.idleTimeoutSec ?? 60,
+    idleRemainingSec: preset.idleRemainingSec ?? null,
+    activeRunId: preset.activeRunId ?? null,
+    sessionActive: preset.sessionActive ?? false,
+    awaitingResponse: preset.awaitingResponse ?? false,
+    followUpDraft: preset.followUpDraft ?? "",
+    followUpQueue: preset.followUpQueue ?? [],
+    items: preset.items ?? [],
+    filter: preset.filter ?? "all",
+    error: preset.error ?? null,
+    unreadCount: preset.unreadCount ?? 0,
+    permissionPending: preset.permissionPending ?? false,
+    closing: preset.closing ?? false,
+  };
+}
+
+function replaceTab(tabs: TabState[], tabId: string, updater: (tab: TabState) => TabState) {
+  return tabs.map((tab) => (tab.id === tabId ? updater(tab) : tab));
+}
+
+function mergeStreamedText(items: TimelineItem[], item: TimelineItem): TimelineItem[] {
+  const previous = items[items.length - 1];
+  const canMerge =
+    (previous?.event.type === "agentMessage" && item.event.type === "agentMessage") ||
+    (previous?.event.type === "thought" && item.event.type === "thought");
+  if (previous && canMerge) {
+    const previousText = (previous.event as { text: string }).text;
+    const incomingText = (item.event as { text: string }).text;
+    const mergedText = `${previousText}${incomingText}`;
+    return [
+      ...items.slice(0, -1),
+      {
+        ...previous,
+        body: `${previous.body}${item.body}`,
+        event: { ...previous.event, text: mergedText } as typeof previous.event,
+      },
+    ];
+  }
+  return [...items, item];
+}
+
+const initialTab = createTabState({}, 0);
+
+export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
+  tabs: [initialTab],
+  activeTabId: initialTab.id,
+
+  addTab: (preset) => {
+    const state = get();
+    const tab = createTabState(preset, state.tabs.length);
+    set({ tabs: [...state.tabs, tab], activeTabId: tab.id });
+    return tab.id;
   },
-  clearFollowUpQueue: () => set({ followUpQueue: [] }),
-  setError: (error) => set({ error }),
-  setFilter: (filter) => set({ filter }),
-  beginRun: () =>
-    set({
-      activeRunId: null,
-      sessionActive: true,
-      awaitingResponse: true,
-      followUpDraft: "",
-      followUpQueue: [],
-      idleRemainingSec: null,
-      items: [],
-      error: null,
-    }),
-  endRun: () =>
-    set({
-      sessionActive: false,
-      awaitingResponse: false,
-      followUpQueue: [],
-      idleRemainingSec: null,
-    }),
-  resetTimeline: () => set({ items: [] }),
-  appendItem: (item) =>
+
+  closeTab: (tabId) => {
+    const state = get();
+    const target = state.tabs.find((t) => t.id === tabId);
+    if (!target) return state.activeTabId;
+
+    if (target.sessionActive && target.activeRunId) {
+      set({
+        tabs: replaceTab(state.tabs, tabId, (tab) => ({ ...tab, closing: true })),
+      });
+      return state.activeTabId;
+    }
+
+    if (state.tabs.length <= 1) {
+      const replacement = createTabState({}, 0);
+      set({ tabs: [replacement], activeTabId: replacement.id });
+      return replacement.id;
+    }
+    const index = state.tabs.findIndex((t) => t.id === tabId);
+    const remaining = state.tabs.filter((t) => t.id !== tabId);
+    let nextActive = state.activeTabId;
+    if (state.activeTabId === tabId) {
+      const neighbor = remaining[index] ?? remaining[index - 1] ?? remaining[0];
+      nextActive = neighbor.id;
+    }
+    set({ tabs: remaining, activeTabId: nextActive });
+    return nextActive;
+  },
+
+  activateTab: (tabId) =>
     set((state) => {
-      const previous = state.items[state.items.length - 1];
-      if (
-        (previous?.event.type === "agentMessage" && item.event.type === "agentMessage") ||
-        (previous?.event.type === "thought" && item.event.type === "thought")
-      ) {
-        const mergedText = `${previous.event.text}${item.event.text}`;
+      if (!state.tabs.some((t) => t.id === tabId)) return state;
+      return {
+        activeTabId: tabId,
+        tabs: replaceTab(state.tabs, tabId, (tab) => ({
+          ...tab,
+          unreadCount: 0,
+        })),
+      };
+    }),
+
+  renameTab: (tabId, title) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({ ...tab, title })),
+    })),
+
+  patchTab: (tabId, patch) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({ ...tab, ...patch })),
+    })),
+
+  enqueueFollowUp: (tabId, text) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => {
+        if (!tab.activeRunId) return tab;
         return {
-          items: [
-            ...state.items.slice(0, -1),
+          ...tab,
+          followUpQueue: [
+            ...tab.followUpQueue,
             {
-              ...previous,
-              body: `${previous.body}${item.body}`,
-              event: { ...previous.event, text: mergedText },
+              id: createId("q"),
+              runId: tab.activeRunId,
+              text,
+              createdAt: Date.now(),
             },
           ],
         };
+      }),
+    })),
+
+  removeFollowUp: (tabId, id) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({
+        ...tab,
+        followUpQueue: tab.followUpQueue.filter((entry) => entry.id !== id),
+      })),
+    })),
+
+  dequeueFollowUp: (tabId) => {
+    const tab = get().tabs.find((t) => t.id === tabId);
+    const [next, ...rest] = tab?.followUpQueue ?? [];
+    if (!next) return undefined;
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (t) => ({ ...t, followUpQueue: rest })),
+    }));
+    return next;
+  },
+
+  appendItem: (tabId, item) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({
+        ...tab,
+        items: mergeStreamedText(tab.items, item),
+      })),
+    })),
+
+  beginRun: (tabId, runId) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({
+        ...tab,
+        activeRunId: runId,
+        sessionActive: true,
+        awaitingResponse: true,
+        followUpDraft: "",
+        followUpQueue: [],
+        idleRemainingSec: null,
+        items: [],
+        error: null,
+        unreadCount: 0,
+        permissionPending: false,
+        closing: false,
+      })),
+    })),
+
+  endRun: (tabId) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({
+        ...tab,
+        sessionActive: false,
+        awaitingResponse: false,
+        followUpQueue: [],
+        idleRemainingSec: null,
+        permissionPending: false,
+      })),
+    })),
+
+  markClosing: (tabId) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({ ...tab, closing: true })),
+    })),
+
+  dispatchRunEvent: (runId, event) => {
+    const state = get();
+    const tab = state.tabs.find((t) => t.activeRunId === runId);
+    if (!tab) return;
+    const item = toTimelineItem(runId, event);
+    const isActive = state.activeTabId === tab.id;
+    const terminal =
+      (event.type === "lifecycle" &&
+        (event.status === "completed" || event.status === "cancelled")) ||
+      event.type === "error";
+
+    set((current) => ({
+      tabs: replaceTab(current.tabs, tab.id, (t) => {
+        const nextItems = mergeStreamedText(t.items, item);
+        let awaitingResponse = t.awaitingResponse;
+        let sessionActive = t.sessionActive;
+        let error = t.error;
+        let permissionPending = t.permissionPending;
+        let idleRemainingSec = t.idleRemainingSec;
+
+        if (event.type === "lifecycle") {
+          if (event.status === "promptSent") {
+            awaitingResponse = true;
+            idleRemainingSec = null;
+          } else if (event.status === "promptCompleted") {
+            awaitingResponse = false;
+          } else if (event.status === "completed" || event.status === "cancelled") {
+            sessionActive = false;
+            awaitingResponse = false;
+            idleRemainingSec = null;
+            permissionPending = false;
+          }
+        } else if (event.type === "error") {
+          sessionActive = false;
+          awaitingResponse = false;
+          idleRemainingSec = null;
+          error = event.message;
+          permissionPending = false;
+        } else if (event.type === "permission") {
+          permissionPending = event.requiresResponse;
+        }
+
+        return {
+          ...t,
+          items: nextItems,
+          awaitingResponse,
+          sessionActive,
+          error,
+          permissionPending,
+          idleRemainingSec,
+          unreadCount: isActive ? 0 : t.unreadCount + 1,
+        };
+      }),
+    }));
+
+    if (terminal && tab.closing) {
+      const after = get();
+      const target = after.tabs.find((t) => t.id === tab.id);
+      if (!target) return;
+      if (after.tabs.length <= 1) {
+        const replacement = createTabState({}, 0);
+        set({ tabs: [replacement], activeTabId: replacement.id });
+        return;
       }
-      return { items: [...state.items, item] };
-    }),
+      const index = after.tabs.findIndex((t) => t.id === tab.id);
+      const remaining = after.tabs.filter((t) => t.id !== tab.id);
+      let nextActive = after.activeTabId;
+      if (after.activeTabId === tab.id) {
+        const neighbor = remaining[index] ?? remaining[index - 1] ?? remaining[0];
+        nextActive = neighbor.id;
+      }
+      set({ tabs: remaining, activeTabId: nextActive });
+    }
+  },
 }));
+
+export function selectTab(state: WorkbenchState, tabId: string): TabState | undefined {
+  return state.tabs.find((t) => t.id === tabId);
+}

--- a/src/features/agent-run/runtime.ts
+++ b/src/features/agent-run/runtime.ts
@@ -1,0 +1,121 @@
+import { cancelAgentRun, listenRunEvents, sendPromptToRun } from "../../shared/api/tauri";
+import { useWorkbenchStore } from "./model";
+
+let installed = false;
+let disposers: Array<() => void> = [];
+
+async function drainTabQueue(tabId: string) {
+  const store = useWorkbenchStore.getState();
+  const tab = store.tabs.find((t) => t.id === tabId);
+  if (
+    !tab ||
+    !tab.sessionActive ||
+    !tab.activeRunId ||
+    tab.awaitingResponse ||
+    tab.closing
+  ) {
+    return;
+  }
+  const runId = tab.activeRunId;
+  const head = tab.followUpQueue[0];
+  if (!head) return;
+  if (head.runId !== runId) {
+    store.removeFollowUp(tabId, head.id);
+    return;
+  }
+  const next = store.dequeueFollowUp(tabId);
+  if (!next) return;
+  store.patchTab(tabId, { awaitingResponse: true });
+  try {
+    await sendPromptToRun(runId, next.text);
+  } catch (err) {
+    const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+    if (current?.activeRunId === runId) {
+      useWorkbenchStore.getState().patchTab(tabId, {
+        awaitingResponse: false,
+        error: String(err),
+      });
+    }
+  }
+}
+
+function startIdleTicker() {
+  const interval = setInterval(() => {
+    const store = useWorkbenchStore.getState();
+    for (const tab of store.tabs) {
+      const shouldCount =
+        tab.sessionActive &&
+        !tab.awaitingResponse &&
+        tab.followUpQueue.length === 0 &&
+        tab.idleTimeoutSec > 0;
+
+      if (!shouldCount) {
+        if (tab.idleRemainingSec !== null) {
+          store.patchTab(tab.id, { idleRemainingSec: null });
+        }
+        continue;
+      }
+
+      const current = tab.idleRemainingSec ?? tab.idleTimeoutSec;
+      const next = current - 1;
+      if (next <= 0) {
+        store.patchTab(tab.id, { idleRemainingSec: null });
+        if (tab.activeRunId) {
+          cancelAgentRun(tab.activeRunId).catch(() => undefined);
+        }
+        store.endRun(tab.id);
+      } else {
+        store.patchTab(tab.id, { idleRemainingSec: next });
+      }
+    }
+  }, 1000);
+  return () => clearInterval(interval);
+}
+
+function subscribeForDrain() {
+  let previousSignature = "";
+  return useWorkbenchStore.subscribe((state) => {
+    const signature = state.tabs
+      .map(
+        (t) =>
+          `${t.id}:${t.sessionActive ? 1 : 0}:${t.awaitingResponse ? 1 : 0}:${t.followUpQueue.length}`,
+      )
+      .join("|");
+    if (signature === previousSignature) return;
+    previousSignature = signature;
+    for (const tab of state.tabs) {
+      if (
+        tab.sessionActive &&
+        !tab.awaitingResponse &&
+        tab.followUpQueue.length > 0 &&
+        tab.activeRunId
+      ) {
+        void drainTabQueue(tab.id);
+      }
+    }
+  });
+}
+
+export async function installAgentRuntime() {
+  if (installed) return;
+  installed = true;
+
+  const unlistenEvents = await listenRunEvents((envelope) => {
+    useWorkbenchStore.getState().dispatchRunEvent(envelope.runId, envelope.event);
+  });
+  disposers.push(unlistenEvents);
+
+  disposers.push(subscribeForDrain());
+  disposers.push(startIdleTicker());
+
+  const meta = import.meta as ImportMeta & {
+    hot?: { dispose: (cb: () => void) => void };
+  };
+  meta.hot?.dispose(() => {
+    disposers.forEach((dispose) => dispose());
+    disposers = [];
+    installed = false;
+  });
+}
+
+export { drainTabQueue };

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -25,11 +25,12 @@ export function useAgentRun(tabId: string) {
   );
 
   useEffect(() => {
-    if (!tab) return;
-    if (agents.length > 0 && !agents.some((agent) => agent.id === tab.selectedAgentId)) {
+    const current = tab?.selectedAgentId;
+    if (!current) return;
+    if (agents.length > 0 && !agents.some((agent) => agent.id === current)) {
       patch({ selectedAgentId: agents[0].id });
     }
-  }, [agents, tab?.selectedAgentId, patch, tab]);
+  }, [agents, tab?.selectedAgentId, patch]);
 
   const selectedAgent = useMemo(
     () => agents.find((agent) => agent.id === tab?.selectedAgentId),

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -3,226 +3,167 @@ import { useCallback, useEffect, useMemo } from "react";
 import {
   cancelAgentRun,
   listAgents,
-  listenRunEvents,
-  sendPromptToRun,
   startAgentRun,
 } from "../../shared/api/tauri";
-import type { AgentRunRequest } from "../../entities/message/model";
-import { toTimelineItem } from "../../entities/message/format";
-import { useAgentRunStore } from "./model";
+import type { AgentRunRequest, EventGroup, TimelineItem } from "../../entities/message/model";
+import { useWorkbenchStore, type TabState, type FollowUpQueueItem } from "./model";
 
-async function drainQueue() {
-  const store = useAgentRunStore.getState();
-  if (!store.sessionActive || !store.activeRunId || store.awaitingResponse) {
-    return;
-  }
-  const next = store.dequeueFollowUp();
-  if (!next) {
-    return;
-  }
-  store.setAwaitingResponse(true);
-  try {
-    await sendPromptToRun(store.activeRunId, next.text);
-  } catch (err) {
-    useAgentRunStore.setState({ awaitingResponse: false });
-    useAgentRunStore.getState().setError(String(err));
-  }
-}
+const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
+const EMPTY_ITEMS: TimelineItem[] = [];
 
-export function useAgentRun() {
-  const state = useAgentRunStore();
+export function useAgentRun(tabId: string) {
   const agentsQuery = useQuery({ queryKey: ["agents"], queryFn: listAgents });
   const agents = agentsQuery.data ?? [];
 
-  useEffect(() => {
-    let unlisten: (() => void) | undefined;
-    let disposed = false;
-    listenRunEvents((envelope) => {
-      const store = useAgentRunStore.getState();
-      store.appendItem(toTimelineItem(envelope.runId, envelope.event));
-      if (envelope.event.type === "lifecycle") {
-        const status = envelope.event.status;
-        if (status === "promptSent") {
-          store.setAwaitingResponse(true);
-        } else if (status === "promptCompleted") {
-          store.setAwaitingResponse(false);
-          void drainQueue();
-        } else if (status === "completed" || status === "cancelled") {
-          store.endRun();
-        }
-      }
-      if (envelope.event.type === "error") {
-        store.endRun();
-        store.setError(envelope.event.message);
-      }
-    }).then((dispose) => {
-      if (disposed) {
-        dispose();
-        return;
-      }
-      unlisten = dispose;
-    });
-    return () => {
-      disposed = true;
-      unlisten?.();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (agents.length > 0 && !agents.some((agent) => agent.id === state.selectedAgentId)) {
-      state.setSelectedAgentId(agents[0].id);
-    }
-  }, [agents, state]);
-
-  useEffect(() => {
-    const shouldCountdown =
-      state.sessionActive &&
-      !state.awaitingResponse &&
-      state.followUpQueue.length === 0 &&
-      state.idleTimeoutSec > 0;
-
-    if (!shouldCountdown) {
-      if (useAgentRunStore.getState().idleRemainingSec !== null) {
-        useAgentRunStore.getState().setIdleRemainingSec(null);
-      }
-      return;
-    }
-
-    useAgentRunStore.getState().setIdleRemainingSec(state.idleTimeoutSec);
-    const interval = setInterval(() => {
-      const current = useAgentRunStore.getState();
-      if (
-        !current.sessionActive ||
-        current.awaitingResponse ||
-        current.followUpQueue.length > 0
-      ) {
-        current.setIdleRemainingSec(null);
-        clearInterval(interval);
-        return;
-      }
-      const next = (current.idleRemainingSec ?? 0) - 1;
-      if (next <= 0) {
-        current.setIdleRemainingSec(null);
-        clearInterval(interval);
-        const runId = current.activeRunId;
-        if (runId) {
-          cancelAgentRun(runId).catch(() => undefined);
-          current.endRun();
-        }
-      } else {
-        current.setIdleRemainingSec(next);
-      }
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [
-    state.sessionActive,
-    state.awaitingResponse,
-    state.followUpQueue.length,
-    state.idleTimeoutSec,
-  ]);
-
-  const selectedAgent = useMemo(
-    () => agents.find((agent) => agent.id === state.selectedAgentId),
-    [agents, state.selectedAgentId],
+  const tab = useWorkbenchStore(
+    (state) => state.tabs.find((t) => t.id === tabId),
   );
 
+  const patch = useCallback(
+    (update: Partial<TabState>) => useWorkbenchStore.getState().patchTab(tabId, update),
+    [tabId],
+  );
+
+  useEffect(() => {
+    if (!tab) return;
+    if (agents.length > 0 && !agents.some((agent) => agent.id === tab.selectedAgentId)) {
+      patch({ selectedAgentId: agents[0].id });
+    }
+  }, [agents, tab?.selectedAgentId, patch, tab]);
+
+  const selectedAgent = useMemo(
+    () => agents.find((agent) => agent.id === tab?.selectedAgentId),
+    [agents, tab?.selectedAgentId],
+  );
+
+  const items = tab?.items ?? EMPTY_ITEMS;
+  const filter: EventGroup | "all" = tab?.filter ?? "all";
   const visibleItems = useMemo(
-    () => (state.filter === "all" ? state.items : state.items.filter((item) => item.group === state.filter)),
-    [state.filter, state.items],
+    () => (filter === "all" ? items : items.filter((item) => item.group === filter)),
+    [filter, items],
   );
 
   const run = useCallback(async () => {
-    const trimmedGoal = state.goal.trim();
+    const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+    if (!current) return;
+    const trimmedGoal = current.goal.trim();
     if (!trimmedGoal) {
-      state.setError("Goal is empty.");
+      patch({ error: "Goal is empty." });
       return;
     }
-    state.beginRun();
+    const runId = crypto.randomUUID();
+    useWorkbenchStore.getState().beginRun(tabId, runId);
 
     const request: AgentRunRequest = {
+      runId,
       goal: trimmedGoal,
-      agentId: state.selectedAgentId,
-      cwd: state.cwd.trim() || undefined,
-      agentCommand: state.customCommand.trim() || undefined,
-      stdioBufferLimitMb: Math.min(512, Math.max(1, state.stdioBufferLimitMb || 50)),
-      autoAllow: state.autoAllow,
+      agentId: current.selectedAgentId,
+      cwd: current.cwd.trim() || undefined,
+      agentCommand: current.customCommand.trim() || undefined,
+      stdioBufferLimitMb: Math.min(512, Math.max(1, current.stdioBufferLimitMb || 50)),
+      autoAllow: current.autoAllow,
     };
 
     try {
-      const started = await startAgentRun(request);
-      state.setActiveRunId(started.id);
+      await startAgentRun(request);
     } catch (err) {
-      state.endRun();
-      state.setError(String(err));
+      useWorkbenchStore.getState().patchTab(tabId, { activeRunId: null });
+      useWorkbenchStore.getState().endRun(tabId);
+      patch({ error: String(err) });
     }
-  }, [state]);
+  }, [tabId, patch]);
 
   const cancel = useCallback(async () => {
-    if (!state.activeRunId) {
-      return;
-    }
+    const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+    if (!current?.activeRunId) return;
     try {
-      await cancelAgentRun(state.activeRunId);
-      state.endRun();
-      state.setError(null);
+      await cancelAgentRun(current.activeRunId);
+      useWorkbenchStore.getState().endRun(tabId);
+      patch({ error: null });
     } catch (err) {
-      state.setError(String(err));
+      patch({ error: String(err) });
     }
-  }, [state]);
+  }, [tabId, patch]);
 
   const send = useCallback(() => {
-    const store = useAgentRunStore.getState();
-    if (!store.sessionActive) {
-      return;
-    }
-    const trimmed = store.followUpDraft.trim();
-    if (!trimmed) {
-      return;
-    }
-    store.enqueueFollowUp(trimmed);
-    store.setFollowUpDraft("");
-    void drainQueue();
-  }, []);
+    const store = useWorkbenchStore.getState();
+    const current = store.tabs.find((t) => t.id === tabId);
+    if (!current?.sessionActive) return;
+    const trimmed = current.followUpDraft.trim();
+    if (!trimmed) return;
+    store.enqueueFollowUp(tabId, trimmed);
+    store.patchTab(tabId, { followUpDraft: "" });
+  }, [tabId]);
 
-  const cancelFollowUp = useCallback((id: string) => {
-    useAgentRunStore.getState().removeFollowUp(id);
-  }, []);
+  const cancelFollowUp = useCallback(
+    (id: string) => useWorkbenchStore.getState().removeFollowUp(tabId, id),
+    [tabId],
+  );
+
+  const setSelectedAgentId = useCallback(
+    (value: string) => patch({ selectedAgentId: value }),
+    [patch],
+  );
+  const setGoal = useCallback((value: string) => patch({ goal: value }), [patch]);
+  const setCwd = useCallback((value: string) => patch({ cwd: value }), [patch]);
+  const setCustomCommand = useCallback(
+    (value: string) => patch({ customCommand: value }),
+    [patch],
+  );
+  const setStdioBufferLimitMb = useCallback(
+    (value: number) => patch({ stdioBufferLimitMb: value }),
+    [patch],
+  );
+  const setAutoAllow = useCallback((value: boolean) => patch({ autoAllow: value }), [patch]);
+  const setIdleTimeoutSec = useCallback(
+    (value: number) => patch({ idleTimeoutSec: value }),
+    [patch],
+  );
+  const setFollowUpDraft = useCallback(
+    (value: string) => patch({ followUpDraft: value }),
+    [patch],
+  );
+  const setFilter = useCallback(
+    (value: EventGroup | "all") => patch({ filter: value }),
+    [patch],
+  );
+  const setError = useCallback((value: string | null) => patch({ error: value }), [patch]);
 
   return {
     agents,
     agentsLoading: agentsQuery.isLoading,
     selectedAgent,
-    selectedAgentId: state.selectedAgentId,
-    setSelectedAgentId: state.setSelectedAgentId,
-    goal: state.goal,
-    setGoal: state.setGoal,
-    cwd: state.cwd,
-    setCwd: state.setCwd,
-    customCommand: state.customCommand,
-    setCustomCommand: state.setCustomCommand,
-    stdioBufferLimitMb: state.stdioBufferLimitMb,
-    setStdioBufferLimitMb: state.setStdioBufferLimitMb,
-    autoAllow: state.autoAllow,
-    setAutoAllow: state.setAutoAllow,
-    idleTimeoutSec: state.idleTimeoutSec,
-    setIdleTimeoutSec: state.setIdleTimeoutSec,
-    idleRemainingSec: state.idleRemainingSec,
-    activeRunId: state.activeRunId,
-    sessionActive: state.sessionActive,
-    awaitingResponse: state.awaitingResponse,
-    isRunning: state.sessionActive,
-    followUpDraft: state.followUpDraft,
-    setFollowUpDraft: state.setFollowUpDraft,
-    followUpQueue: state.followUpQueue,
+    selectedAgentId: tab?.selectedAgentId ?? "",
+    setSelectedAgentId,
+    goal: tab?.goal ?? "",
+    setGoal,
+    cwd: tab?.cwd ?? "",
+    setCwd,
+    customCommand: tab?.customCommand ?? "",
+    setCustomCommand,
+    stdioBufferLimitMb: tab?.stdioBufferLimitMb ?? 50,
+    setStdioBufferLimitMb,
+    autoAllow: tab?.autoAllow ?? true,
+    setAutoAllow,
+    idleTimeoutSec: tab?.idleTimeoutSec ?? 0,
+    setIdleTimeoutSec,
+    idleRemainingSec: tab?.idleRemainingSec ?? null,
+    activeRunId: tab?.activeRunId ?? null,
+    sessionActive: tab?.sessionActive ?? false,
+    awaitingResponse: tab?.awaitingResponse ?? false,
+    isRunning: tab?.sessionActive ?? false,
+    followUpDraft: tab?.followUpDraft ?? "",
+    setFollowUpDraft,
+    followUpQueue: tab?.followUpQueue ?? EMPTY_FOLLOW_UP_QUEUE,
     cancelFollowUp,
-    error: state.error ?? (agentsQuery.error ? String(agentsQuery.error) : null),
-    setError: state.setError,
+    error: tab?.error ?? (agentsQuery.error ? String(agentsQuery.error) : null),
+    setError,
     run,
     cancel,
     send,
-    items: state.items,
+    items,
     visibleItems,
-    filter: state.filter,
-    setFilter: state.setFilter,
+    filter,
+    setFilter,
   };
 }

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -1,12 +1,15 @@
 import { GoalEditor } from "../../features/goal-input/GoalEditor";
 import { useAgentRun } from "../../features/agent-run/useAgentRun";
+import { useWorkbenchStore } from "../../features/agent-run/model";
 import { EventStream } from "../../widgets/event-stream/EventStream";
 import { FollowUpComposer } from "../../widgets/follow-up-composer/FollowUpComposer";
 import { FollowUpQueue } from "../../widgets/follow-up-queue/FollowUpQueue";
 import { RunPanel } from "../../widgets/run-panel/RunPanel";
+import { TabBar } from "../../widgets/workbench-tabs/TabBar";
 
 export function AgentWorkbenchPage() {
-  const state = useAgentRun();
+  const activeTabId = useWorkbenchStore((s) => s.activeTabId);
+  const state = useAgentRun(activeTabId);
 
   return (
     <main className="shell min-h-screen">
@@ -17,6 +20,8 @@ export function AgentWorkbenchPage() {
         </div>
         {state.error ? <div className="error-banner">{state.error}</div> : null}
       </header>
+
+      <TabBar />
 
       <div className="workspace-grid">
         <div className="left-column">

--- a/src/widgets/workbench-tabs/TabBar.tsx
+++ b/src/widgets/workbench-tabs/TabBar.tsx
@@ -2,6 +2,8 @@ import { useCallback } from "react";
 import { cancelAgentRun } from "../../shared/api/tauri";
 import { useWorkbenchStore, type TabState } from "../../features/agent-run/model";
 
+const CLOSE_FALLBACK_MS = 5000;
+
 type TabStatus =
   | "idle"
   | "running"
@@ -71,7 +73,16 @@ export function TabBar() {
         useWorkbenchStore.getState().patchTab(tabId, {
           error: `탭 종료 실패: ${String(err)}`,
         });
+        return;
       }
+      setTimeout(() => {
+        const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+        if (current && current.closing && !current.error) {
+          useWorkbenchStore.getState().patchTab(tabId, {
+            error: "backend lifecycle 이벤트를 받지 못했습니다. 강제로 닫을 수 있습니다.",
+          });
+        }
+      }, CLOSE_FALLBACK_MS);
       return;
     }
     store.closeTab(tabId);

--- a/src/widgets/workbench-tabs/TabBar.tsx
+++ b/src/widgets/workbench-tabs/TabBar.tsx
@@ -58,6 +58,10 @@ export function TabBar() {
     const store = useWorkbenchStore.getState();
     const tab = store.tabs.find((t) => t.id === tabId);
     if (!tab) return;
+    if (tab.closing && tab.error) {
+      store.forceCloseTab(tabId);
+      return;
+    }
     if (tab.closing) return;
     if (tab.activeRunId && tab.sessionActive) {
       store.closeTab(tabId);
@@ -105,14 +109,25 @@ export function TabBar() {
             <button
               type="button"
               className="tab-close"
-              aria-label={tab.closing ? "종료 중" : "탭 닫기"}
-              disabled={tab.closing}
+              aria-label={
+                tab.closing && tab.error
+                  ? "강제 닫기"
+                  : tab.closing
+                    ? "종료 중"
+                    : "탭 닫기"
+              }
+              disabled={tab.closing && !tab.error}
               onClick={(event) => {
                 event.stopPropagation();
                 void handleClose(tab.id);
               }}
+              title={
+                tab.closing && tab.error
+                  ? "닫기를 재시도하면 강제로 제거합니다"
+                  : undefined
+              }
             >
-              {tab.closing ? "…" : "×"}
+              {tab.closing && tab.error ? "!" : tab.closing ? "…" : "×"}
             </button>
           </div>
         );

--- a/src/widgets/workbench-tabs/TabBar.tsx
+++ b/src/widgets/workbench-tabs/TabBar.tsx
@@ -1,0 +1,125 @@
+import { useCallback } from "react";
+import { cancelAgentRun } from "../../shared/api/tauri";
+import { useWorkbenchStore, type TabState } from "../../features/agent-run/model";
+
+type TabStatus =
+  | "idle"
+  | "running"
+  | "awaiting"
+  | "error"
+  | "idle-countdown"
+  | "closing";
+
+function resolveStatus(tab: TabState): TabStatus {
+  if (tab.closing) return "closing";
+  if (tab.error) return "error";
+  if (!tab.sessionActive) return "idle";
+  if (tab.awaitingResponse) return "awaiting";
+  if (tab.idleRemainingSec !== null) return "idle-countdown";
+  return "running";
+}
+
+function statusLabel(status: TabStatus) {
+  switch (status) {
+    case "running":
+      return "활성";
+    case "awaiting":
+      return "응답 대기";
+    case "error":
+      return "오류";
+    case "idle-countdown":
+      return "idle 카운트다운";
+    case "closing":
+      return "종료 중";
+    default:
+      return "대기";
+  }
+}
+
+function tabDisplayTitle(tab: TabState) {
+  if (tab.title && tab.title.trim().length > 0) return tab.title;
+  const goalPreview = tab.goal.trim().split(/\s+/).slice(0, 5).join(" ");
+  return goalPreview || "빈 탭";
+}
+
+export function TabBar() {
+  const tabs = useWorkbenchStore((state) => state.tabs);
+  const activeTabId = useWorkbenchStore((state) => state.activeTabId);
+
+  const handleActivate = useCallback((tabId: string) => {
+    useWorkbenchStore.getState().activateTab(tabId);
+  }, []);
+
+  const handleAdd = useCallback(() => {
+    useWorkbenchStore.getState().addTab();
+  }, []);
+
+  const handleClose = useCallback(async (tabId: string) => {
+    const store = useWorkbenchStore.getState();
+    const tab = store.tabs.find((t) => t.id === tabId);
+    if (!tab) return;
+    if (tab.closing) return;
+    if (tab.activeRunId && tab.sessionActive) {
+      store.closeTab(tabId);
+      try {
+        await cancelAgentRun(tab.activeRunId);
+      } catch (err) {
+        useWorkbenchStore.getState().patchTab(tabId, {
+          error: `탭 종료 실패: ${String(err)}`,
+        });
+      }
+      return;
+    }
+    store.closeTab(tabId);
+  }, []);
+
+  return (
+    <div className="tab-bar" role="tablist">
+      {tabs.map((tab) => {
+        const status = resolveStatus(tab);
+        const isActive = tab.id === activeTabId;
+        return (
+          <div
+            key={tab.id}
+            role="tab"
+            aria-selected={isActive}
+            className={`tab-item ${isActive ? "tab-item--active" : ""}`}
+            onClick={() => handleActivate(tab.id)}
+          >
+            <span
+              className={`tab-status tab-status--${status}`}
+              title={statusLabel(status)}
+              aria-label={statusLabel(status)}
+            />
+            <span className="tab-title">{tabDisplayTitle(tab)}</span>
+            {tab.permissionPending ? (
+              <span className="tab-permission" title="권한 요청 대기">
+                ⚠
+              </span>
+            ) : null}
+            {!isActive && tab.unreadCount > 0 ? (
+              <span className="tab-unread" aria-label={`${tab.unreadCount}개 새 이벤트`}>
+                {tab.unreadCount > 99 ? "99+" : tab.unreadCount}
+              </span>
+            ) : null}
+            <button
+              type="button"
+              className="tab-close"
+              aria-label={tab.closing ? "종료 중" : "탭 닫기"}
+              disabled={tab.closing}
+              onClick={(event) => {
+                event.stopPropagation();
+                void handleClose(tab.id);
+              }}
+            >
+              {tab.closing ? "…" : "×"}
+            </button>
+          </div>
+        );
+      })}
+      <button type="button" className="tab-add" onClick={handleAdd} aria-label="새 탭">
+        +
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Backend: `reserve_run_if_idle` → `reserve_run` (multi-run), optional `ACP_WORKBENCH_MAX_RUNS` limit, new tests for concurrent reserve/cancel/duplicate-id.
- Frontend: `useAgentRunStore` → `useWorkbenchStore` with `tabs` + `activeTabId` + per-tab `TabState`; `useAgentRun(tabId)` scoped hook; `TabBar` with status dot, unread badge, permission ⚠, close.
- Runtime: one app-level listener routes `agent-run-event` by `envelope.runId`; runtime handles follow-up queue drain + idle countdown across all tabs; HMR dispose prevents listener duplication.
- Safety: run id is generated on the client before invoking `start_agent_run` so early backend events can't be dropped; closing a running tab enters a `closing` state and waits for the lifecycle terminal event before removing; queue items are bound to their originating run id to block cross-run delivery.
- Out of scope: multi-window (Phase 2) tracked separately.

Closes #1 (Phase 1 scope).

## Test plan
- [ ] `cargo test --lib` passes (11 tests incl. 3 new multi-run tests)
- [ ] `tsc --noEmit` clean
- [ ] `vite build` clean
- [ ] Manual: start `claude-code` in tab A and `codex` in tab B, confirm each tab receives only its own timeline
- [ ] Manual: send follow-up prompts to each tab independently; confirm queue doesn't cross tabs
- [ ] Manual: cancel one tab's run; confirm the other tab continues
- [ ] Manual: close a running tab; confirm backend cancel is awaited, tab shows `closing` and removes after lifecycle event
- [ ] Manual: permission request from one run; confirm ⚠ shows only on the owning tab
- [ ] Manual: switch tabs while each has queued work; confirm unread badge increments on inactive tabs
- [ ] Manual: reload dev server (HMR) and confirm a single active listener (no duplicated timeline entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)