### PR TITLE
Refactor React frontend toward Feature-Sliced Design

### DIFF
--- a/docs/frontend-fsd.md
+++ b/docs/frontend-fsd.md
@@ -1,0 +1,77 @@
+# Frontend Feature-Sliced Design
+
+The React frontend follows a lightweight Feature-Sliced Design layout. The goal is to keep page composition, user-facing features, business entities, and generic infrastructure from bleeding into each other as the workbench grows.
+
+## Layers
+
+Dependency direction flows from top to bottom:
+
+```text
+app -> pages -> widgets -> features -> entities -> shared
+```
+
+- `app`: providers, app-level runtime installation, routing/layout wiring, global styles.
+- `pages`: route-level composition. Pages assemble widgets and features but should not own durable business logic.
+- `widgets`: page sections made from features, entities, and shared UI. Widgets should not call Tauri commands or own long-lived application state directly.
+- `features`: user actions and business interactions, such as agent runs, goal file loading, permission responses, and future task/scenario actions.
+- `entities`: stable frontend business objects and formatting helpers, such as agents and messages.
+- `shared`: domain-agnostic infrastructure, reusable UI primitives, and generic utilities.
+
+## Import Rules
+
+- `app` may import from any layer.
+- `pages` may import from `widgets`, `features`, `entities`, and `shared`.
+- `widgets` may import from `features`, `entities`, and `shared`.
+- `features` may import from `entities` and `shared`.
+- `entities` may import from `shared`.
+- `shared` must not import from app-specific layers.
+- Cross-slice imports should use each slice's public `index.ts` when practical.
+
+Same-slice imports can use relative paths for internal implementation files. For example, `features/agent-run/runtime.ts` can import `./model` directly.
+
+## Public APIs
+
+Each externally consumed slice should expose a small public API through `index.ts`.
+
+Examples:
+
+- `features/agent-run`
+- `features/goal-input`
+- `features/permission-response`
+- `entities/message`
+- `widgets/event-stream`
+- `shared/ui`
+
+Avoid importing another slice's internal files directly, such as `features/agent-run/model.ts`, from widgets or pages unless the symbol is deliberately exported by that slice.
+
+## Tauri Boundary
+
+`shared/api` exposes generic Tauri transport helpers only:
+
+- `invokeCommand`
+- `listenEvent`
+
+Typed command wrappers belong to the feature that owns the use case:
+
+- `features/agent-run/api.ts`: agent run commands, follow-up prompt, event subscription, agent list.
+- `features/goal-input/api.ts`: goal file loading.
+- `features/permission-response/api.ts`: permission response command.
+
+This keeps `shared` independent from entities and feature-specific contracts.
+
+## Current Slice Ownership
+
+- `features/agent-run`: tab/run state, run lifecycle hook, runtime event listener, follow-up queue draining, tab close orchestration.
+- `features/goal-input`: goal editor UI and goal file loading.
+- `features/permission-response`: permission option selection, pending response state, response command.
+- `entities/message`: ACP run event types, event formatting, event groups.
+- `entities/agent`: agent descriptor type.
+- `widgets/*`: visual workbench sections that compose feature APIs and shared UI.
+
+## Review Checklist
+
+- Does the changed file import only from allowed lower layers?
+- Are cross-slice imports going through public APIs?
+- Does a widget call transport/API code directly? If yes, move that behavior into a feature.
+- Does `shared` import an entity, feature, widget, page, or app module? If yes, move the domain-specific wrapper out of `shared`.
+- Does a broad feature store own unrelated state that should become an entity or a smaller feature concern?

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { AgentWorkbenchPage } from "../pages/agent-workbench";
-import { installAgentRuntime } from "../features/agent-run/runtime";
+import { installAgentRuntime } from "../features/agent-run";
 
 const queryClient = new QueryClient();
 

--- a/src/entities/agent/index.ts
+++ b/src/entities/agent/index.ts
@@ -1,0 +1,1 @@
+export type { AgentDescriptor } from "./model";

--- a/src/entities/message/format.ts
+++ b/src/entities/message/format.ts
@@ -1,5 +1,5 @@
 import type { EventGroup, RunEvent, TimelineItem } from "./model";
