### PR TITLE
Render thought stream chunks as markdown

### DIFF
--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -125,7 +125,10 @@ export const useAgentRunStore = create<AgentRunState>((set, get) => ({
   appendItem: (item) =>
     set((state) => {
       const previous = state.items[state.items.length - 1];
-      if (previous?.event.type === "agentMessage" && item.event.type === "agentMessage") {
+      if (
+        (previous?.event.type === "agentMessage" && item.event.type === "agentMessage") ||
+        (previous?.event.type === "thought" && item.event.type === "thought")
+      ) {
         const mergedText = `${previous.event.text}${item.event.text}`;
         return {
           items: [

--- a/src/widgets/event-stream/EventStream.tsx
+++ b/src/widgets/event-stream/EventStream.tsx
@@ -64,7 +64,7 @@ export function EventStream({ items, filter, onFilterChange, onError }: EventStr
                 <span>{item.group}</span>
                 <strong>{item.title}</strong>
               </div>
-              {item.group === "assistant/message" ? <StreamingMarkdown content={item.body} /> : <pre>{item.body}</pre>}
+              {isMarkdownStream(item) ? <StreamingMarkdown content={item.body} /> : <pre>{item.body}</pre>}
               {item.event.type === "permission" && item.event.requiresResponse && item.event.permissionId ? (
                 <div className="permission-actions">
                   <button
@@ -90,6 +90,10 @@ export function EventStream({ items, filter, onFilterChange, onError }: EventStr
       </div>
     </section>
   );
+}
+
+function isMarkdownStream(item: TimelineItem) {
+  return item.group === "assistant/message" || item.group === "thought";
 }
 
 function StreamingMarkdown({ content }: { content: string }) {


### PR DESCRIPTION
## Summary

- Merge consecutive `thought` stream chunks into one timeline item, matching assistant message streaming behavior.
- Render `thought` timeline items through the existing Markdown stream renderer.
- Preserve existing assistant message coalescing and non-markdown rendering for other event types.

Closes #5

## Tests

- `npm run build`
