### PR TITLE
Support parallel Tauri dev instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,18 @@ npm run tauri:dev
 
 `npm run tauri:dev`는 `1420`부터 사용 가능한 포트를 찾아 Tauri의 `devUrl`과 Vite 개발 서버 포트를 함께 설정합니다. 따라서 이미 개발용 앱이 떠 있어도 다른 포트로 추가 인스턴스를 실행할 수 있습니다.
 
+여러 개발용 앱을 동시에 실행할 때는 `npm run tauri dev` 대신 `npm run tauri:dev`를 사용해야 합니다. 기존 `npm run tauri dev`는 `src-tauri/tauri.conf.json`의 고정 `1420` 포트를 그대로 사용합니다.
+
 특정 시작 포트를 지정하려면 다음처럼 실행합니다.
 
 ```sh
 TAURI_DEV_PORT=1430 npm run tauri:dev
+```
+
+실제 앱을 띄우지 않고 선택될 Tauri dev 설정만 확인하려면 다음 명령을 사용할 수 있습니다.
+
+```sh
+npm run tauri:dev -- --print-config
 ```
 
 프론트엔드만 실행하려면 다음 명령을 사용할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,15 @@ npm install
 ## 개발 실행
 
 ```sh
-npm run tauri dev
+npm run tauri:dev
+```
+
+`npm run tauri:dev`는 `1420`부터 사용 가능한 포트를 찾아 Tauri의 `devUrl`과 Vite 개발 서버 포트를 함께 설정합니다. 따라서 이미 개발용 앱이 떠 있어도 다른 포트로 추가 인스턴스를 실행할 수 있습니다.
+
+특정 시작 포트를 지정하려면 다음처럼 실행합니다.
+
+```sh
+TAURI_DEV_PORT=1430 npm run tauri:dev
 ```
 
 프론트엔드만 실행하려면 다음 명령을 사용할 수 있습니다.
@@ -82,7 +90,7 @@ npm run tauri build
 `ACP_AGENT_CATALOG_PATH` 환경 변수에 JSON 파일 경로를 지정하면 기본 에이전트 목록 대신 해당 파일을 읽습니다.
 
 ```sh
-ACP_AGENT_CATALOG_PATH=/path/to/agents.json npm run tauri dev
+ACP_AGENT_CATALOG_PATH=/path/to/agents.json npm run tauri:dev
 ```
 
 파일 형식은 다음과 같습니다.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "tauri:dev": "node scripts/tauri-dev.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -84,8 +84,9 @@ if (printConfig) {
 
 console.log(`Starting Tauri dev app at ${config.build.devUrl}`);
 
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const child = spawn(
-  "npm",
+  npmCommand,
   ["run", "tauri", "--", "dev", "--config", JSON.stringify(config), ...tauriArgs],
   {
     stdio: "inherit",

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -1,0 +1,108 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+
+const DEFAULT_PORT = 1420;
+const MAX_PORT_ATTEMPTS = 100;
+
+function parsePort(value, fallback) {
+  if (!value) {
+    return fallback;
+  }
+
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+
+  return port;
+}
+
+function canListen(host, port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+
+    server.once("error", () => {
+      resolve(false);
+    });
+
+    server.once("listening", () => {
+      server.close(() => {
+        resolve(true);
+      });
+    });
+
+    server.listen(port, host);
+  });
+}
+
+async function findAvailablePort(host, startPort) {
+  for (let offset = 0; offset < MAX_PORT_ATTEMPTS; offset += 1) {
+    const port = startPort + offset;
+    if (port > 65535) {
+      break;
+    }
+
+    if (await canListen(host, port)) {
+      return port;
+    }
+  }
+
+  throw new Error(
+    `No available development port found from ${startPort} to ${Math.min(
+      startPort + MAX_PORT_ATTEMPTS - 1,
+      65535,
+    )}`,
+  );
+}
+
+function createTauriDevConfig(host, port) {
+  const urlHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+
+  return {
+    build: {
+      beforeDevCommand: `npm run dev -- --host ${host} --port ${port} --strictPort`,
+      devUrl: `http://${urlHost}:${port}`,
+    },
+  };
+}
+
+const passthroughArgs = process.argv.slice(2);
+const printConfig = passthroughArgs.includes("--print-config");
+const tauriArgs = passthroughArgs.filter((arg) => arg !== "--print-config");
+const host = process.env.TAURI_DEV_HOST ?? "127.0.0.1";
+const requestedPort = parsePort(
+  process.env.TAURI_DEV_PORT ?? process.env.VITE_DEV_SERVER_PORT,
+  DEFAULT_PORT,
+);
+const port = await findAvailablePort(host, requestedPort);
+const config = createTauriDevConfig(host, port);
+
+if (printConfig) {
+  console.log(JSON.stringify(config, null, 2));
+  process.exit(0);
+}
+
+console.log(`Starting Tauri dev app at ${config.build.devUrl}`);
+
+const child = spawn(
+  "npm",
+  ["run", "tauri", "--", "dev", "--config", JSON.stringify(config), ...tauriArgs],
+  {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      TAURI_DEV_HOST: host,
+      TAURI_DEV_PORT: String(port),
+      VITE_DEV_SERVER_PORT: String(port),
+    },
+  },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const devServerPort = Number.parseInt(process.env.VITE_DEV_SERVER_PORT ?? "1420", 10);
+
 export default defineConfig({
   plugins: [react()],
   clearScreen: false,
   server: {
-    port: 1420,
+    port: Number.isInteger(devServerPort) ? devServerPort : 1420,
     strictPort: true,
   },
   envPrefix: ["VITE_", "TAURI_"],


### PR DESCRIPTION
## Summary
- Add a `tauri:dev` script that finds an available dev server port starting at 1420
- Override Tauri `devUrl` and `beforeDevCommand` together so each dev app instance uses its own Vite server
- Document the new command and `TAURI_DEV_PORT` override

## Verification
- `node --check scripts/tauri-dev.mjs`
- `node scripts/tauri-dev.mjs --print-config`
- occupied port 1420 and confirmed `--print-config` selects 1421
- `npm run build`
- `cargo test`

Closes #4