-import { stripAnsi } from "../../shared/lib/ansi";
+import { stripAnsi } from "../../shared/lib";
 
 export function toTimelineItem(runId: string, event: RunEvent): TimelineItem {
   const createdAt = Date.now();

--- a/src/entities/message/index.ts
+++ b/src/entities/message/index.ts
@@ -1,0 +1,12 @@
+export { eventGroups, toTimelineItem } from "./format";
+export type {
+  AgentRun,
+  AgentRunRequest,
+  EventGroup,
+  LifecycleStatus,
+  PermissionOption,
+  PlanEntry,
+  RunEvent,
+  RunEventEnvelope,
+  TimelineItem,
+} from "./model";

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -1,0 +1,23 @@
+import type { AgentDescriptor } from "../../entities/agent";
+import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message";
+import { invokeCommand, listenEvent } from "../../shared/api";
+
+export function listAgents() {
+  return invokeCommand<AgentDescriptor[]>("list_agents");
+}
+
+export function startAgentRun(request: AgentRunRequest) {
+  return invokeCommand<AgentRun>("start_agent_run", { request });
+}
+
+export function cancelAgentRun(runId: string) {
+  return invokeCommand<void>("cancel_agent_run", { runId });
+}
+
+export function sendPromptToRun(runId: string, prompt: string) {
+  return invokeCommand<void>("send_prompt_to_run", { runId, prompt });
+}
+
+export function listenRunEvents(callback: (event: RunEventEnvelope) => void) {
+  return listenEvent<RunEventEnvelope>("agent-run-event", callback);
+}

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -2,8 +2,6 @@ export { closeWorkbenchTab } from "./tabActions";
 export { installAgentRuntime } from "./runtime";
 export { useAgentRun } from "./useAgentRun";
 export {
-  createTabState,
-  selectTab,
   useWorkbenchStore,
   type FollowUpQueueItem,
   type TabState,

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -1,0 +1,10 @@
+export { closeWorkbenchTab } from "./tabActions";
+export { installAgentRuntime } from "./runtime";
+export { useAgentRun } from "./useAgentRun";
+export {
+  createTabState,
+  selectTab,
+  useWorkbenchStore,
+  type FollowUpQueueItem,
+  type TabState,
+} from "./model";

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -1,6 +1,5 @@
 import { create } from "zustand";
-import type { EventGroup, RunEvent, TimelineItem } from "../../entities/message/model";
-import { toTimelineItem } from "../../entities/message/format";
+import { toTimelineItem, type EventGroup, type RunEvent, type TimelineItem } from "../../entities/message";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
 

--- a/src/features/agent-run/runtime.ts
+++ b/src/features/agent-run/runtime.ts
@@ -1,4 +1,4 @@
-import { cancelAgentRun, listenRunEvents, sendPromptToRun } from "../../shared/api/tauri";
+import { cancelAgentRun, listenRunEvents, sendPromptToRun } from "./api";
 import { useWorkbenchStore } from "./model";
 
 let installed = false;

--- a/src/features/agent-run/tabActions.ts
+++ b/src/features/agent-run/tabActions.ts
@@ -1,0 +1,39 @@
+import { cancelAgentRun } from "./api";
+import { useWorkbenchStore } from "./model";
+
+const CLOSE_FALLBACK_MS = 5000;
+
+export async function closeWorkbenchTab(tabId: string) {
+  const store = useWorkbenchStore.getState();
+  const tab = store.tabs.find((t) => t.id === tabId);
+  if (!tab) return;
+
+  if (tab.closing && tab.error) {
+    store.forceCloseTab(tabId);
+    return;
+  }
+  if (tab.closing) return;
+
+  if (tab.activeRunId && tab.sessionActive) {
+    store.closeTab(tabId);
+    try {
+      await cancelAgentRun(tab.activeRunId);
+    } catch (err) {
+      useWorkbenchStore.getState().patchTab(tabId, {
+        error: `탭 종료 실패: ${String(err)}`,
+      });
+      return;
+    }
+    setTimeout(() => {
+      const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+      if (current && current.closing && !current.error) {
+        useWorkbenchStore.getState().patchTab(tabId, {
+          error: "backend lifecycle 이벤트를 받지 못했습니다. 강제로 닫을 수 있습니다.",
+        });
+      }
+    }, CLOSE_FALLBACK_MS);
+    return;
+  }
+
+  store.closeTab(tabId);
+}

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -4,8 +4,8 @@ import {
   cancelAgentRun,
   listAgents,
   startAgentRun,
-} from "../../shared/api/tauri";
-import type { AgentRunRequest, EventGroup, TimelineItem } from "../../entities/message/model";
+} from "./api";
+import type { AgentRunRequest, EventGroup, TimelineItem } from "../../entities/message";
 import { useWorkbenchStore, type TabState, type FollowUpQueueItem } from "./model";
 
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];

--- a/src/features/goal-input/GoalEditor.tsx
+++ b/src/features/goal-input/GoalEditor.tsx
@@ -1,9 +1,7 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { FileUp } from "lucide-react";
-import { loadGoalFile } from "../../shared/api/tauri";
-import { Button } from "../../shared/ui/Button";
-import { Card, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui/Card";
-import { Textarea } from "../../shared/ui/Textarea";
+import { Button, Card, CardHeader, CardTitle, CardTitleBlock, Textarea } from "../../shared/ui";
+import { loadGoalFile } from "./api";
 
 type GoalEditorProps = {
   value: string;

--- a/src/features/goal-input/api.ts
+++ b/src/features/goal-input/api.ts
@@ -1,0 +1,5 @@
+import { invokeCommand } from "../../shared/api";
+
+export function loadGoalFile(path: string) {
+  return invokeCommand<string>("load_goal_file", { path });
+}

--- a/src/features/goal-input/index.ts
+++ b/src/features/goal-input/index.ts
@@ -1,0 +1,1 @@
+export { GoalEditor } from "./GoalEditor";

--- a/src/features/permission-response/api.ts
+++ b/src/features/permission-response/api.ts
@@ -1,0 +1,5 @@
+import { invokeCommand } from "../../shared/api";
+
+export function respondAgentPermission(permissionId: string, optionId: string) {
+  return invokeCommand<void>("respond_agent_permission", { permissionId, optionId });
+}

--- a/src/features/permission-response/index.ts
+++ b/src/features/permission-response/index.ts
@@ -1,0 +1,1 @@
+export { usePermissionResponse } from "./usePermissionResponse";

--- a/src/features/permission-response/usePermissionResponse.ts
+++ b/src/features/permission-response/usePermissionResponse.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from "react";
+import type { TimelineItem } from "../../entities/message";
+import { respondAgentPermission } from "./api";
+
+type PermissionMode = "allow" | "reject";
+
+export function usePermissionResponse(
+  items: TimelineItem[],
+  onError: (message: string | null) => void,
+) {
+  const [pendingPermissionIds, setPendingPermissionIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setPendingPermissionIds((current) => {
+      const next = new Set(current);
+      for (const item of items) {
+        if (item.event.type === "permission" && item.event.permissionId && !item.event.requiresResponse) {
+          next.delete(item.event.permissionId);
+        }
+      }
+      return next;
+    });
+  }, [items]);
+
+  const isPending = useCallback(
+    (permissionId: string) => pendingPermissionIds.has(permissionId),
+    [pendingPermissionIds],
+  );
+
+  const hasOption = useCallback(
+    (item: TimelineItem, mode: PermissionMode) => Boolean(findPermissionOption(item, mode)),
+    [],
+  );
+
+  const respond = useCallback(
+    async (item: TimelineItem, mode: PermissionMode) => {
+      if (item.event.type !== "permission" || !item.event.permissionId) {
+        return;
+      }
+      const option = findPermissionOption(item, mode);
+      if (!option) {
+        return;
+      }
+      const permissionId = item.event.permissionId;
+      setPendingPermissionIds((current) => new Set(current).add(permissionId));
+      try {
+        await respondAgentPermission(permissionId, option.optionId);
+        onError(null);
+      } catch (err) {
+        setPendingPermissionIds((current) => {
+          const next = new Set(current);
+          next.delete(permissionId);
+          return next;
+        });
+        onError(String(err));
+      }
+    },
+    [onError],
+  );
+
+  return { hasOption, isPending, respond };
+}
+
+function findPermissionOption(item: TimelineItem, mode: PermissionMode) {
+  if (item.event.type !== "permission") {
+    return undefined;
+  }
+  return item.event.options.find((option) => {
+    const kind = option.kind.toLowerCase();
+    if (mode === "allow") {
+      return kind.startsWith("allow");
+    }
+    return kind.startsWith("reject") || kind.startsWith("deny");
+  });
+}

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -1,11 +1,10 @@
-import { GoalEditor } from "../../features/goal-input/GoalEditor";
-import { useAgentRun } from "../../features/agent-run/useAgentRun";
-import { useWorkbenchStore } from "../../features/agent-run/model";
-import { EventStream } from "../../widgets/event-stream/EventStream";
-import { FollowUpComposer } from "../../widgets/follow-up-composer/FollowUpComposer";
-import { FollowUpQueue } from "../../widgets/follow-up-queue/FollowUpQueue";
-import { RunPanel } from "../../widgets/run-panel/RunPanel";
-import { TabBar } from "../../widgets/workbench-tabs/TabBar";
+import { useAgentRun, useWorkbenchStore } from "../../features/agent-run";
+import { GoalEditor } from "../../features/goal-input";
+import { EventStream } from "../../widgets/event-stream";
+import { FollowUpComposer } from "../../widgets/follow-up-composer";
+import { FollowUpQueue } from "../../widgets/follow-up-queue";
+import { RunPanel } from "../../widgets/run-panel";
+import { TabBar } from "../../widgets/workbench-tabs";
 
 export function AgentWorkbenchPage() {
   const activeTabId = useWorkbenchStore((s) => s.activeTabId);

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,1 @@
+export { invokeCommand, listenEvent } from "./tauri";

--- a/src/shared/api/tauri.ts
+++ b/src/shared/api/tauri.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
+// Keep shared/api as a domain-agnostic transport seam; feature slices own typed command wrappers.
 export function invokeCommand<T>(command: string, args?: Record<string, unknown>) {
   return invoke<T>(command, args);
 }

--- a/src/shared/api/tauri.ts
+++ b/src/shared/api/tauri.ts
@@ -1,32 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { AgentDescriptor } from "../../entities/agent/model";
-import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message/model";
 
-export function listAgents() {
-  return invoke<AgentDescriptor[]>("list_agents");
+export function invokeCommand<T>(command: string, args?: Record<string, unknown>) {
+  return invoke<T>(command, args);
 }
 
-export function startAgentRun(request: AgentRunRequest) {
-  return invoke<AgentRun>("start_agent_run", { request });
-}
-
-export function cancelAgentRun(runId: string) {
-  return invoke<void>("cancel_agent_run", { runId });
-}
-
-export function sendPromptToRun(runId: string, prompt: string) {
-  return invoke<void>("send_prompt_to_run", { runId, prompt });
-}
-
-export function loadGoalFile(path: string) {
-  return invoke<string>("load_goal_file", { path });
-}
-
-export function respondAgentPermission(permissionId: string, optionId: string) {
-  return invoke<void>("respond_agent_permission", { permissionId, optionId });
-}
-
-export function listenRunEvents(callback: (event: RunEventEnvelope) => void) {
-  return listen<RunEventEnvelope>("agent-run-event", (event) => callback(event.payload));
+export function listenEvent<T>(eventName: string, callback: (payload: T) => void) {
+  return listen<T>(eventName, (event) => callback(event.payload));
 }

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,0 +1,2 @@
+export { stripAnsi } from "./ansi";
+export { cn } from "./utils";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,6 @@
+export { Badge, badgeVariants } from "./Badge";
+export { Button, buttonVariants } from "./Button";
+export { Card, CardContent, CardHeader, CardTitle, CardTitleBlock } from "./Card";
+export { Input } from "./Input";
+export { NativeSelect } from "./NativeSelect";
+export { Textarea } from "./Textarea";

--- a/src/widgets/event-stream/EventStream.tsx
+++ b/src/widgets/event-stream/EventStream.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { useEffect, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { eventGroups } from "../../entities/message/format";
-import type { EventGroup, TimelineItem } from "../../entities/message/model";
-import { respondAgentPermission } from "../../shared/api/tauri";
-import { cn } from "../../shared/lib/utils";
-import { Button } from "../../shared/ui/Button";
-import { Card, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui/Card";
+import { eventGroups, type EventGroup, type TimelineItem } from "../../entities/message";
+import { usePermissionResponse } from "../../features/permission-response";
+import { cn } from "../../shared/lib";
+import { Button, Card, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui";
 
 type EventStreamProps = {
   items: TimelineItem[];
@@ -17,22 +15,10 @@ type EventStreamProps = {
 
 export function EventStream({ items, filter, onFilterChange, onError }: EventStreamProps) {
   const endRef = useRef<HTMLDivElement | null>(null);
-  const [pendingPermissionIds, setPendingPermissionIds] = useState<Set<string>>(() => new Set());
+  const permissionResponse = usePermissionResponse(items, onError);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ block: "end" });
-  }, [items]);
-
-  useEffect(() => {
-    setPendingPermissionIds((current) => {
-      const next = new Set(current);
-      for (const item of items) {
-        if (item.event.type === "permission" && item.event.permissionId && !item.event.requiresResponse) {
-          next.delete(item.event.permissionId);
-        }
-      }
-      return next;
-    });
   }, [items]);
 
   return (
@@ -85,8 +71,8 @@ export function EventStream({ items, filter, onFilterChange, onError }: EventStr
                     type="button"
                     variant="primary"
                     size="sm"
-                    onClick={() => respondToPermission(item, "allow", setPendingPermissionIds, onError)}
-                    disabled={pendingPermissionIds.has(item.event.permissionId) || !findPermissionOption(item, "allow")}
+                    onClick={() => permissionResponse.respond(item, "allow")}
+                    disabled={permissionResponse.isPending(item.event.permissionId) || !permissionResponse.hasOption(item, "allow")}
                   >
                     Approve
                   </Button>
@@ -94,8 +80,8 @@ export function EventStream({ items, filter, onFilterChange, onError }: EventStr
                     type="button"
                     variant="secondary"
                     size="sm"
-                    onClick={() => respondToPermission(item, "reject", setPendingPermissionIds, onError)}
-                    disabled={pendingPermissionIds.has(item.event.permissionId) || !findPermissionOption(item, "reject")}
+                    onClick={() => permissionResponse.respond(item, "reject")}
+                    disabled={permissionResponse.isPending(item.event.permissionId) || !permissionResponse.hasOption(item, "reject")}
                   >
                     Reject
                   </Button>
@@ -227,46 +213,5 @@ function toneClassName(item: TimelineItem) {
     case "info":
     default:
       return "border-l-info";
-  }
-}
-
-function findPermissionOption(item: TimelineItem, mode: "allow" | "reject") {
-  if (item.event.type !== "permission") {
-    return undefined;
-  }
-  return item.event.options.find((option) => {
-    const kind = option.kind.toLowerCase();
-    if (mode === "allow") {
-      return kind.startsWith("allow");
-    }
-    return kind.startsWith("reject") || kind.startsWith("deny");
-  });
-}
-
-async function respondToPermission(
-  item: TimelineItem,
-  mode: "allow" | "reject",
-  setPendingPermissionIds: Dispatch<SetStateAction<Set<string>>>,
-  onError: (message: string | null) => void,
-) {
-  if (item.event.type !== "permission" || !item.event.permissionId) {
-    return;
-  }
-  const option = findPermissionOption(item, mode);
-  if (!option) {
-    return;
-  }
-  const permissionId = item.event.permissionId;
-  setPendingPermissionIds((current) => new Set(current).add(permissionId));
-  try {
-    await respondAgentPermission(permissionId, option.optionId);
-    onError(null);
-  } catch (err) {
-    setPendingPermissionIds((current) => {
-      const next = new Set(current);
-      next.delete(permissionId);
-      return next;
-    });
-    onError(String(err));
   }
 }

--- a/src/widgets/event-stream/index.ts
+++ b/src/widgets/event-stream/index.ts
@@ -1,0 +1,1 @@
+export { EventStream } from "./EventStream";

--- a/src/widgets/follow-up-composer/FollowUpComposer.tsx
+++ b/src/widgets/follow-up-composer/FollowUpComposer.tsx
@@ -1,8 +1,6 @@
 import { Send } from "lucide-react";
 import type { KeyboardEvent } from "react";
-import { Button } from "../../shared/ui/Button";
-import { Card, CardContent, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui/Card";
-import { Textarea } from "../../shared/ui/Textarea";
+import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Textarea } from "../../shared/ui";
 
 type FollowUpComposerProps = {
   value: string;

--- a/src/widgets/follow-up-composer/index.ts
+++ b/src/widgets/follow-up-composer/index.ts
@@ -1,0 +1,1 @@
+export { FollowUpComposer } from "./FollowUpComposer";

--- a/src/widgets/follow-up-queue/FollowUpQueue.tsx
+++ b/src/widgets/follow-up-queue/FollowUpQueue.tsx
@@ -1,8 +1,6 @@
 import { X } from "lucide-react";
-import type { FollowUpQueueItem } from "../../features/agent-run/model";
-import { Badge } from "../../shared/ui/Badge";
-import { Button } from "../../shared/ui/Button";
-import { Card, CardContent, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui/Card";
+import type { FollowUpQueueItem } from "../../features/agent-run";
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui";
 
 type FollowUpQueueProps = {
   items: FollowUpQueueItem[];

--- a/src/widgets/follow-up-queue/index.ts
+++ b/src/widgets/follow-up-queue/index.ts
@@ -1,0 +1,1 @@
+export { FollowUpQueue } from "./FollowUpQueue";

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -1,10 +1,7 @@
 import { Octagon, Play, ShieldCheck } from "lucide-react";
-import type { AgentDescriptor } from "../../entities/agent/model";
-import { Button } from "../../shared/ui/Button";
-import { Card, CardContent, CardHeader, CardTitle, CardTitleBlock } from "../../shared/ui/Card";
-import { Input } from "../../shared/ui/Input";
-import { NativeSelect } from "../../shared/ui/NativeSelect";
-import { cn } from "../../shared/lib/utils";
+import type { AgentDescriptor } from "../../entities/agent";
+import { cn } from "../../shared/lib";
+import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect } from "../../shared/ui";
 
 type RunPanelProps = {
   agents: AgentDescriptor[];

--- a/src/widgets/run-panel/index.ts
+++ b/src/widgets/run-panel/index.ts
@@ -1,0 +1,1 @@
+export { RunPanel } from "./RunPanel";

--- a/src/widgets/workbench-tabs/TabBar.tsx
+++ b/src/widgets/workbench-tabs/TabBar.tsx
@@ -1,11 +1,7 @@
 import { useCallback } from "react";
-import { cancelAgentRun } from "../../shared/api/tauri";
-import { useWorkbenchStore, type TabState } from "../../features/agent-run/model";
-import { cn } from "../../shared/lib/utils";
-import { Badge } from "../../shared/ui/Badge";
-import { Button } from "../../shared/ui/Button";
-
-const CLOSE_FALLBACK_MS = 5000;
+import { closeWorkbenchTab, useWorkbenchStore, type TabState } from "../../features/agent-run";
+import { cn } from "../../shared/lib";
+import { Badge, Button } from "../../shared/ui";
 
 type TabStatus =
   | "idle"
@@ -76,36 +72,8 @@ export function TabBar() {
     useWorkbenchStore.getState().addTab();
   }, []);
 
-  const handleClose = useCallback(async (tabId: string) => {
-    const store = useWorkbenchStore.getState();
-    const tab = store.tabs.find((t) => t.id === tabId);
-    if (!tab) return;
-    if (tab.closing && tab.error) {
-      store.forceCloseTab(tabId);
-      return;
-    }
-    if (tab.closing) return;
-    if (tab.activeRunId && tab.sessionActive) {
-      store.closeTab(tabId);
-      try {
-        await cancelAgentRun(tab.activeRunId);
-      } catch (err) {
-        useWorkbenchStore.getState().patchTab(tabId, {
-          error: `탭 종료 실패: ${String(err)}`,
-        });
-        return;
-      }
-      setTimeout(() => {
-        const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
-        if (current && current.closing && !current.error) {
-          useWorkbenchStore.getState().patchTab(tabId, {
-            error: "backend lifecycle 이벤트를 받지 못했습니다. 강제로 닫을 수 있습니다.",
-          });
-        }
-      }, CLOSE_FALLBACK_MS);
-      return;
-    }
-    store.closeTab(tabId);
+  const handleClose = useCallback((tabId: string) => {
+    void closeWorkbenchTab(tabId);
   }, []);
 
   return (

--- a/src/widgets/workbench-tabs/index.ts
+++ b/src/widgets/workbench-tabs/index.ts
@@ -1,0 +1,1 @@
+export { TabBar } from "./TabBar";


### PR DESCRIPTION
## Summary

- Add public APIs for existing FSD slices across entities, features, widgets, shared API/lib/ui.
- Move typed Tauri command wrappers out of `shared/api` into owning feature slices so `shared` stays domain-agnostic.
- Extract permission response behavior from `EventStream` into `features/permission-response`.
- Extract running tab close/cancel orchestration from `TabBar` into `features/agent-run`.
- Document frontend FSD layers, import rules, public API expectations, and review checklist.

Closes #12

## Tests

- `npm run build`
