### PR TITLE
Backend hexagonal refactor (#11)

### DIFF
--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -1,0 +1,132 @@
+# Backend Architecture
+
+ACP Agent Workbench의 Rust/Tauri 백엔드는 hexagonal(ports-and-adapters) 스타일로 구성되어 있다.
+
+이 문서는 각 레이어의 책임, 허용되는 의존 방향, 그리고 새 기능을 추가할 때 어디에 코드를 두어야 하는지를 정리한다.
+
+## 레이어
+
+```mermaid
+flowchart LR
+    subgraph domain["domain/"]
+        direction TB
+        events[events.rs]
+        run[run.rs]
+        agent[agent.rs]
+    end
+
+    subgraph ports["ports/"]
+        direction TB
+        session_registry[session_registry.rs]
+        session_handle[session_handle.rs]
+        event_sink[event_sink.rs]
+        permission[permission.rs]
+        agent_catalog[agent_catalog.rs]
+        goal_file[goal_file.rs]
+    end
+
+    subgraph application["application/"]
+        direction TB
+        start_agent_run[start_agent_run.rs]
+        send_prompt[send_prompt.rs]
+        cancel_agent_run[cancel_agent_run.rs]
+        list_agents[list_agents.rs]
+        load_goal_file[load_goal_file.rs]
+        respond_permission[respond_permission.rs]
+    end
+
+    subgraph adapters["adapters/"]
+        direction TB
+        tauri_cmd["tauri/commands.rs"]
+        tauri_sink["tauri/event_sink.rs"]
+        session_reg_impl["session_registry.rs"]
+        perm_broker["permission_broker.rs"]
+        acp_runner["acp/runner.rs"]
+        acp_client["acp/client.rs"]
+        acp_transport["acp/transport.rs"]
+        acp_mapper["acp/session_update_mapper.rs"]
+        agent_cat_impl["agent_catalog.rs"]
+        fs_impl["fs.rs"]
+    end
+
+    ports --> domain
+    application --> ports
+    application --> domain
+    adapters --> application
+    adapters --> ports
+    adapters --> domain
+```
+
+## 의존 방향
+
+`domain → ports → application → adapters`가 단 하나의 허용되는 방향이다.
+
+| Layer | 의존 가능 | 의존 불가 |
+|---|---|---|
+| `domain/` | (없음) | `ports`, `application`, `adapters` |
+| `ports/` | `domain` | `application`, `adapters` |
+| `application/` | `domain`, `ports` | `adapters` (원칙적으로. 클로저 주입으로 adapter 타입이 유출되지 않게 한다) |
+| `adapters/` | `domain`, `ports`, `application` | — |
+
+요지:
+- **domain**은 순수 데이터 타입과 도메인 규칙만 들고 있어야 한다. Tauri / JSON-RPC / subprocess / 파일시스템 경로 구체에 의존하지 않는다.
+- **ports**는 application이 외부세계에 요구하는 최소 인터페이스만 정의한다. 어댑터 구현 세부사항을 따라가지 않는다.
+- **application**은 유스케이스 오케스트레이션을 소유한다. `SessionRegistry`, `SessionHandle`, `RunEventSink` 같은 포트를 통해 일한다. 테스트에서는 fake port로 대체 가능.
+- **adapters**는 포트를 구현하면서 Tauri, ACP JSON-RPC, subprocess, 파일시스템, 권한 결정 등 외부 프로토콜을 격리한다.
+
+## 주요 포트
+
+| 포트 | 책임 |
+|---|---|
+| `SessionRegistry` | run id 예약/중복/동시성 한도 관리, task handle / session handle 보관, 취소 |
+| `SessionHandle` | 활성 세션에 follow-up 프롬프트 전송 (AcpSession의 ACP 의존성을 숨긴다) |
+| `RunEventSink` | 특정 run id의 `RunEvent`를 외부 세계(예: 프런트엔드)로 내보냄 |
+| `PermissionDecisionPort` | 권한 대기열 생성/응답 |
+| `AgentCatalog` | 가용 에이전트 목록과 기본 커맨드 조회 |
+| `GoalFileReader` | 디스크의 goal 파일 로드 |
+
+## 주요 유스케이스
+
+| UseCase | 입력 | 핵심 작업 |
+|---|---|---|
+| `StartAgentRunUseCase` | `AgentRunRequest`, sink, launcher closure | run 예약 → 세션 launch → attach → driver await → finish |
+| `SendPromptUseCase` | run id, prompt, sink | 활성 세션 조회 → `SessionHandle::send_prompt` → 에러를 이벤트로 surface |
+| `CancelAgentRunUseCase` | run id, sink | registry cancel 호출 + `Cancelled` 라이프사이클 이벤트 emit (미존재 run도 fallback 메시지로 emit) |
+| `ListAgentsUseCase` | — | `AgentCatalog` 조회 |
+| `LoadGoalFileUseCase` | 경로 | `GoalFileReader` 조회 |
+| `RespondPermissionUseCase` | permission id, option id | `PermissionDecisionPort::respond` |
+
+## 주요 어댑터
+
+| Adapter | 구현 포트 / 역할 |
+|---|---|
+| `adapters/session_registry.rs::AppState` | `SessionRegistry` 구현. 내부에 `PermissionBroker` 소유 |
+| `adapters/permission_broker.rs::PermissionBroker` | `PermissionDecisionPort` 구현 |
+| `adapters/acp/runner.rs::AcpAgentRunner` | ACP agent subprocess 기동 + 세션 생성. `launch_agent_run`은 `StartAgentRunUseCase`가 받는 launcher 구현이다. |
+| `adapters/acp/runner.rs::AcpSession` | `SessionHandle` 구현 |
+| `adapters/acp/client.rs::AcpClient` | 에이전트로부터의 JSON-RPC 요청/알림 처리 (권한/fs/terminal/tool/stateful tool tracking) |
+| `adapters/acp/transport.rs::RpcPeer` + `read_loop` | JSON-RPC 2.0 peer, stdin 기반 read loop |
+| `adapters/acp/session_update_mapper.rs` | `session/update` payload → `RunEvent` 순수 매핑 (단위테스트 가능) |
+| `adapters/tauri/commands.rs` | Tauri command 진입점. 입력 파싱 + 유스케이스 호출 + 에러 매핑만 담당 |
+| `adapters/tauri/event_sink.rs::TauriRunEventSink` | `RunEventSink` 구현. Tauri event로 브리지 |
+| `adapters/agent_catalog.rs::ConfigurableAgentCatalog` | `AgentCatalog` 구현 |
+| `adapters/fs.rs::LocalGoalFileReader` | `GoalFileReader` 구현 |
+
+## 새 기능을 추가할 때
+
+1. 새 유스케이스가 필요한가? — `application/`에 추가. 필요한 포트를 먼저 `ports/`에 정의하거나 기존 포트 사용.
+2. 새 외부 연동이 필요한가? — `adapters/`에 어댑터 추가하고 해당 포트를 구현.
+3. Tauri command는 `adapters/tauri/commands.rs`에서 얇게 유스케이스를 호출.
+4. 직접 `tauri::State<AppState>`에서 비즈니스 로직을 실행하지 않는다 — 그건 유스케이스가 담당.
+5. 어댑터 타입(`AcpSession`, `Child` 등)이 application 시그니처에 드러나지 않도록 한다. 필요하면 새 포트로 숨기거나 (S4의 `SessionHandle`처럼) 클로저 주입으로 우회.
+
+## 테스트 전략
+
+- **adapter** 테스트: 가능한 경우 subprocess / Tauri 없이 — 예: `session_update_mapper`는 순수 함수라 JSON fixture로 모든 분기 검증.
+- **application** 테스트: fake 포트 구현으로 use case를 단위 테스트. `start_agent_run::tests`가 예시.
+- **registry** 테스트: in-memory `AppState`를 직접 사용.
+- 통합 테스트(실제 ACP 에이전트 기동)는 별도 range로. 현재 리포에는 없다.
+
+## Phase 2 확장 지점
+
+`#8`(멀티 윈도우) 대비 포트 설계가 이미 소유권 확장을 염두에 두고 있다. `SessionRegistry`에 `reserve_run(run_id, owner)` 변형을 추가하고 `run_owners` 필드를 가진 `AppState` 변형으로 교체하면 `StartAgentRunUseCase`는 거의 그대로 재사용 가능하다.

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -79,6 +79,7 @@ flowchart LR
 | 포트 | 책임 |
 |---|---|
 | `SessionRegistry` | run id 예약/중복/동시성 한도 관리, task handle / session handle 보관, 취소 |
+| `SessionLauncher` | 세션 1건 기동. 성공 시 `LaunchedSession { session, commander }` 반환. `RunCommander`는 `run_to_completion` 또는 `abort` 중 하나만 소비 (Command/Strategy 패턴) |
 | `SessionHandle` | 활성 세션에 follow-up 프롬프트 전송 (AcpSession의 ACP 의존성을 숨긴다) |
 | `RunEventSink` | 특정 run id의 `RunEvent`를 외부 세계(예: 프런트엔드)로 내보냄 |
 | `PermissionDecisionPort` | 권한 대기열 생성/응답 |
@@ -89,7 +90,7 @@ flowchart LR
 
 | UseCase | 입력 | 핵심 작업 |
 |---|---|---|
-| `StartAgentRunUseCase` | `AgentRunRequest`, sink, launcher closure | run 예약 → 세션 launch → attach → driver await → finish |
+| `StartAgentRunUseCase` | `AgentRunRequest`, sink, `SessionLauncher` | run 예약 → 세션 launch → attach → driver await → finish |
 | `SendPromptUseCase` | run id, prompt, sink | 활성 세션 조회 → `SessionHandle::send_prompt` → 에러를 이벤트로 surface |
 | `CancelAgentRunUseCase` | run id, sink | registry cancel 호출 + `Cancelled` 라이프사이클 이벤트 emit (미존재 run도 fallback 메시지로 emit) |
 | `ListAgentsUseCase` | — | `AgentCatalog` 조회 |
@@ -102,7 +103,7 @@ flowchart LR
 |---|---|
 | `adapters/session_registry.rs::AppState` | `SessionRegistry` 구현. 내부에 `PermissionBroker` 소유 |
 | `adapters/permission_broker.rs::PermissionBroker` | `PermissionDecisionPort` 구현 |
-| `adapters/acp/runner.rs::AcpAgentRunner` | ACP agent subprocess 기동 + 세션 생성. `launch_agent_run`은 `StartAgentRunUseCase`가 받는 launcher 구현이다. |
+| `adapters/acp/runner.rs::AcpAgentRunner` | ACP agent subprocess 기동 + 세션 생성. `SessionLauncher`를 직접 구현한다. |
 | `adapters/acp/runner.rs::AcpSession` | `SessionHandle` 구현 |
 | `adapters/acp/client.rs::AcpClient` | 에이전트로부터의 JSON-RPC 요청/알림 처리 (권한/fs/terminal/tool/stateful tool tracking) |
 | `adapters/acp/transport.rs::RpcPeer` + `read_loop` | JSON-RPC 2.0 peer, stdin 기반 read loop |

--- a/src-tauri/src/adapters/acp/client.rs
+++ b/src-tauri/src/adapters/acp/client.rs
@@ -2,117 +2,24 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde_json::{Value, json};
 use std::{collections::HashMap, fs, path::PathBuf, process::Stdio, sync::Arc};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
-    process::{Child, ChildStdin, Command},
-    sync::{Mutex, oneshot},
+    io::AsyncReadExt,
+    process::{Child, Command},
+    sync::Mutex,
 };
 use uuid::Uuid;
 
 use crate::{
-    adapters::acp::util::{
-        clean_tool_title, display_command, expand_tilde, extract_locations, normalize_path,
-        select_lines, string_param,
+    adapters::acp::{
+        session_update_mapper::{MappedSessionUpdate, map_session_update},
+        transport::RpcPeer,
+        util::{
+            clean_tool_title, display_command, expand_tilde, extract_locations, normalize_path,
+            select_lines, string_param,
+        },
     },
-    domain::events::{LifecycleStatus, PermissionOption, PlanEntry, RunEvent},
+    domain::events::{LifecycleStatus, PermissionOption, RunEvent},
     ports::{event_sink::RunEventSink, permission::PermissionDecisionPort},
 };
-
-use super::util::RpcError;
-
-type PendingMap = HashMap<u64, oneshot::Sender<std::result::Result<Value, RpcError>>>;
-
-#[derive(Clone)]
-pub struct RpcPeer {
-    writer: Arc<Mutex<ChildStdin>>,
-    pending: Arc<Mutex<PendingMap>>,
-    next_id: Arc<Mutex<u64>>,
-}
-
-impl RpcPeer {
-    pub fn new(stdin: ChildStdin) -> Self {
-        Self {
-            writer: Arc::new(Mutex::new(stdin)),
-            pending: Arc::new(Mutex::new(HashMap::new())),
-            next_id: Arc::new(Mutex::new(0)),
-        }
-    }
-
-    pub async fn request(
-        &self,
-        method: &str,
-        params: Value,
-    ) -> std::result::Result<Value, RpcError> {
-        let id = {
-            let mut next_id = self.next_id.lock().await;
-            let id = *next_id;
-            *next_id += 1;
-            id
-        };
-        let (tx, rx) = oneshot::channel();
-        self.pending.lock().await.insert(id, tx);
-        let payload = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
-        if let Err(err) = self.send_value(&payload).await {
-            let _ = self.pending.lock().await.remove(&id);
-            return Err(RpcError {
-                code: -32603,
-                message: err.to_string(),
-                data: None,
-            });
-        }
-        match rx.await {
-            Ok(result) => result,
-            Err(err) => Err(RpcError {
-                code: -32603,
-                message: format!("connection closed while waiting for {method}: {err}"),
-                data: None,
-            }),
-        }
-    }
-
-    async fn respond_ok(&self, id: Value, result: Value) -> Result<()> {
-        self.send_value(&json!({"jsonrpc": "2.0", "id": id, "result": result}))
-            .await
-    }
-
-    async fn respond_error(
-        &self,
-        id: Value,
-        code: i64,
-        message: &str,
-        data: Option<Value>,
-    ) -> Result<()> {
-        let mut error = json!({"code": code, "message": message});
-        if let Some(data) = data {
-            error["data"] = data;
-        }
-        self.send_value(&json!({"jsonrpc": "2.0", "id": id, "error": error}))
-            .await
-    }
-
-    async fn fail_pending(&self, message: impl Into<String>) {
-        let message = message.into();
-        let pending = {
-            let mut pending = self.pending.lock().await;
-            std::mem::take(&mut *pending)
-        };
-        for (_, tx) in pending {
-            let _ = tx.send(Err(RpcError {
-                code: -32603,
-                message: message.clone(),
-                data: None,
-            }));
-        }
-    }
-
-    async fn send_value(&self, value: &Value) -> Result<()> {
-        let mut writer = self.writer.lock().await;
-        let mut bytes = serde_json::to_vec(value)?;
-        bytes.push(b'\n');
-        writer.write_all(&bytes).await?;
-        writer.flush().await?;
-        Ok(())
-    }
-}
 
 struct TerminalState {
     child: Arc<Mutex<Child>>,
@@ -164,6 +71,12 @@ where
         self.sink.emit(&self.run_id, event);
     }
 
+    /// Emit a RunEvent on behalf of the transport layer (used from
+    /// `read_loop` to report JSON-RPC parse failures).
+    pub fn emit_raw(&self, event: RunEvent) {
+        self.emit(event);
+    }
+
     pub async fn handle_request(
         self: Arc<Self>,
         peer: RpcPeer,
@@ -210,11 +123,6 @@ where
     pub async fn handle_notification(&self, method: &str, params: Value) {
         if method == "session/update" {
             self.session_update(params).await;
-        } else if method.starts_with("ext/") {
-            self.emit(RunEvent::Raw {
-                method: method.to_string(),
-                payload: params,
-            });
         } else {
             self.emit(RunEvent::Raw {
                 method: method.to_string(),
@@ -305,68 +213,10 @@ where
     }
 
     async fn session_update(&self, params: Value) {
-        let Some(update) = params.get("update") else {
-            self.emit(RunEvent::Raw {
-                method: "session/update".into(),
-                payload: params,
-            });
-            return;
-        };
-        let kind = update
-            .get("sessionUpdate")
-            .and_then(Value::as_str)
-            .unwrap_or("session/update");
-        match kind {
-            "agent_message_chunk" => {
-                if let Some(text) = update.pointer("/content/text").and_then(Value::as_str) {
-                    self.emit(RunEvent::AgentMessage { text: text.into() });
-                }
-            }
-            "agent_thought_chunk" => {
-                if let Some(text) = update.pointer("/content/text").and_then(Value::as_str) {
-                    self.emit(RunEvent::Thought { text: text.into() });
-                }
-            }
-            "plan" => {
-                let entries = update
-                    .get("entries")
-                    .and_then(Value::as_array)
-                    .map(|entries| {
-                        entries
-                            .iter()
-                            .map(|entry| PlanEntry {
-                                status: entry
-                                    .get("status")
-                                    .and_then(Value::as_str)
-                                    .unwrap_or("")
-                                    .to_string(),
-                                content: entry
-                                    .get("content")
-                                    .and_then(Value::as_str)
-                                    .unwrap_or("")
-                                    .to_string(),
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default();
-                self.emit(RunEvent::Plan { entries });
-            }
-            "tool_call" | "tool_call_update" => self.tool_update(update).await,
-            "usage_update" => {
-                let used = update
-                    .get("used")
-                    .and_then(Value::as_i64)
-                    .unwrap_or_default();
-                let size = update
-                    .get("size")
-                    .and_then(Value::as_i64)
-                    .unwrap_or_default();
-                self.emit(RunEvent::Usage { used, size });
-            }
-            other => self.emit(RunEvent::Raw {
-                method: other.to_string(),
-                payload: update.clone(),
-            }),
+        match map_session_update(&params) {
+            MappedSessionUpdate::Event(event) => self.emit(event),
+            MappedSessionUpdate::Tool(update) => self.tool_update(&update).await,
+            MappedSessionUpdate::Ignored => {}
         }
     }
 
@@ -636,82 +486,6 @@ where
     }
 }
 
-pub async fn read_loop<R, S, P>(
-    mut reader: BufReader<R>,
-    peer: RpcPeer,
-    client: Arc<AcpClient<S, P>>,
-    limit: usize,
-) -> Result<()>
-where
-    R: AsyncRead + Unpin,
-    S: RunEventSink,
-    P: PermissionDecisionPort,
-{
-    loop {
-        let mut bytes = Vec::new();
-        let read = reader.read_until(b'\n', &mut bytes).await?;
-        if read == 0 {
-            peer.fail_pending("ACP connection closed").await;
-            break;
-        }
-        if bytes.len() > limit {
-            peer.fail_pending("ACP message exceeded stdio buffer limit")
-                .await;
-            bail!("ACP message exceeded stdio buffer limit of {limit} bytes");
-        }
-        let message: Value = match serde_json::from_slice(&bytes) {
-            Ok(message) => message,
-            Err(err) => {
-                client.emit(RunEvent::Diagnostic {
-                    message: format!("failed to parse JSON-RPC message: {err}"),
-                });
-                continue;
-            }
-        };
-        let method = message
-            .get("method")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let id = message.get("id").cloned();
-        match (method, id) {
-            (Some(method), Some(id)) => {
-                let params = message.get("params").cloned().unwrap_or(Value::Null);
-                let peer = peer.clone();
-                let client = Arc::clone(&client);
-                tokio::spawn(async move {
-                    client.handle_request(peer, id, method, params).await;
-                });
-            }
-            (Some(method), None) => {
-                let params = message.get("params").cloned().unwrap_or(Value::Null);
-                client.handle_notification(&method, params).await;
-            }
-            (None, Some(id)) => {
-                if let Some(request_id) = id.as_u64() {
-                    if let Some(tx) = peer.pending.lock().await.remove(&request_id) {
-                        if let Some(result) = message.get("result") {
-                            let _ = tx.send(Ok(result.clone()));
-                        } else {
-                            let error = message.get("error").cloned().unwrap_or(Value::Null);
-                            let _ = tx.send(Err(RpcError {
-                                code: error.get("code").and_then(Value::as_i64).unwrap_or(-32603),
-                                message: error
-                                    .get("message")
-                                    .and_then(Value::as_str)
-                                    .unwrap_or("Error")
-                                    .to_string(),
-                                data: error.get("data").cloned(),
-                            }));
-                        }
-                    }
-                }
-            }
-            (None, None) => {}
-        }
-    }
-    Ok(())
-}
-
 fn select_permission_option<'a>(options: &'a [Value], auto_allow: bool) -> Option<&'a Value> {
     if auto_allow {
         for desired in ["allow_once", "allow_always"] {
@@ -798,10 +572,8 @@ pub fn lifecycle(status: LifecycleStatus, message: impl Into<String>) -> RunEven
 
 #[cfg(test)]
 mod tests {
-    use super::{RpcPeer, select_permission_option};
+    use super::select_permission_option;
     use serde_json::json;
-    use std::process::Stdio;
-    use tokio::process::Command;
 
     #[test]
     fn auto_allow_prefers_allow_once_before_allow_always() {
@@ -831,25 +603,5 @@ mod tests {
             selected.get("optionId").and_then(|value| value.as_str()),
             Some("always")
         );
-    }
-
-    #[tokio::test]
-    async fn fail_pending_releases_waiting_requests() {
-        let mut child = Command::new("cat")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .spawn()
-            .expect("spawn cat");
-        let stdin = child.stdin.take().expect("stdin");
-        let peer = RpcPeer::new(stdin);
-        let (tx, pending) = tokio::sync::oneshot::channel();
-        peer.pending.lock().await.insert(1, tx);
-
-        peer.fail_pending("closed for test").await;
-
-        let result = pending.await.expect("pending response");
-        assert!(result.is_err());
-        assert_eq!(result.err().expect("error").message, "closed for test");
-        let _ = child.kill().await;
     }
 }

--- a/src-tauri/src/adapters/acp/mod.rs
+++ b/src-tauri/src/adapters/acp/mod.rs
@@ -1,3 +1,5 @@
 pub mod client;
 pub mod runner;
+pub mod session_update_mapper;
+pub mod transport;
 pub mod util;

--- a/src-tauri/src/adapters/acp/runner.rs
+++ b/src-tauri/src/adapters/acp/runner.rs
@@ -10,7 +10,8 @@ use tokio::{
 
 use crate::{
     adapters::acp::{
-        client::{AcpClient, RpcPeer, lifecycle, read_loop},
+        client::{AcpClient, lifecycle},
+        transport::{RpcPeer, read_loop},
         util::{RpcError, display_command, expand_tilde, normalize_path, rpc_to_anyhow},
     },
     application::start_agent_run::{

--- a/src-tauri/src/adapters/acp/runner.rs
+++ b/src-tauri/src/adapters/acp/runner.rs
@@ -14,16 +14,16 @@ use crate::{
         transport::{RpcPeer, read_loop},
         util::{RpcError, display_command, expand_tilde, normalize_path, rpc_to_anyhow},
     },
-    application::start_agent_run::{
-        AbortFuture, DriverFuture, LaunchedSession, RunCommander,
-    },
     domain::{
         events::{LifecycleStatus, RunEvent},
         run::AgentRunRequest,
     },
     ports::{
-        agent_catalog::AgentCatalog, event_sink::RunEventSink, permission::PermissionDecisionPort,
+        agent_catalog::AgentCatalog,
+        event_sink::RunEventSink,
+        permission::PermissionDecisionPort,
         session_handle::SessionHandle,
+        session_launcher::{AbortFuture, DriverFuture, LaunchedSession, RunCommander, SessionLauncher},
     },
 };
 
@@ -202,41 +202,47 @@ pub struct AcpSessionSetup {
     pub stderr_task: Option<JoinHandle<()>>,
 }
 
-pub async fn launch_agent_run<C, P, S>(
-    runner: Arc<AcpAgentRunner<C, P>>,
-    request: AgentRunRequest,
-    run_id: String,
-    sink: S,
-) -> Result<LaunchedSession<AcpSession>>
+impl<C, P> SessionLauncher for AcpAgentRunner<C, P>
 where
     C: AgentCatalog,
     P: PermissionDecisionPort,
-    S: RunEventSink,
 {
-    let setup = runner
-        .start_session(&request, run_id.clone(), sink.clone())
-        .await?;
-    let AcpSessionSetup {
-        session,
-        child,
-        read_task,
-        stderr_task,
-    } = setup;
+    type Session = AcpSession;
 
-    let commander = AcpRunCommander {
-        child,
-        read_task,
-        stderr_task,
-        session: session.clone(),
-        sink,
-        run_id,
-        initial_goal: request.goal,
-    };
+    async fn launch<S>(
+        self,
+        request: AgentRunRequest,
+        run_id: String,
+        sink: S,
+    ) -> Result<LaunchedSession<AcpSession>>
+    where
+        S: RunEventSink,
+    {
+        let setup = self
+            .start_session(&request, run_id.clone(), sink.clone())
+            .await?;
+        let AcpSessionSetup {
+            session,
+            child,
+            read_task,
+            stderr_task,
+        } = setup;
 
-    Ok(LaunchedSession {
-        session,
-        commander: Box::new(commander),
-    })
+        let commander = AcpRunCommander {
+            child,
+            read_task,
+            stderr_task,
+            session: session.clone(),
+            sink,
+            run_id,
+            initial_goal: request.goal,
+        };
+
+        Ok(LaunchedSession {
+            session,
+            commander: Box::new(commander),
+        })
+    }
 }
 
 struct AcpRunCommander<S>

--- a/src-tauri/src/adapters/acp/runner.rs
+++ b/src-tauri/src/adapters/acp/runner.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     ports::{
         agent_catalog::AgentCatalog, event_sink::RunEventSink, permission::PermissionDecisionPort,
+        session_handle::SessionHandle,
     },
 };
 
@@ -271,7 +272,7 @@ where
             let run_id_for_prompt = run_id.clone();
             tokio::spawn(async move {
                 if let Err(err) = session_for_prompt
-                    .send_prompt(&sink_for_prompt, initial_goal)
+                    .send_prompt(sink_for_prompt.clone(), initial_goal)
                     .await
                 {
                     sink_for_prompt.emit(
@@ -349,8 +350,10 @@ impl AcpSession {
     pub async fn session_id(&self) -> String {
         self.session_id.lock().await.clone()
     }
+}
 
-    pub async fn send_prompt<S>(&self, sink: &S, text: String) -> Result<String>
+impl SessionHandle for AcpSession {
+    async fn send_prompt<S>(&self, sink: S, text: String) -> Result<String>
     where
         S: RunEventSink,
     {

--- a/src-tauri/src/adapters/acp/runner.rs
+++ b/src-tauri/src/adapters/acp/runner.rs
@@ -13,6 +13,9 @@ use crate::{
         client::{AcpClient, RpcPeer, lifecycle, read_loop},
         util::{RpcError, display_command, expand_tilde, normalize_path, rpc_to_anyhow},
     },
+    application::start_agent_run::{
+        AbortFuture, DriverFuture, LaunchedSession, RunCommander,
+    },
     domain::{
         events::{LifecycleStatus, RunEvent},
         run::AgentRunRequest,
@@ -195,6 +198,143 @@ pub struct AcpSessionSetup {
     pub child: Child,
     pub read_task: JoinHandle<Result<()>>,
     pub stderr_task: Option<JoinHandle<()>>,
+}
+
+pub async fn launch_agent_run<C, P, S>(
+    runner: Arc<AcpAgentRunner<C, P>>,
+    request: AgentRunRequest,
+    run_id: String,
+    sink: S,
+) -> Result<LaunchedSession<AcpSession>>
+where
+    C: AgentCatalog,
+    P: PermissionDecisionPort,
+    S: RunEventSink,
+{
+    let setup = runner
+        .start_session(&request, run_id.clone(), sink.clone())
+        .await?;
+    let AcpSessionSetup {
+        session,
+        child,
+        read_task,
+        stderr_task,
+    } = setup;
+
+    let commander = AcpRunCommander {
+        child,
+        read_task,
+        stderr_task,
+        session: session.clone(),
+        sink,
+        run_id,
+        initial_goal: request.goal,
+    };
+
+    Ok(LaunchedSession {
+        session,
+        commander: Box::new(commander),
+    })
+}
+
+struct AcpRunCommander<S>
+where
+    S: RunEventSink,
+{
+    child: Child,
+    read_task: JoinHandle<Result<()>>,
+    stderr_task: Option<JoinHandle<()>>,
+    session: Arc<AcpSession>,
+    sink: S,
+    run_id: String,
+    initial_goal: String,
+}
+
+impl<S> RunCommander for AcpRunCommander<S>
+where
+    S: RunEventSink,
+{
+    fn run_to_completion(self: Box<Self>) -> DriverFuture {
+        Box::pin(async move {
+            let Self {
+                mut child,
+                read_task,
+                stderr_task,
+                session,
+                sink,
+                run_id,
+                initial_goal,
+            } = *self;
+
+            let session_for_prompt = session.clone();
+            let sink_for_prompt = sink.clone();
+            let run_id_for_prompt = run_id.clone();
+            tokio::spawn(async move {
+                if let Err(err) = session_for_prompt
+                    .send_prompt(&sink_for_prompt, initial_goal)
+                    .await
+                {
+                    sink_for_prompt.emit(
+                        &run_id_for_prompt,
+                        RunEvent::Error {
+                            message: err.to_string(),
+                        },
+                    );
+                }
+            });
+
+            match child.wait().await {
+                Ok(status) => {
+                    if let Some(code) = status.code() {
+                        if code != 0 {
+                            sink.emit(
+                                &run_id,
+                                RunEvent::Diagnostic {
+                                    message: format!("agent process exited with code {code}"),
+                                },
+                            );
+                        }
+                    }
+                }
+                Err(err) => {
+                    sink.emit(
+                        &run_id,
+                        RunEvent::Diagnostic {
+                            message: format!("failed to wait for agent process: {err}"),
+                        },
+                    );
+                }
+            }
+
+            read_task.abort();
+            let _ = read_task.await;
+            if let Some(task) = stderr_task {
+                task.abort();
+            }
+
+            sink.emit(
+                &run_id,
+                lifecycle(LifecycleStatus::Completed, "agent exited"),
+            );
+        })
+    }
+
+    fn abort(self: Box<Self>) -> AbortFuture {
+        Box::pin(async move {
+            let Self {
+                mut child,
+                read_task,
+                stderr_task,
+                ..
+            } = *self;
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            read_task.abort();
+            if let Some(task) = stderr_task {
+                task.abort();
+            }
+        })
+    }
 }
 
 pub struct AcpSession {

--- a/src-tauri/src/adapters/acp/session_update_mapper.rs
+++ b/src-tauri/src/adapters/acp/session_update_mapper.rs
@@ -1,0 +1,93 @@
+use serde_json::Value;
+
+use crate::domain::events::{PlanEntry, RunEvent};
+
+/// Outcome of mapping a `session/update` JSON-RPC payload.
+///
+/// The ACP protocol mixes stateless updates (message chunks, plans,
+/// usage) with stateful ones (tool call transitions that depend on
+/// earlier tool events). The stateless mapping is captured here so it
+/// can be unit-tested without the rest of the ACP client; stateful
+/// tool updates are forwarded back to the caller as a raw `Value` for
+/// session-aware handling.
+pub enum MappedSessionUpdate {
+    /// A ready-to-emit `RunEvent`.
+    Event(RunEvent),
+    /// A `tool_call` or `tool_call_update` payload; the caller tracks
+    /// tool identity / locations / dedupe signature state.
+    Tool(Value),
+    /// Update contained no actionable data (e.g. an agent message
+    /// chunk without text). The caller should emit nothing.
+    Ignored,
+}
+
+/// Map a `session/update` params JSON into either a direct run event,
+/// a tool payload that requires stateful handling, or a no-op.
+pub fn map_session_update(params: &Value) -> MappedSessionUpdate {
+    let Some(update) = params.get("update") else {
+        return MappedSessionUpdate::Event(RunEvent::Raw {
+            method: "session/update".into(),
+            payload: params.clone(),
+        });
+    };
+
+    let kind = update
+        .get("sessionUpdate")
+        .and_then(Value::as_str)
+        .unwrap_or("session/update");
+
+    match kind {
+        "agent_message_chunk" => update
+            .pointer("/content/text")
+            .and_then(Value::as_str)
+            .map(|text| {
+                MappedSessionUpdate::Event(RunEvent::AgentMessage { text: text.into() })
+            })
+            .unwrap_or(MappedSessionUpdate::Ignored),
+        "agent_thought_chunk" => update
+            .pointer("/content/text")
+            .and_then(Value::as_str)
+            .map(|text| MappedSessionUpdate::Event(RunEvent::Thought { text: text.into() }))
+            .unwrap_or(MappedSessionUpdate::Ignored),
+        "plan" => {
+            let entries = update
+                .get("entries")
+                .and_then(Value::as_array)
+                .map(|entries| {
+                    entries
+                        .iter()
+                        .map(|entry| PlanEntry {
+                            status: entry
+                                .get("status")
+                                .and_then(Value::as_str)
+                                .unwrap_or("")
+                                .to_string(),
+                            content: entry
+                                .get("content")
+                                .and_then(Value::as_str)
+                                .unwrap_or("")
+                                .to_string(),
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            MappedSessionUpdate::Event(RunEvent::Plan { entries })
+        }
+        "tool_call" | "tool_call_update" => MappedSessionUpdate::Tool(update.clone()),
+        "usage_update" => {
+            let used = update
+                .get("used")
+                .and_then(Value::as_i64)
+                .unwrap_or_default();
+            let size = update
+                .get("size")
+                .and_then(Value::as_i64)
+                .unwrap_or_default();
+            MappedSessionUpdate::Event(RunEvent::Usage { used, size })
+        }
+        other => MappedSessionUpdate::Event(RunEvent::Raw {
+            method: other.to_string(),
+            payload: update.clone(),
+        }),
+    }
+}

--- a/src-tauri/src/adapters/acp/session_update_mapper.rs
+++ b/src-tauri/src/adapters/acp/session_update_mapper.rs
@@ -91,3 +91,198 @@ pub fn map_session_update(params: &Value) -> MappedSessionUpdate {
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn expect_event(mapped: MappedSessionUpdate) -> RunEvent {
+        match mapped {
+            MappedSessionUpdate::Event(event) => event,
+            MappedSessionUpdate::Tool(_) => panic!("expected Event, got Tool"),
+            MappedSessionUpdate::Ignored => panic!("expected Event, got Ignored"),
+        }
+    }
+
+    #[test]
+    fn missing_update_field_falls_through_as_raw_session_update() {
+        let params = json!({"sessionId": "abc"});
+        let event = expect_event(map_session_update(&params));
+        match event {
+            RunEvent::Raw { method, payload } => {
+                assert_eq!(method, "session/update");
+                assert_eq!(payload, params);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_message_chunk_with_text_maps_to_agent_message_event() {
+        let params = json!({
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"text": "hello"}
+            }
+        });
+        match expect_event(map_session_update(&params)) {
+            RunEvent::AgentMessage { text } => assert_eq!(text, "hello"),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_message_chunk_without_text_is_ignored() {
+        let params = json!({
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {}
+            }
+        });
+        assert!(matches!(
+            map_session_update(&params),
+            MappedSessionUpdate::Ignored
+        ));
+    }
+
+    #[test]
+    fn agent_thought_chunk_with_text_maps_to_thought_event() {
+        let params = json!({
+            "update": {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"text": "planning"}
+            }
+        });
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Thought { text } => assert_eq!(text, "planning"),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_maps_to_plan_event_with_entries() {
+        let params = json!({
+            "update": {
+                "sessionUpdate": "plan",
+                "entries": [
+                    {"status": "pending", "content": "step 1"},
+                    {"status": "completed", "content": "step 0"}
+                ]
+            }
+        });
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Plan { entries } => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].status, "pending");
+                assert_eq!(entries[0].content, "step 1");
+                assert_eq!(entries[1].status, "completed");
+                assert_eq!(entries[1].content, "step 0");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_without_entries_maps_to_empty_plan() {
+        let params = json!({"update": {"sessionUpdate": "plan"}});
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Plan { entries } => assert!(entries.is_empty()),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_update_maps_to_usage_event() {
+        let params = json!({
+            "update": {
+                "sessionUpdate": "usage_update",
+                "used": 1200,
+                "size": 16_000
+            }
+        });
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Usage { used, size } => {
+                assert_eq!(used, 1200);
+                assert_eq!(size, 16_000);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_update_with_missing_fields_uses_defaults() {
+        let params = json!({"update": {"sessionUpdate": "usage_update"}});
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Usage { used, size } => {
+                assert_eq!(used, 0);
+                assert_eq!(size, 0);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_and_tool_call_update_require_stateful_handling() {
+        let tool_call = json!({
+            "update": {
+                "sessionUpdate": "tool_call",
+                "status": "pending",
+                "title": "Read"
+            }
+        });
+        match map_session_update(&tool_call) {
+            MappedSessionUpdate::Tool(payload) => {
+                assert_eq!(payload.get("sessionUpdate").and_then(|v| v.as_str()), Some("tool_call"));
+            }
+            other => panic!("unexpected mapping: {other:?}"),
+        }
+
+        let tool_call_update = json!({
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "status": "completed"
+            }
+        });
+        assert!(matches!(
+            map_session_update(&tool_call_update),
+            MappedSessionUpdate::Tool(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_kind_falls_through_as_raw_event_preserving_kind() {
+        let params = json!({
+            "update": {
+                "sessionUpdate": "mysterious_event",
+                "extra": 42
+            }
+        });
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Raw { method, payload } => {
+                assert_eq!(method, "mysterious_event");
+                assert_eq!(payload.get("extra").and_then(|v| v.as_i64()), Some(42));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_session_update_kind_falls_back_to_session_update_marker() {
+        let params = json!({"update": {}});
+        match expect_event(map_session_update(&params)) {
+            RunEvent::Raw { method, .. } => assert_eq!(method, "session/update"),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    impl std::fmt::Debug for MappedSessionUpdate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                MappedSessionUpdate::Event(event) => write!(f, "Event({event:?})"),
+                MappedSessionUpdate::Tool(value) => write!(f, "Tool({value})"),
+                MappedSessionUpdate::Ignored => write!(f, "Ignored"),
+            }
+        }
+    }
+}

--- a/src-tauri/src/adapters/acp/transport.rs
+++ b/src-tauri/src/adapters/acp/transport.rs
@@ -1,0 +1,224 @@
+use anyhow::{Result, bail};
+use serde_json::{Value, json};
+use std::{collections::HashMap, sync::Arc};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader},
+    process::ChildStdin,
+    sync::{Mutex, oneshot},
+};
+
+use crate::{
+    adapters::acp::{client::AcpClient, util::RpcError},
+    domain::events::RunEvent,
+    ports::{event_sink::RunEventSink, permission::PermissionDecisionPort},
+};
+
+type PendingMap = HashMap<u64, oneshot::Sender<std::result::Result<Value, RpcError>>>;
+
+/// JSON-RPC 2.0 peer over the agent's stdin/stdout.
+///
+/// Owns outbound writes, an id counter, and the map of in-flight
+/// requests so response frames read from stdout can be correlated
+/// back to their waiting callers.
+#[derive(Clone)]
+pub struct RpcPeer {
+    writer: Arc<Mutex<ChildStdin>>,
+    pub(crate) pending: Arc<Mutex<PendingMap>>,
+    next_id: Arc<Mutex<u64>>,
+}
+
+impl RpcPeer {
+    pub fn new(stdin: ChildStdin) -> Self {
+        Self {
+            writer: Arc::new(Mutex::new(stdin)),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub async fn request(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> std::result::Result<Value, RpcError> {
+        let id = {
+            let mut next_id = self.next_id.lock().await;
+            let id = *next_id;
+            *next_id += 1;
+            id
+        };
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+        let payload = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        if let Err(err) = self.send_value(&payload).await {
+            let _ = self.pending.lock().await.remove(&id);
+            return Err(RpcError {
+                code: -32603,
+                message: err.to_string(),
+                data: None,
+            });
+        }
+        match rx.await {
+            Ok(result) => result,
+            Err(err) => Err(RpcError {
+                code: -32603,
+                message: format!("connection closed while waiting for {method}: {err}"),
+                data: None,
+            }),
+        }
+    }
+
+    pub(crate) async fn respond_ok(&self, id: Value, result: Value) -> Result<()> {
+        self.send_value(&json!({"jsonrpc": "2.0", "id": id, "result": result}))
+            .await
+    }
+
+    pub(crate) async fn respond_error(
+        &self,
+        id: Value,
+        code: i64,
+        message: &str,
+        data: Option<Value>,
+    ) -> Result<()> {
+        let mut error = json!({"code": code, "message": message});
+        if let Some(data) = data {
+            error["data"] = data;
+        }
+        self.send_value(&json!({"jsonrpc": "2.0", "id": id, "error": error}))
+            .await
+    }
+
+    pub(crate) async fn fail_pending(&self, message: impl Into<String>) {
+        let message = message.into();
+        let pending = {
+            let mut pending = self.pending.lock().await;
+            std::mem::take(&mut *pending)
+        };
+        for (_, tx) in pending {
+            let _ = tx.send(Err(RpcError {
+                code: -32603,
+                message: message.clone(),
+                data: None,
+            }));
+        }
+    }
+
+    async fn send_value(&self, value: &Value) -> Result<()> {
+        let mut writer = self.writer.lock().await;
+        let mut bytes = serde_json::to_vec(value)?;
+        bytes.push(b'\n');
+        writer.write_all(&bytes).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+}
+
+/// Drive the read side of the JSON-RPC connection.
+///
+/// Parses each newline-terminated message, dispatches incoming requests
+/// to `AcpClient::handle_request`, incoming notifications to
+/// `AcpClient::handle_notification`, and resolves outstanding request
+/// responses on the `RpcPeer`. Exits cleanly on EOF or fails fast if
+/// a message exceeds `limit` bytes.
+pub async fn read_loop<R, S, P>(
+    mut reader: BufReader<R>,
+    peer: RpcPeer,
+    client: Arc<AcpClient<S, P>>,
+    limit: usize,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    S: RunEventSink,
+    P: PermissionDecisionPort,
+{
+    loop {
+        let mut bytes = Vec::new();
+        let read = reader.read_until(b'\n', &mut bytes).await?;
+        if read == 0 {
+            peer.fail_pending("ACP connection closed").await;
+            break;
+        }
+        if bytes.len() > limit {
+            peer.fail_pending("ACP message exceeded stdio buffer limit")
+                .await;
+            bail!("ACP message exceeded stdio buffer limit of {limit} bytes");
+        }
+        let message: Value = match serde_json::from_slice(&bytes) {
+            Ok(message) => message,
+            Err(err) => {
+                client.emit_raw(RunEvent::Diagnostic {
+                    message: format!("failed to parse JSON-RPC message: {err}"),
+                });
+                continue;
+            }
+        };
+        let method = message
+            .get("method")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let id = message.get("id").cloned();
+        match (method, id) {
+            (Some(method), Some(id)) => {
+                let params = message.get("params").cloned().unwrap_or(Value::Null);
+                let peer = peer.clone();
+                let client = Arc::clone(&client);
+                tokio::spawn(async move {
+                    client.handle_request(peer, id, method, params).await;
+                });
+            }
+            (Some(method), None) => {
+                let params = message.get("params").cloned().unwrap_or(Value::Null);
+                client.handle_notification(&method, params).await;
+            }
+            (None, Some(id)) => {
+                if let Some(request_id) = id.as_u64() {
+                    if let Some(tx) = peer.pending.lock().await.remove(&request_id) {
+                        if let Some(result) = message.get("result") {
+                            let _ = tx.send(Ok(result.clone()));
+                        } else {
+                            let error = message.get("error").cloned().unwrap_or(Value::Null);
+                            let _ = tx.send(Err(RpcError {
+                                code: error.get("code").and_then(Value::as_i64).unwrap_or(-32603),
+                                message: error
+                                    .get("message")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or("Error")
+                                    .to_string(),
+                                data: error.get("data").cloned(),
+                            }));
+                        }
+                    }
+                }
+            }
+            (None, None) => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RpcPeer;
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    #[tokio::test]
+    async fn fail_pending_releases_waiting_requests() {
+        let mut child = Command::new("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .spawn()
+            .expect("spawn cat");
+        let stdin = child.stdin.take().expect("stdin");
+        let peer = RpcPeer::new(stdin);
+        let (tx, pending) = tokio::sync::oneshot::channel();
+        peer.pending.lock().await.insert(1, tx);
+
+        peer.fail_pending("closed for test").await;
+
+        let result = pending.await.expect("pending response");
+        assert!(result.is_err());
+        assert_eq!(result.err().expect("error").message, "closed for test");
+        let _ = child.kill().await;
+    }
+}

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -1,4 +1,6 @@
 pub mod acp;
 pub mod agent_catalog;
 pub mod fs;
+pub mod permission_broker;
+pub mod session_registry;
 pub mod tauri;

--- a/src-tauri/src/adapters/permission_broker.rs
+++ b/src-tauri/src/adapters/permission_broker.rs
@@ -1,0 +1,82 @@
+use anyhow::{Result, anyhow};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{Mutex, oneshot};
+
+use crate::ports::permission::{PermissionDecision, PermissionDecisionPort};
+
+struct PendingPermission {
+    run_id: String,
+    sender: oneshot::Sender<PermissionDecision>,
+}
+
+#[derive(Clone, Default)]
+pub struct PermissionBroker {
+    pending: Arc<Mutex<HashMap<String, PendingPermission>>>,
+}
+
+impl PermissionDecisionPort for PermissionBroker {
+    async fn create_waiter(
+        &self,
+        run_id: String,
+        permission_id: String,
+    ) -> oneshot::Receiver<PermissionDecision> {
+        let (sender, receiver) = oneshot::channel();
+        self.pending
+            .lock()
+            .await
+            .insert(permission_id, PendingPermission { run_id, sender });
+        receiver
+    }
+
+    async fn respond(&self, permission_id: &str, decision: PermissionDecision) -> Result<()> {
+        let Some(pending) = self.pending.lock().await.remove(permission_id) else {
+            return Err(anyhow!(
+                "unknown or already answered permission: {permission_id}"
+            ));
+        };
+        pending
+            .sender
+            .send(decision)
+            .map_err(|_| anyhow!("permission waiter is no longer active"))
+    }
+}
+
+impl PermissionBroker {
+    pub async fn clear_run(&self, run_id: &str) {
+        self.pending
+            .lock()
+            .await
+            .retain(|_, pending| pending.run_id != run_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PermissionBroker;
+    use crate::ports::permission::{PermissionDecision, PermissionDecisionPort};
+
+    #[tokio::test]
+    async fn clearing_one_run_keeps_other_run_permission_waiters() {
+        let broker = PermissionBroker::default();
+        let first = broker
+            .create_waiter("run-a".to_string(), "permission-a".to_string())
+            .await;
+        let second = broker
+            .create_waiter("run-b".to_string(), "permission-b".to_string())
+            .await;
+
+        broker.clear_run("run-a").await;
+
+        assert!(first.await.is_err());
+        broker
+            .respond(
+                "permission-b",
+                PermissionDecision {
+                    option_id: "allow".to_string(),
+                },
+            )
+            .await
+            .expect("second run permission should remain active");
+        assert_eq!(second.await.expect("decision").option_id, "allow");
+    }
+}

--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, env, sync::Arc};
 use tokio::{sync::Mutex, task::JoinHandle};
 
 use crate::{
-    adapters::acp::runner::AcpSession,
-    ports::permission::{PermissionDecision, PermissionDecisionPort},
+    adapters::{acp::runner::AcpSession, permission_broker::PermissionBroker},
+    ports::session_registry::SessionRegistry,
 };
 
 const MAX_RUNS_ENV: &str = "ACP_WORKBENCH_MAX_RUNS";
@@ -37,6 +37,10 @@ impl AppState {
             max_concurrent_runs,
         }
     }
+
+    pub fn permissions(&self) -> PermissionBroker {
+        self.permissions.clone()
+    }
 }
 
 enum RunSlot {
@@ -49,12 +53,10 @@ struct RunContext {
     session: Option<Arc<AcpSession>>,
 }
 
-impl AppState {
-    pub fn permissions(&self) -> PermissionBroker {
-        self.permissions.clone()
-    }
+impl SessionRegistry for AppState {
+    type Session = AcpSession;
 
-    pub async fn reserve_run(&self, run_id: String) -> Result<()> {
+    async fn reserve_run(&self, run_id: String) -> Result<()> {
         let mut runs = self.runs.lock().await;
         if runs.contains_key(&run_id) {
             return Err(anyhow!("duplicate run id: {run_id}"));
@@ -70,11 +72,7 @@ impl AppState {
         Ok(())
     }
 
-    pub async fn active_run_count(&self) -> usize {
-        self.runs.lock().await.len()
-    }
-
-    pub async fn attach_run_handle(&self, run_id: &str, handle: JoinHandle<()>) -> Result<()> {
+    async fn attach_run_handle(&self, run_id: &str, handle: JoinHandle<()>) -> Result<()> {
         let mut runs = self.runs.lock().await;
         let Some(slot) = runs.get_mut(run_id) else {
             handle.abort();
@@ -87,7 +85,7 @@ impl AppState {
         Ok(())
     }
 
-    pub async fn attach_session(&self, run_id: &str, session: Arc<AcpSession>) -> Result<()> {
+    async fn attach_session(&self, run_id: &str, session: Arc<AcpSession>) -> Result<()> {
         let mut runs = self.runs.lock().await;
         match runs.get_mut(run_id) {
             Some(RunSlot::Running(ctx)) => {
@@ -98,7 +96,7 @@ impl AppState {
         }
     }
 
-    pub async fn active_session(&self, run_id: &str) -> Option<Arc<AcpSession>> {
+    async fn active_session(&self, run_id: &str) -> Option<Arc<AcpSession>> {
         let runs = self.runs.lock().await;
         match runs.get(run_id) {
             Some(RunSlot::Running(ctx)) => ctx.session.clone(),
@@ -106,12 +104,12 @@ impl AppState {
         }
     }
 
-    pub async fn finish_run(&self, run_id: &str) {
+    async fn finish_run(&self, run_id: &str) {
         self.runs.lock().await.remove(run_id);
         self.permissions.clear_run(run_id).await;
     }
 
-    pub async fn cancel_run(&self, run_id: &str) -> bool {
+    async fn cancel_run(&self, run_id: &str) -> bool {
         let cancelled = match self.runs.lock().await.remove(run_id) {
             Some(RunSlot::Running(ctx)) => {
                 ctx.join_handle.abort();
@@ -125,58 +123,16 @@ impl AppState {
         }
         cancelled
     }
-}
 
-struct PendingPermission {
-    run_id: String,
-    sender: tokio::sync::oneshot::Sender<PermissionDecision>,
-}
-
-#[derive(Clone, Default)]
-pub struct PermissionBroker {
-    pending: Arc<Mutex<HashMap<String, PendingPermission>>>,
-}
-
-impl PermissionDecisionPort for PermissionBroker {
-    async fn create_waiter(
-        &self,
-        run_id: String,
-        permission_id: String,
-    ) -> tokio::sync::oneshot::Receiver<PermissionDecision> {
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        self.pending
-            .lock()
-            .await
-            .insert(permission_id, PendingPermission { run_id, sender });
-        receiver
-    }
-
-    async fn respond(&self, permission_id: &str, decision: PermissionDecision) -> Result<()> {
-        let Some(pending) = self.pending.lock().await.remove(permission_id) else {
-            return Err(anyhow!(
-                "unknown or already answered permission: {permission_id}"
-            ));
-        };
-        pending
-            .sender
-            .send(decision)
-            .map_err(|_| anyhow!("permission waiter is no longer active"))
-    }
-}
-
-impl PermissionBroker {
-    pub async fn clear_run(&self, run_id: &str) {
-        self.pending
-            .lock()
-            .await
-            .retain(|_, pending| pending.run_id != run_id);
+    async fn active_run_count(&self) -> usize {
+        self.runs.lock().await.len()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AppState, PermissionBroker};
-    use crate::ports::permission::{PermissionDecision, PermissionDecisionPort};
+    use super::AppState;
+    use crate::ports::session_registry::SessionRegistry;
 
     #[tokio::test]
     async fn reserve_run_allows_multiple_distinct_run_ids() {
@@ -239,30 +195,5 @@ mod tests {
             .await
             .expect_err("duplicate id must fail");
         assert!(err.to_string().contains("duplicate run id"));
-    }
-
-    #[tokio::test]
-    async fn clearing_one_run_keeps_other_run_permission_waiters() {
-        let broker = PermissionBroker::default();
-        let first = broker
-            .create_waiter("run-a".to_string(), "permission-a".to_string())
-            .await;
-        let second = broker
-            .create_waiter("run-b".to_string(), "permission-b".to_string())
-            .await;
-
-        broker.clear_run("run-a").await;
-
-        assert!(first.await.is_err());
-        broker
-            .respond(
-                "permission-b",
-                PermissionDecision {
-                    option_id: "allow".to_string(),
-                },
-            )
-            .await
-            .expect("second run permission should remain active");
-        assert_eq!(second.await.expect("decision").option_id, "allow");
     }
 }

--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -124,7 +124,11 @@ impl SessionRegistry for AppState {
         cancelled
     }
 
-    async fn active_run_count(&self) -> usize {
+}
+
+#[cfg(test)]
+impl AppState {
+    pub async fn active_run_count(&self) -> usize {
         self.runs.lock().await.len()
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use tauri::{AppHandle, State};
 
 use crate::{
     adapters::{
-        acp::{client::lifecycle, runner::AcpAgentRunner},
+        acp::runner::{AcpAgentRunner, launch_agent_run},
         agent_catalog::ConfigurableAgentCatalog,
         fs::LocalGoalFileReader,
         session_registry::AppState,
@@ -10,7 +12,7 @@ use crate::{
     },
     application::{
         list_agents::ListAgentsUseCase, load_goal_file::LoadGoalFileUseCase,
-        respond_permission::RespondPermissionUseCase,
+        respond_permission::RespondPermissionUseCase, start_agent_run::StartAgentRunUseCase,
     },
     domain::{
         agent::AgentDescriptor,
@@ -38,124 +40,20 @@ pub async fn start_agent_run(
     state: State<'_, AppState>,
     request: AgentRunRequest,
 ) -> Result<AgentRun, String> {
-    let run = match request.run_id.clone() {
-        Some(id) if !id.trim().is_empty() => {
-            AgentRun::with_id(id, request.goal.clone(), request.agent_id.clone())
-        }
-        _ => AgentRun::new(request.goal.clone(), request.agent_id.clone()),
-    };
-    let run_for_task = run.clone();
     let sink = TauriRunEventSink::new(app);
     let permissions = state.permissions();
-    let state_handle = state.inner().clone();
-    let state_for_task = state_handle.clone();
+    let registry = state.inner().clone();
+    let runner = Arc::new(AcpAgentRunner::new(
+        ConfigurableAgentCatalog::from_env(),
+        permissions,
+    ));
 
-    state_handle
-        .reserve_run(run.id.clone())
+    StartAgentRunUseCase::new(registry)
+        .execute(sink, request, move |request, run_id, sink_for_launch| {
+            let runner = runner.clone();
+            async move { launch_agent_run(runner, request, run_id, sink_for_launch).await }
+        })
         .await
-        .map_err(|err| err.to_string())?;
-
-    let handle = tokio::spawn(async move {
-        let runner = AcpAgentRunner::new(ConfigurableAgentCatalog::from_env(), permissions);
-        let setup = match runner
-            .start_session(&request, run_for_task.id.clone(), sink.clone())
-            .await
-        {
-            Ok(setup) => setup,
-            Err(err) => {
-                sink.emit(
-                    &run_for_task.id,
-                    RunEvent::Error {
-                        message: err.to_string(),
-                    },
-                );
-                state_for_task.finish_run(&run_for_task.id).await;
-                return;
-            }
-        };
-        let session = setup.session;
-        let mut child = setup.child;
-        let read_task = setup.read_task;
-        let stderr_task = setup.stderr_task;
-
-        if let Err(err) = state_for_task
-            .attach_session(&run_for_task.id, session.clone())
-            .await
-        {
-            sink.emit(
-                &run_for_task.id,
-                RunEvent::Diagnostic {
-                    message: err.to_string(),
-                },
-            );
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            read_task.abort();
-            if let Some(task) = stderr_task {
-                task.abort();
-            }
-            state_for_task.finish_run(&run_for_task.id).await;
-            return;
-        }
-
-        let session_for_prompt = session.clone();
-        let sink_for_prompt = sink.clone();
-        let run_id_for_prompt = run_for_task.id.clone();
-        tokio::spawn(async move {
-            if let Err(err) = session_for_prompt
-                .send_prompt(&sink_for_prompt, request.goal)
-                .await
-            {
-                sink_for_prompt.emit(
-                    &run_id_for_prompt,
-                    RunEvent::Error {
-                        message: err.to_string(),
-                    },
-                );
-            }
-        });
-
-        match child.wait().await {
-            Ok(status) => {
-                if let Some(code) = status.code() {
-                    if code != 0 {
-                        sink.emit(
-                            &run_for_task.id,
-                            RunEvent::Diagnostic {
-                                message: format!("agent process exited with code {code}"),
-                            },
-                        );
-                    }
-                }
-            }
-            Err(err) => {
-                sink.emit(
-                    &run_for_task.id,
-                    RunEvent::Diagnostic {
-                        message: format!("failed to wait for agent process: {err}"),
-                    },
-                );
-            }
-        }
-
-        read_task.abort();
-        let _ = read_task.await;
-        if let Some(task) = stderr_task {
-            task.abort();
-        }
-
-        sink.emit(
-            &run_for_task.id,
-            lifecycle(LifecycleStatus::Completed, "agent exited"),
-        );
-        state_for_task.finish_run(&run_for_task.id).await;
-    });
-    state_handle
-        .attach_run_handle(&run.id, handle)
-        .await
-        .map_err(|err| err.to_string())?;
-
-    Ok(run)
 }
 
 #[tauri::command]

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -65,9 +65,7 @@ pub async fn send_prompt_to_run(
     let sink = TauriRunEventSink::new(app);
     let registry = state.inner().clone();
     SendPromptUseCase::new(registry)
-        .execute(sink, run_id, prompt, |session, sink, text| async move {
-            session.send_prompt(&sink, text).await
-        })
+        .execute(sink, run_id, prompt)
         .await
 }
 

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
 use tauri::{AppHandle, State};
 
 use crate::{
     adapters::{
-        acp::runner::{AcpAgentRunner, launch_agent_run},
+        acp::runner::AcpAgentRunner,
         agent_catalog::ConfigurableAgentCatalog,
         fs::LocalGoalFileReader,
         session_registry::AppState,
@@ -42,16 +40,10 @@ pub async fn start_agent_run(
     let sink = TauriRunEventSink::new(app);
     let permissions = state.permissions();
     let registry = state.inner().clone();
-    let runner = Arc::new(AcpAgentRunner::new(
-        ConfigurableAgentCatalog::from_env(),
-        permissions,
-    ));
+    let runner = AcpAgentRunner::new(ConfigurableAgentCatalog::from_env(), permissions);
 
     StartAgentRunUseCase::new(registry)
-        .execute(sink, request, move |request, run_id, sink_for_launch| {
-            let runner = runner.clone();
-            async move { launch_agent_run(runner, request, run_id, sink_for_launch).await }
-        })
+        .execute(runner, sink, request)
         .await
 }
 

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -5,7 +5,8 @@ use crate::{
         acp::{client::lifecycle, runner::AcpAgentRunner},
         agent_catalog::ConfigurableAgentCatalog,
         fs::LocalGoalFileReader,
-        tauri::{event_sink::TauriRunEventSink, session_state::AppState},
+        session_registry::AppState,
+        tauri::event_sink::TauriRunEventSink,
     },
     application::{
         list_agents::ListAgentsUseCase, load_goal_file::LoadGoalFileUseCase,
@@ -16,7 +17,7 @@ use crate::{
         events::{LifecycleStatus, RunEvent},
         run::{AgentRun, AgentRunRequest},
     },
-    ports::event_sink::RunEventSink,
+    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
 };
 
 #[tauri::command]

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -11,15 +11,14 @@ use crate::{
         tauri::event_sink::TauriRunEventSink,
     },
     application::{
-        list_agents::ListAgentsUseCase, load_goal_file::LoadGoalFileUseCase,
-        respond_permission::RespondPermissionUseCase, start_agent_run::StartAgentRunUseCase,
+        cancel_agent_run::CancelAgentRunUseCase, list_agents::ListAgentsUseCase,
+        load_goal_file::LoadGoalFileUseCase, respond_permission::RespondPermissionUseCase,
+        send_prompt::SendPromptUseCase, start_agent_run::StartAgentRunUseCase,
     },
     domain::{
         agent::AgentDescriptor,
-        events::{LifecycleStatus, RunEvent},
         run::{AgentRun, AgentRunRequest},
     },
-    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
 };
 
 #[tauri::command]
@@ -63,27 +62,13 @@ pub async fn send_prompt_to_run(
     run_id: String,
     prompt: String,
 ) -> Result<(), String> {
-    let trimmed = prompt.trim();
-    if trimmed.is_empty() {
-        return Err("prompt is empty".into());
-    }
-    let session = state
-        .active_session(&run_id)
-        .await
-        .ok_or_else(|| "agent run is not active".to_string())?;
     let sink = TauriRunEventSink::new(app);
-    let prompt_text = trimmed.to_string();
-    tokio::spawn(async move {
-        if let Err(err) = session.send_prompt(&sink, prompt_text).await {
-            sink.emit(
-                &session.run_id,
-                RunEvent::Error {
-                    message: err.to_string(),
-                },
-            );
-        }
-    });
-    Ok(())
+    let registry = state.inner().clone();
+    SendPromptUseCase::new(registry)
+        .execute(sink, run_id, prompt, |session, sink, text| async move {
+            session.send_prompt(&sink, text).await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -92,18 +77,11 @@ pub async fn cancel_agent_run(
     state: State<'_, AppState>,
     run_id: String,
 ) -> Result<(), String> {
-    let cancelled = state.cancel_run(&run_id).await;
-    TauriRunEventSink::new(app).emit(
-        &run_id,
-        RunEvent::Lifecycle {
-            status: LifecycleStatus::Cancelled,
-            message: if cancelled {
-                "run cancelled".into()
-            } else {
-                "run was already terminated".into()
-            },
-        },
-    );
+    let sink = TauriRunEventSink::new(app);
+    let registry = state.inner().clone();
+    CancelAgentRunUseCase::new(registry)
+        .execute(sink, run_id)
+        .await;
     Ok(())
 }
 

--- a/src-tauri/src/adapters/tauri/mod.rs
+++ b/src-tauri/src/adapters/tauri/mod.rs
@@ -1,3 +1,2 @@
 pub mod commands;
 pub mod event_sink;
-pub mod session_state;

--- a/src-tauri/src/application/cancel_agent_run.rs
+++ b/src-tauri/src/application/cancel_agent_run.rs
@@ -1,0 +1,137 @@
+use crate::{
+    domain::events::{LifecycleStatus, RunEvent},
+    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
+};
+
+/// Cancel an active agent run and emit a Cancelled lifecycle event.
+///
+/// The lifecycle is emitted even when the run is unknown so the
+/// frontend can always clear a "closing" tab on an acknowledged event
+/// instead of waiting for a response it will never receive.
+pub struct CancelAgentRunUseCase<R>
+where
+    R: SessionRegistry,
+{
+    registry: R,
+}
+
+impl<R> CancelAgentRunUseCase<R>
+where
+    R: SessionRegistry,
+{
+    pub fn new(registry: R) -> Self {
+        Self { registry }
+    }
+
+    pub async fn execute<S>(self, sink: S, run_id: String)
+    where
+        S: RunEventSink,
+    {
+        let cancelled = self.registry.cancel_run(&run_id).await;
+        sink.emit(
+            &run_id,
+            RunEvent::Lifecycle {
+                status: LifecycleStatus::Cancelled,
+                message: if cancelled {
+                    "run cancelled".into()
+                } else {
+                    "run was already terminated".into()
+                },
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::session_registry::SessionRegistry;
+    use anyhow::Result;
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tokio::sync::Mutex;
+    use tokio::task::JoinHandle;
+
+    struct FakeSession;
+
+    #[derive(Clone, Default)]
+    struct FakeRegistry {
+        cancelled: Arc<Mutex<Vec<String>>>,
+        next_cancel_result: Arc<Mutex<bool>>,
+    }
+
+    impl SessionRegistry for FakeRegistry {
+        type Session = FakeSession;
+
+        async fn reserve_run(&self, _: String) -> Result<()> {
+            Ok(())
+        }
+        async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {
+            handle.abort();
+            Ok(())
+        }
+        async fn attach_session(&self, _: &str, _: Arc<FakeSession>) -> Result<()> {
+            Ok(())
+        }
+        async fn active_session(&self, _: &str) -> Option<Arc<FakeSession>> {
+            None
+        }
+        async fn finish_run(&self, _: &str) {}
+        async fn cancel_run(&self, run_id: &str) -> bool {
+            self.cancelled.lock().await.push(run_id.to_string());
+            *self.next_cancel_result.lock().await
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CollectingSink {
+        events: Arc<StdMutex<Vec<(String, RunEvent)>>>,
+    }
+
+    impl RunEventSink for CollectingSink {
+        fn emit(&self, run_id: &str, event: RunEvent) {
+            self.events
+                .lock()
+                .unwrap()
+                .push((run_id.to_string(), event));
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_cancelled_lifecycle_with_success_message_when_cancel_returns_true() {
+        let registry = FakeRegistry::default();
+        *registry.next_cancel_result.lock().await = true;
+        let sink = CollectingSink::default();
+
+        CancelAgentRunUseCase::new(registry)
+            .execute(sink.clone(), "run-a".into())
+            .await;
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0].1 {
+            RunEvent::Lifecycle { status, message } => {
+                assert!(matches!(status, LifecycleStatus::Cancelled));
+                assert_eq!(message, "run cancelled");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_cancelled_lifecycle_with_fallback_message_when_run_unknown() {
+        let registry = FakeRegistry::default();
+        let sink = CollectingSink::default();
+
+        CancelAgentRunUseCase::new(registry)
+            .execute(sink.clone(), "run-b".into())
+            .await;
+
+        let events = sink.events.lock().unwrap();
+        match &events[0].1 {
+            RunEvent::Lifecycle { message, .. } => {
+                assert_eq!(message, "run was already terminated");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,3 +1,4 @@
 pub mod list_agents;
 pub mod load_goal_file;
 pub mod respond_permission;
+pub mod start_agent_run;

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,4 +1,6 @@
+pub mod cancel_agent_run;
 pub mod list_agents;
 pub mod load_goal_file;
 pub mod respond_permission;
+pub mod send_prompt;
 pub mod start_agent_run;

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -1,24 +1,20 @@
-use std::{future::Future, sync::Arc};
-
-use anyhow::Result;
-
 use crate::{
     domain::events::RunEvent,
-    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
+    ports::{
+        event_sink::RunEventSink, session_handle::SessionHandle,
+        session_registry::SessionRegistry,
+    },
 };
 
 /// Dispatch a follow-up prompt to an active run.
 ///
-/// The actual prompt transport is provided by the caller as a closure so
-/// the use case stays independent of the concrete session adapter. Errors
-/// from the dispatch are surfaced to the run event stream instead of being
-/// returned to the command caller, which matches the behavior of the
-/// previous inline implementation (the command returns as soon as the
-/// prompt is accepted; failures arrive asynchronously on the event
-/// stream).
+/// The use case looks up the active session via the registry port and
+/// delegates prompt delivery to `SessionHandle::send_prompt`, so the
+/// command handler stays independent of the ACP adapter.
 pub struct SendPromptUseCase<R>
 where
     R: SessionRegistry,
+    R::Session: SessionHandle,
 {
     registry: R,
 }
@@ -26,22 +22,20 @@ where
 impl<R> SendPromptUseCase<R>
 where
     R: SessionRegistry,
+    R::Session: SessionHandle,
 {
     pub fn new(registry: R) -> Self {
         Self { registry }
     }
 
-    pub async fn execute<S, F, Fut>(
+    pub async fn execute<S>(
         self,
         sink: S,
         run_id: String,
         prompt: String,
-        dispatch: F,
     ) -> Result<(), String>
     where
         S: RunEventSink,
-        F: FnOnce(Arc<R::Session>, S, String) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<String>> + Send + 'static,
     {
         let trimmed = prompt.trim().to_string();
         if trimmed.is_empty() {
@@ -54,7 +48,7 @@ where
             .ok_or_else(|| "agent run is not active".to_string())?;
         let sink_for_task = sink.clone();
         tokio::spawn(async move {
-            if let Err(err) = dispatch(session, sink_for_task.clone(), trimmed).await {
+            if let Err(err) = session.send_prompt(sink_for_task.clone(), trimmed).await {
                 sink_for_task.emit(
                     &run_id,
                     RunEvent::Error {
@@ -74,15 +68,33 @@ mod tests {
     use anyhow::{Result, anyhow};
     use std::{
         collections::HashMap,
-        sync::{
-            Arc, Mutex as StdMutex,
-            atomic::{AtomicUsize, Ordering},
-        },
+        sync::{Arc, Mutex as StdMutex},
     };
     use tokio::sync::{Mutex, Notify};
     use tokio::task::JoinHandle;
 
-    struct FakeSession;
+    enum FakeBehavior {
+        Ok,
+        Err,
+    }
+
+    struct FakeSession {
+        behavior: FakeBehavior,
+        done: Arc<Notify>,
+    }
+
+    impl SessionHandle for FakeSession {
+        async fn send_prompt<S>(&self, _sink: S, _text: String) -> Result<String>
+        where
+            S: RunEventSink,
+        {
+            self.done.notify_one();
+            match self.behavior {
+                FakeBehavior::Ok => Ok("end_turn".into()),
+                FakeBehavior::Err => Err(anyhow!("dispatch exploded")),
+            }
+        }
+    }
 
     #[derive(Clone, Default)]
     struct FakeRegistry {
@@ -90,13 +102,17 @@ mod tests {
     }
 
     impl FakeRegistry {
-        async fn with_session(run_id: &str) -> Self {
+        async fn with_session(run_id: &str, behavior: FakeBehavior) -> (Self, Arc<Notify>) {
             let reg = Self::default();
-            reg.sessions
-                .lock()
-                .await
-                .insert(run_id.to_string(), Arc::new(FakeSession));
-            reg
+            let done = Arc::new(Notify::new());
+            reg.sessions.lock().await.insert(
+                run_id.to_string(),
+                Arc::new(FakeSession {
+                    behavior,
+                    done: done.clone(),
+                }),
+            );
+            (reg, done)
         }
     }
 
@@ -140,21 +156,13 @@ mod tests {
     async fn rejects_empty_prompt_without_touching_registry() {
         let registry = FakeRegistry::default();
         let sink = CollectingSink::default();
-        let invoked = Arc::new(AtomicUsize::new(0));
-        let invoked_clone = invoked.clone();
 
         let result = SendPromptUseCase::new(registry)
-            .execute(sink.clone(), "run-a".into(), "   ".into(), move |_, _, _| {
-                let invoked = invoked_clone.clone();
-                async move {
-                    invoked.fetch_add(1, Ordering::SeqCst);
-                    Ok::<_, anyhow::Error>(String::new())
-                }
-            })
+            .execute(sink.clone(), "run-a".into(), "   ".into())
             .await;
 
         assert_eq!(result, Err("prompt is empty".into()));
-        assert_eq!(invoked.load(Ordering::SeqCst), 0);
+        assert!(sink.events.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -163,9 +171,7 @@ mod tests {
         let sink = CollectingSink::default();
 
         let result = SendPromptUseCase::new(registry)
-            .execute(sink, "missing".into(), "hi".into(), move |_, _, _| async move {
-                Ok::<_, anyhow::Error>(String::new())
-            })
+            .execute(sink, "missing".into(), "hi".into())
             .await;
 
         assert_eq!(result, Err("agent run is not active".into()));
@@ -173,25 +179,15 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_error_surfaces_as_run_event_error() {
-        let registry = FakeRegistry::with_session("run-a").await;
+        let (registry, done) = FakeRegistry::with_session("run-a", FakeBehavior::Err).await;
         let sink = CollectingSink::default();
-        let done = Arc::new(Notify::new());
-        let done_clone = done.clone();
 
         SendPromptUseCase::new(registry)
-            .execute(sink.clone(), "run-a".into(), "hi".into(), move |_, _, _| {
-                let done = done_clone.clone();
-                async move {
-                    let err: Result<String> = Err(anyhow!("dispatch exploded"));
-                    done.notify_one();
-                    err
-                }
-            })
+            .execute(sink.clone(), "run-a".into(), "hi".into())
             .await
             .expect("use case should accept the request");
 
         done.notified().await;
-        // Allow the spawned task to finish emitting the error.
         tokio::task::yield_now().await;
         let events = sink.events.lock().unwrap();
         assert!(

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -73,6 +73,7 @@ mod tests {
     use tokio::sync::{Mutex, Notify};
     use tokio::task::JoinHandle;
 
+    #[allow(dead_code)]
     enum FakeBehavior {
         Ok,
         Err,

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -1,0 +1,203 @@
+use std::{future::Future, sync::Arc};
+
+use anyhow::Result;
+
+use crate::{
+    domain::events::RunEvent,
+    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
+};
+
+/// Dispatch a follow-up prompt to an active run.
+///
+/// The actual prompt transport is provided by the caller as a closure so
+/// the use case stays independent of the concrete session adapter. Errors
+/// from the dispatch are surfaced to the run event stream instead of being
+/// returned to the command caller, which matches the behavior of the
+/// previous inline implementation (the command returns as soon as the
+/// prompt is accepted; failures arrive asynchronously on the event
+/// stream).
+pub struct SendPromptUseCase<R>
+where
+    R: SessionRegistry,
+{
+    registry: R,
+}
+
+impl<R> SendPromptUseCase<R>
+where
+    R: SessionRegistry,
+{
+    pub fn new(registry: R) -> Self {
+        Self { registry }
+    }
+
+    pub async fn execute<S, F, Fut>(
+        self,
+        sink: S,
+        run_id: String,
+        prompt: String,
+        dispatch: F,
+    ) -> Result<(), String>
+    where
+        S: RunEventSink,
+        F: FnOnce(Arc<R::Session>, S, String) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<String>> + Send + 'static,
+    {
+        let trimmed = prompt.trim().to_string();
+        if trimmed.is_empty() {
+            return Err("prompt is empty".into());
+        }
+        let session = self
+            .registry
+            .active_session(&run_id)
+            .await
+            .ok_or_else(|| "agent run is not active".to_string())?;
+        let sink_for_task = sink.clone();
+        tokio::spawn(async move {
+            if let Err(err) = dispatch(session, sink_for_task.clone(), trimmed).await {
+                sink_for_task.emit(
+                    &run_id,
+                    RunEvent::Error {
+                        message: err.to_string(),
+                    },
+                );
+            }
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::session_registry::SessionRegistry;
+    use anyhow::{Result, anyhow};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc, Mutex as StdMutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+    use tokio::sync::{Mutex, Notify};
+    use tokio::task::JoinHandle;
+
+    struct FakeSession;
+
+    #[derive(Clone, Default)]
+    struct FakeRegistry {
+        sessions: Arc<Mutex<HashMap<String, Arc<FakeSession>>>>,
+    }
+
+    impl FakeRegistry {
+        async fn with_session(run_id: &str) -> Self {
+            let reg = Self::default();
+            reg.sessions
+                .lock()
+                .await
+                .insert(run_id.to_string(), Arc::new(FakeSession));
+            reg
+        }
+    }
+
+    impl SessionRegistry for FakeRegistry {
+        type Session = FakeSession;
+
+        async fn reserve_run(&self, _: String) -> Result<()> {
+            Ok(())
+        }
+        async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {
+            handle.abort();
+            Ok(())
+        }
+        async fn attach_session(&self, _: &str, _: Arc<FakeSession>) -> Result<()> {
+            Ok(())
+        }
+        async fn active_session(&self, run_id: &str) -> Option<Arc<FakeSession>> {
+            self.sessions.lock().await.get(run_id).cloned()
+        }
+        async fn finish_run(&self, _: &str) {}
+        async fn cancel_run(&self, _: &str) -> bool {
+            false
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CollectingSink {
+        events: Arc<StdMutex<Vec<(String, RunEvent)>>>,
+    }
+
+    impl RunEventSink for CollectingSink {
+        fn emit(&self, run_id: &str, event: RunEvent) {
+            self.events
+                .lock()
+                .unwrap()
+                .push((run_id.to_string(), event));
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_prompt_without_touching_registry() {
+        let registry = FakeRegistry::default();
+        let sink = CollectingSink::default();
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let invoked_clone = invoked.clone();
+
+        let result = SendPromptUseCase::new(registry)
+            .execute(sink.clone(), "run-a".into(), "   ".into(), move |_, _, _| {
+                let invoked = invoked_clone.clone();
+                async move {
+                    invoked.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, anyhow::Error>(String::new())
+                }
+            })
+            .await;
+
+        assert_eq!(result, Err("prompt is empty".into()));
+        assert_eq!(invoked.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn rejects_when_run_has_no_active_session() {
+        let registry = FakeRegistry::default();
+        let sink = CollectingSink::default();
+
+        let result = SendPromptUseCase::new(registry)
+            .execute(sink, "missing".into(), "hi".into(), move |_, _, _| async move {
+                Ok::<_, anyhow::Error>(String::new())
+            })
+            .await;
+
+        assert_eq!(result, Err("agent run is not active".into()));
+    }
+
+    #[tokio::test]
+    async fn dispatch_error_surfaces_as_run_event_error() {
+        let registry = FakeRegistry::with_session("run-a").await;
+        let sink = CollectingSink::default();
+        let done = Arc::new(Notify::new());
+        let done_clone = done.clone();
+
+        SendPromptUseCase::new(registry)
+            .execute(sink.clone(), "run-a".into(), "hi".into(), move |_, _, _| {
+                let done = done_clone.clone();
+                async move {
+                    let err: Result<String> = Err(anyhow!("dispatch exploded"));
+                    done.notify_one();
+                    err
+                }
+            })
+            .await
+            .expect("use case should accept the request");
+
+        done.notified().await;
+        // Allow the spawned task to finish emitting the error.
+        tokio::task::yield_now().await;
+        let events = sink.events.lock().unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|(_, event)| matches!(event, RunEvent::Error { .. }))
+        );
+    }
+}

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -1,50 +1,21 @@
-use std::{future::Future, pin::Pin, sync::Arc};
-
-use anyhow::Result;
-
 use crate::{
     domain::{
         events::RunEvent,
         run::{AgentRun, AgentRunRequest},
     },
-    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
+    ports::{
+        event_sink::RunEventSink,
+        session_launcher::{LaunchedSession, SessionLauncher},
+        session_registry::SessionRegistry,
+    },
 };
-
-/// Future that drives a launched session to its natural completion
-/// (initial prompt submission, process wait, stream cleanup, terminal
-/// lifecycle event).
-pub type DriverFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
-
-/// Future that tears a launched session down without running it to
-/// completion (used when the orchestrator decides to stop the run
-/// before the driver is awaited).
-pub type AbortFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
-
-/// Adapter-facing controller over a freshly launched agent session.
-///
-/// Exactly one of `run_to_completion` or `abort` is awaited per run,
-/// and both consume the commander by value.
-pub trait RunCommander: Send + 'static {
-    fn run_to_completion(self: Box<Self>) -> DriverFuture;
-    fn abort(self: Box<Self>) -> AbortFuture;
-}
-
-/// Outcome of a successful launcher call. The session handle is shared
-/// with the registry; the commander owns the process/tasks that back it.
-pub struct LaunchedSession<Session>
-where
-    Session: Send + Sync + 'static,
-{
-    pub session: Arc<Session>,
-    pub commander: Box<dyn RunCommander>,
-}
 
 /// Start a new agent run.
 ///
-/// The caller supplies a launcher closure that is responsible for all
-/// adapter-level setup (spawning the ACP subprocess, opening the session,
-/// etc.). This use case owns the registry bookkeeping and the error/
-/// cleanup flow around the launcher, so Tauri command handlers stay thin.
+/// The use case owns the registry bookkeeping and the error/cleanup
+/// flow around the launcher, so Tauri command handlers stay thin. All
+/// adapter-level setup (spawning the ACP subprocess, opening the
+/// session) is hidden behind the `SessionLauncher` port.
 pub struct StartAgentRunUseCase<R>
 where
     R: SessionRegistry,
@@ -60,16 +31,15 @@ where
         Self { registry }
     }
 
-    pub async fn execute<S, F, Fut>(
+    pub async fn execute<L, S>(
         self,
+        launcher: L,
         sink: S,
         request: AgentRunRequest,
-        launch: F,
     ) -> Result<AgentRun, String>
     where
+        L: SessionLauncher<Session = R::Session>,
         S: RunEventSink,
-        F: FnOnce(AgentRunRequest, String, S) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<LaunchedSession<R::Session>>> + Send + 'static,
     {
         let run = build_run(&request);
         self.registry
@@ -82,7 +52,10 @@ where
         let sink_for_task = sink.clone();
 
         let handle = tokio::spawn(async move {
-            let launched = match launch(request, run_id.clone(), sink_for_task.clone()).await {
+            let launched = match launcher
+                .launch(request, run_id.clone(), sink_for_task.clone())
+                .await
+            {
                 Ok(launched) => launched,
                 Err(err) => {
                     sink_for_task.emit(
@@ -135,8 +108,9 @@ fn build_run(request: &AgentRunRequest) -> AgentRun {
 mod tests {
     use super::*;
     use crate::domain::events::{LifecycleStatus, RunEvent};
+    use crate::ports::session_launcher::{AbortFuture, DriverFuture, RunCommander};
     use crate::ports::session_registry::SessionRegistry;
-    use anyhow::anyhow;
+    use anyhow::{Result, anyhow};
     use std::{
         collections::HashMap,
         sync::{
@@ -179,11 +153,7 @@ mod tests {
             Ok(())
         }
 
-        async fn attach_run_handle(
-            &self,
-            run_id: &str,
-            handle: JoinHandle<()>,
-        ) -> Result<()> {
+        async fn attach_run_handle(&self, run_id: &str, handle: JoinHandle<()>) -> Result<()> {
             self.inner
                 .lock()
                 .await
@@ -254,6 +224,67 @@ mod tests {
         }
     }
 
+    struct FakeLauncher {
+        aborted: Arc<AtomicUsize>,
+        completed: Arc<AtomicUsize>,
+        done: Arc<Notify>,
+        fail_launch: bool,
+    }
+
+    impl FakeLauncher {
+        fn success(counters: &(Arc<AtomicUsize>, Arc<AtomicUsize>, Arc<Notify>)) -> Self {
+            Self {
+                aborted: counters.0.clone(),
+                completed: counters.1.clone(),
+                done: counters.2.clone(),
+                fail_launch: false,
+            }
+        }
+        fn failing(done: Arc<Notify>) -> Self {
+            Self {
+                aborted: Arc::new(AtomicUsize::new(0)),
+                completed: Arc::new(AtomicUsize::new(0)),
+                done,
+                fail_launch: true,
+            }
+        }
+    }
+
+    impl SessionLauncher for FakeLauncher {
+        type Session = FakeSession;
+
+        async fn launch<S>(
+            self,
+            _request: AgentRunRequest,
+            _run_id: String,
+            _sink: S,
+        ) -> Result<LaunchedSession<FakeSession>>
+        where
+            S: RunEventSink,
+        {
+            if self.fail_launch {
+                self.done.notify_one();
+                return Err(anyhow!("launch failed"));
+            }
+            Ok(LaunchedSession {
+                session: Arc::new(FakeSession),
+                commander: Box::new(FakeCommander {
+                    aborted: self.aborted,
+                    completed: self.completed,
+                    done: self.done,
+                }),
+            })
+        }
+    }
+
+    fn counters() -> (Arc<AtomicUsize>, Arc<AtomicUsize>, Arc<Notify>) {
+        (
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(Notify::new()),
+        )
+    }
+
     fn make_request() -> AgentRunRequest {
         AgentRunRequest {
             goal: "hello".into(),
@@ -270,28 +301,15 @@ mod tests {
     async fn driver_runs_when_launch_and_attach_succeed() {
         let registry = FakeRegistry::default();
         let sink = CollectingSink::default();
-        let aborted = Arc::new(AtomicUsize::new(0));
-        let completed = Arc::new(AtomicUsize::new(0));
-        let done = Arc::new(Notify::new());
-        let aborted_clone = aborted.clone();
-        let completed_clone = completed.clone();
-        let done_clone = done.clone();
+        let c = counters();
+        let launcher = FakeLauncher::success(&c);
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(sink.clone(), make_request(), move |_, _, _| async move {
-                Ok(LaunchedSession {
-                    session: Arc::new(FakeSession),
-                    commander: Box::new(FakeCommander {
-                        aborted: aborted_clone,
-                        completed: completed_clone,
-                        done: done_clone,
-                    }),
-                })
-            })
+            .execute(launcher, sink.clone(), make_request())
             .await
             .expect("start should succeed");
 
-        done.notified().await;
+        c.2.notified().await;
         let handle = registry
             .inner
             .lock()
@@ -301,8 +319,8 @@ mod tests {
             .expect("handle stored");
         handle.await.expect("task should finish");
 
-        assert_eq!(completed.load(Ordering::SeqCst), 1);
-        assert_eq!(aborted.load(Ordering::SeqCst), 0);
+        assert_eq!(c.1.load(Ordering::SeqCst), 1);
+        assert_eq!(c.0.load(Ordering::SeqCst), 0);
         let state = registry.inner.lock().await;
         assert_eq!(state.reserved, vec!["run-1".to_string()]);
         assert_eq!(state.finished, vec!["run-1".to_string()]);
@@ -312,28 +330,15 @@ mod tests {
     async fn aborter_runs_when_attach_session_fails() {
         let registry = FakeRegistry::with_failing_attach().await;
         let sink = CollectingSink::default();
-        let aborted = Arc::new(AtomicUsize::new(0));
-        let completed = Arc::new(AtomicUsize::new(0));
-        let done = Arc::new(Notify::new());
-        let aborted_clone = aborted.clone();
-        let completed_clone = completed.clone();
-        let done_clone = done.clone();
+        let c = counters();
+        let launcher = FakeLauncher::success(&c);
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(sink.clone(), make_request(), move |_, _, _| async move {
-                Ok(LaunchedSession {
-                    session: Arc::new(FakeSession),
-                    commander: Box::new(FakeCommander {
-                        aborted: aborted_clone,
-                        completed: completed_clone,
-                        done: done_clone,
-                    }),
-                })
-            })
+            .execute(launcher, sink.clone(), make_request())
             .await
             .expect("start call itself should succeed");
 
-        done.notified().await;
+        c.2.notified().await;
         let handle = registry
             .inner
             .lock()
@@ -343,10 +348,14 @@ mod tests {
             .expect("handle stored");
         handle.await.expect("task should finish");
 
-        assert_eq!(aborted.load(Ordering::SeqCst), 1);
-        assert_eq!(completed.load(Ordering::SeqCst), 0);
+        assert_eq!(c.0.load(Ordering::SeqCst), 1);
+        assert_eq!(c.1.load(Ordering::SeqCst), 0);
         let events = sink.events.lock().unwrap();
-        assert!(events.iter().any(|(_, event)| matches!(event, RunEvent::Diagnostic { .. })));
+        assert!(
+            events
+                .iter()
+                .any(|(_, event)| matches!(event, RunEvent::Diagnostic { .. }))
+        );
     }
 
     #[tokio::test]
@@ -354,20 +363,10 @@ mod tests {
         let registry = FakeRegistry::default();
         let sink = CollectingSink::default();
         let done = Arc::new(Notify::new());
-        let done_clone = done.clone();
-        let sink_clone = sink.clone();
+        let launcher = FakeLauncher::failing(done.clone());
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(
-                sink.clone(),
-                make_request(),
-                move |_, run_id, _sink_for_launch| async move {
-                    // emit is handled by the use case on our behalf; just fail.
-                    let _ = (run_id, sink_clone);
-                    done_clone.notify_one();
-                    Err::<LaunchedSession<FakeSession>, _>(anyhow!("launch failed"))
-                },
-            )
+            .execute(launcher, sink.clone(), make_request())
             .await
             .expect("start call itself should succeed");
 
@@ -382,7 +381,11 @@ mod tests {
         handle.await.expect("task should finish");
 
         let events = sink.events.lock().unwrap();
-        assert!(events.iter().any(|(_, event)| matches!(event, RunEvent::Error { .. })));
+        assert!(
+            events
+                .iter()
+                .any(|(_, event)| matches!(event, RunEvent::Error { .. }))
+        );
         assert!(!events.iter().any(|(_, event)| matches!(
             event,
             RunEvent::Lifecycle {

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -1,0 +1,396 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use anyhow::Result;
+
+use crate::{
+    domain::{
+        events::RunEvent,
+        run::{AgentRun, AgentRunRequest},
+    },
+    ports::{event_sink::RunEventSink, session_registry::SessionRegistry},
+};
+
+/// Future that drives a launched session to its natural completion
+/// (initial prompt submission, process wait, stream cleanup, terminal
+/// lifecycle event).
+pub type DriverFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Future that tears a launched session down without running it to
+/// completion (used when the orchestrator decides to stop the run
+/// before the driver is awaited).
+pub type AbortFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Adapter-facing controller over a freshly launched agent session.
+///
+/// Exactly one of `run_to_completion` or `abort` is awaited per run,
+/// and both consume the commander by value.
+pub trait RunCommander: Send + 'static {
+    fn run_to_completion(self: Box<Self>) -> DriverFuture;
+    fn abort(self: Box<Self>) -> AbortFuture;
+}
+
+/// Outcome of a successful launcher call. The session handle is shared
+/// with the registry; the commander owns the process/tasks that back it.
+pub struct LaunchedSession<Session>
+where
+    Session: Send + Sync + 'static,
+{
+    pub session: Arc<Session>,
+    pub commander: Box<dyn RunCommander>,
+}
+
+/// Start a new agent run.
+///
+/// The caller supplies a launcher closure that is responsible for all
+/// adapter-level setup (spawning the ACP subprocess, opening the session,
+/// etc.). This use case owns the registry bookkeeping and the error/
+/// cleanup flow around the launcher, so Tauri command handlers stay thin.
+pub struct StartAgentRunUseCase<R>
+where
+    R: SessionRegistry,
+{
+    registry: R,
+}
+
+impl<R> StartAgentRunUseCase<R>
+where
+    R: SessionRegistry,
+{
+    pub fn new(registry: R) -> Self {
+        Self { registry }
+    }
+
+    pub async fn execute<S, F, Fut>(
+        self,
+        sink: S,
+        request: AgentRunRequest,
+        launch: F,
+    ) -> Result<AgentRun, String>
+    where
+        S: RunEventSink,
+        F: FnOnce(AgentRunRequest, String, S) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<LaunchedSession<R::Session>>> + Send + 'static,
+    {
+        let run = build_run(&request);
+        self.registry
+            .reserve_run(run.id.clone())
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let registry = self.registry.clone();
+        let run_id = run.id.clone();
+        let sink_for_task = sink.clone();
+
+        let handle = tokio::spawn(async move {
+            let launched = match launch(request, run_id.clone(), sink_for_task.clone()).await {
+                Ok(launched) => launched,
+                Err(err) => {
+                    sink_for_task.emit(
+                        &run_id,
+                        RunEvent::Error {
+                            message: err.to_string(),
+                        },
+                    );
+                    registry.finish_run(&run_id).await;
+                    return;
+                }
+            };
+            let LaunchedSession { session, commander } = launched;
+
+            if let Err(err) = registry.attach_session(&run_id, session).await {
+                sink_for_task.emit(
+                    &run_id,
+                    RunEvent::Diagnostic {
+                        message: err.to_string(),
+                    },
+                );
+                commander.abort().await;
+                registry.finish_run(&run_id).await;
+                return;
+            }
+
+            commander.run_to_completion().await;
+            registry.finish_run(&run_id).await;
+        });
+
+        self.registry
+            .attach_run_handle(&run.id, handle)
+            .await
+            .map_err(|err| err.to_string())?;
+
+        Ok(run)
+    }
+}
+
+fn build_run(request: &AgentRunRequest) -> AgentRun {
+    match request.run_id.clone() {
+        Some(id) if !id.trim().is_empty() => {
+            AgentRun::with_id(id, request.goal.clone(), request.agent_id.clone())
+        }
+        _ => AgentRun::new(request.goal.clone(), request.agent_id.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::events::{LifecycleStatus, RunEvent};
+    use crate::ports::session_registry::SessionRegistry;
+    use anyhow::anyhow;
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc, Mutex as StdMutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+    use tokio::sync::{Mutex, Notify};
+    use tokio::task::JoinHandle;
+
+    struct FakeSession;
+
+    #[derive(Clone, Default)]
+    struct FakeRegistry {
+        inner: Arc<Mutex<FakeRegistryState>>,
+    }
+
+    #[derive(Default)]
+    struct FakeRegistryState {
+        reserved: Vec<String>,
+        finished: Vec<String>,
+        sessions: HashMap<String, Arc<FakeSession>>,
+        handles: HashMap<String, JoinHandle<()>>,
+        fail_attach_session: bool,
+    }
+
+    impl FakeRegistry {
+        async fn with_failing_attach() -> Self {
+            let reg = Self::default();
+            reg.inner.lock().await.fail_attach_session = true;
+            reg
+        }
+    }
+
+    impl SessionRegistry for FakeRegistry {
+        type Session = FakeSession;
+
+        async fn reserve_run(&self, run_id: String) -> Result<()> {
+            self.inner.lock().await.reserved.push(run_id);
+            Ok(())
+        }
+
+        async fn attach_run_handle(
+            &self,
+            run_id: &str,
+            handle: JoinHandle<()>,
+        ) -> Result<()> {
+            self.inner
+                .lock()
+                .await
+                .handles
+                .insert(run_id.to_string(), handle);
+            Ok(())
+        }
+
+        async fn attach_session(
+            &self,
+            run_id: &str,
+            session: Arc<FakeSession>,
+        ) -> Result<()> {
+            let mut state = self.inner.lock().await;
+            if state.fail_attach_session {
+                return Err(anyhow!("simulated attach_session failure"));
+            }
+            state.sessions.insert(run_id.to_string(), session);
+            Ok(())
+        }
+
+        async fn active_session(&self, run_id: &str) -> Option<Arc<FakeSession>> {
+            self.inner.lock().await.sessions.get(run_id).cloned()
+        }
+
+        async fn finish_run(&self, run_id: &str) {
+            self.inner.lock().await.finished.push(run_id.to_string());
+        }
+
+        async fn cancel_run(&self, _run_id: &str) -> bool {
+            false
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CollectingSink {
+        events: Arc<StdMutex<Vec<(String, RunEvent)>>>,
+    }
+
+    impl RunEventSink for CollectingSink {
+        fn emit(&self, run_id: &str, event: RunEvent) {
+            self.events
+                .lock()
+                .unwrap()
+                .push((run_id.to_string(), event));
+        }
+    }
+
+    struct FakeCommander {
+        aborted: Arc<AtomicUsize>,
+        completed: Arc<AtomicUsize>,
+        done: Arc<Notify>,
+    }
+
+    impl RunCommander for FakeCommander {
+        fn run_to_completion(self: Box<Self>) -> DriverFuture {
+            Box::pin(async move {
+                self.completed.fetch_add(1, Ordering::SeqCst);
+                self.done.notify_one();
+            })
+        }
+
+        fn abort(self: Box<Self>) -> AbortFuture {
+            Box::pin(async move {
+                self.aborted.fetch_add(1, Ordering::SeqCst);
+                self.done.notify_one();
+            })
+        }
+    }
+
+    fn make_request() -> AgentRunRequest {
+        AgentRunRequest {
+            goal: "hello".into(),
+            agent_id: "agent".into(),
+            cwd: None,
+            agent_command: None,
+            stdio_buffer_limit_mb: None,
+            auto_allow: None,
+            run_id: Some("run-1".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_runs_when_launch_and_attach_succeed() {
+        let registry = FakeRegistry::default();
+        let sink = CollectingSink::default();
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let done = Arc::new(Notify::new());
+        let aborted_clone = aborted.clone();
+        let completed_clone = completed.clone();
+        let done_clone = done.clone();
+
+        let run = StartAgentRunUseCase::new(registry.clone())
+            .execute(sink.clone(), make_request(), move |_, _, _| async move {
+                Ok(LaunchedSession {
+                    session: Arc::new(FakeSession),
+                    commander: Box::new(FakeCommander {
+                        aborted: aborted_clone,
+                        completed: completed_clone,
+                        done: done_clone,
+                    }),
+                })
+            })
+            .await
+            .expect("start should succeed");
+
+        done.notified().await;
+        let handle = registry
+            .inner
+            .lock()
+            .await
+            .handles
+            .remove(&run.id)
+            .expect("handle stored");
+        handle.await.expect("task should finish");
+
+        assert_eq!(completed.load(Ordering::SeqCst), 1);
+        assert_eq!(aborted.load(Ordering::SeqCst), 0);
+        let state = registry.inner.lock().await;
+        assert_eq!(state.reserved, vec!["run-1".to_string()]);
+        assert_eq!(state.finished, vec!["run-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn aborter_runs_when_attach_session_fails() {
+        let registry = FakeRegistry::with_failing_attach().await;
+        let sink = CollectingSink::default();
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let done = Arc::new(Notify::new());
+        let aborted_clone = aborted.clone();
+        let completed_clone = completed.clone();
+        let done_clone = done.clone();
+
+        let run = StartAgentRunUseCase::new(registry.clone())
+            .execute(sink.clone(), make_request(), move |_, _, _| async move {
+                Ok(LaunchedSession {
+                    session: Arc::new(FakeSession),
+                    commander: Box::new(FakeCommander {
+                        aborted: aborted_clone,
+                        completed: completed_clone,
+                        done: done_clone,
+                    }),
+                })
+            })
+            .await
+            .expect("start call itself should succeed");
+
+        done.notified().await;
+        let handle = registry
+            .inner
+            .lock()
+            .await
+            .handles
+            .remove(&run.id)
+            .expect("handle stored");
+        handle.await.expect("task should finish");
+
+        assert_eq!(aborted.load(Ordering::SeqCst), 1);
+        assert_eq!(completed.load(Ordering::SeqCst), 0);
+        let events = sink.events.lock().unwrap();
+        assert!(events.iter().any(|(_, event)| matches!(event, RunEvent::Diagnostic { .. })));
+    }
+
+    #[tokio::test]
+    async fn error_during_launch_emits_run_error_and_finishes_run() {
+        let registry = FakeRegistry::default();
+        let sink = CollectingSink::default();
+        let done = Arc::new(Notify::new());
+        let done_clone = done.clone();
+        let sink_clone = sink.clone();
+
+        let run = StartAgentRunUseCase::new(registry.clone())
+            .execute(
+                sink.clone(),
+                make_request(),
+                move |_, run_id, _sink_for_launch| async move {
+                    // emit is handled by the use case on our behalf; just fail.
+                    let _ = (run_id, sink_clone);
+                    done_clone.notify_one();
+                    Err::<LaunchedSession<FakeSession>, _>(anyhow!("launch failed"))
+                },
+            )
+            .await
+            .expect("start call itself should succeed");
+
+        done.notified().await;
+        let handle = registry
+            .inner
+            .lock()
+            .await
+            .handles
+            .remove(&run.id)
+            .expect("handle stored");
+        handle.await.expect("task should finish");
+
+        let events = sink.events.lock().unwrap();
+        assert!(events.iter().any(|(_, event)| matches!(event, RunEvent::Error { .. })));
+        assert!(!events.iter().any(|(_, event)| matches!(
+            event,
+            RunEvent::Lifecycle {
+                status: LifecycleStatus::Completed,
+                ..
+            }
+        )));
+        let state = registry.inner.lock().await;
+        assert_eq!(state.finished, vec!["run-1".to_string()]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,12 +3,12 @@ mod application;
 mod domain;
 mod ports;
 
-use adapters::tauri::{
-    commands::{
+use adapters::{
+    session_registry::AppState,
+    tauri::commands::{
         cancel_agent_run, list_agents, load_goal_file, respond_agent_permission, send_prompt_to_run,
         start_agent_run,
     },
-    session_state::AppState,
 };
 
 pub fn run() {

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -2,4 +2,5 @@ pub mod agent_catalog;
 pub mod event_sink;
 pub mod goal_file;
 pub mod permission;
+pub mod session_handle;
 pub mod session_registry;

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -2,3 +2,4 @@ pub mod agent_catalog;
 pub mod event_sink;
 pub mod goal_file;
 pub mod permission;
+pub mod session_registry;

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -3,4 +3,5 @@ pub mod event_sink;
 pub mod goal_file;
 pub mod permission;
 pub mod session_handle;
+pub mod session_launcher;
 pub mod session_registry;

--- a/src-tauri/src/ports/session_handle.rs
+++ b/src-tauri/src/ports/session_handle.rs
@@ -1,0 +1,23 @@
+use std::future::Future;
+
+use anyhow::Result;
+
+use crate::ports::event_sink::RunEventSink;
+
+/// Behavior the application layer needs from a launched agent session.
+///
+/// The session registry stores opaque `Arc<Session>` handles; this port
+/// is what turns that handle into a prompt-capable entity so use cases
+/// like `SendPromptUseCase` do not have to know about the ACP adapter.
+pub trait SessionHandle: Send + Sync + 'static {
+    /// Send a prompt to the session and return the stop reason reported
+    /// by the agent. Streaming events are emitted through `sink` as
+    /// they arrive.
+    fn send_prompt<S>(
+        &self,
+        sink: S,
+        text: String,
+    ) -> impl Future<Output = Result<String>> + Send
+    where
+        S: RunEventSink;
+}

--- a/src-tauri/src/ports/session_launcher.rs
+++ b/src-tauri/src/ports/session_launcher.rs
@@ -1,0 +1,54 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use anyhow::Result;
+
+use crate::{domain::run::AgentRunRequest, ports::event_sink::RunEventSink};
+
+/// Future that drives a launched session to its natural completion
+/// (initial prompt submission, process wait, stream cleanup, terminal
+/// lifecycle event).
+pub type DriverFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Future that tears a launched session down without running it to
+/// completion (used when the orchestrator decides to stop the run
+/// before the driver is awaited).
+pub type AbortFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Adapter-facing controller over a freshly launched agent session.
+///
+/// Exactly one of `run_to_completion` or `abort` is awaited per run
+/// and both consume the commander by value.
+pub trait RunCommander: Send + 'static {
+    fn run_to_completion(self: Box<Self>) -> DriverFuture;
+    fn abort(self: Box<Self>) -> AbortFuture;
+}
+
+/// Outcome of a successful launcher call. The session handle is shared
+/// with the registry; the commander owns the process/tasks that back it.
+pub struct LaunchedSession<Session>
+where
+    Session: Send + Sync + 'static,
+{
+    pub session: Arc<Session>,
+    pub commander: Box<dyn RunCommander>,
+}
+
+/// Bring a session online so the application layer can attach it to
+/// a `SessionRegistry` and drive it to completion.
+///
+/// Adapter implementors (currently only `AcpAgentRunner`) are
+/// responsible for all external setup — spawning the agent subprocess,
+/// initializing the ACP session, and producing a `RunCommander` that
+/// can either drive the session or tear it down.
+pub trait SessionLauncher: Send + Sync + 'static {
+    type Session: Send + Sync + 'static;
+
+    fn launch<S>(
+        self,
+        request: AgentRunRequest,
+        run_id: String,
+        sink: S,
+    ) -> impl Future<Output = Result<LaunchedSession<Self::Session>>> + Send
+    where
+        S: RunEventSink;
+}

--- a/src-tauri/src/ports/session_registry.rs
+++ b/src-tauri/src/ports/session_registry.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use std::{future::Future, sync::Arc};
+use tokio::task::JoinHandle;
+
+/// Storage for in-flight agent runs and their sessions.
+///
+/// The registry enforces identity/lifecycle invariants (unique run ids,
+/// optional concurrency limit, cancellation) and owns the handles that allow
+/// aborting a run. It is intentionally generic over the concrete session
+/// type so the application layer can depend on this port without pulling in
+/// adapter details.
+pub trait SessionRegistry: Clone + Send + Sync + 'static {
+    type Session: Send + Sync + 'static;
+
+    fn reserve_run(&self, run_id: String) -> impl Future<Output = Result<()>> + Send;
+
+    fn attach_run_handle(
+        &self,
+        run_id: &str,
+        handle: JoinHandle<()>,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    fn attach_session(
+        &self,
+        run_id: &str,
+        session: Arc<Self::Session>,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    fn active_session(
+        &self,
+        run_id: &str,
+    ) -> impl Future<Output = Option<Arc<Self::Session>>> + Send;
+
+    fn finish_run(&self, run_id: &str) -> impl Future<Output = ()> + Send;
+
+    fn cancel_run(&self, run_id: &str) -> impl Future<Output = bool> + Send;
+
+    fn active_run_count(&self) -> impl Future<Output = usize> + Send;
+}

--- a/src-tauri/src/ports/session_registry.rs
+++ b/src-tauri/src/ports/session_registry.rs
@@ -34,6 +34,4 @@ pub trait SessionRegistry: Clone + Send + Sync + 'static {
     fn finish_run(&self, run_id: &str) -> impl Future<Output = ()> + Send;
 
     fn cancel_run(&self, run_id: &str) -> impl Future<Output = bool> + Send;
-
-    fn active_run_count(&self) -> impl Future<Output = usize> + Send;
 }


### PR DESCRIPTION
## Summary
8 behavior-preserving steps that complete the hexagonal direction called for in #11.

- **S1** Introduce `SessionRegistry` port, relocate the registry adapter out of `adapters/tauri/`, split `PermissionBroker` into its own module.
- **S2** Extract `StartAgentRunUseCase` with a launcher closure and `RunCommander` trait so the run-lifecycle orchestration leaves `commands.rs`.
- **S3** Extract `SendPromptUseCase` and `CancelAgentRunUseCase`; commands become thin wire-and-map.
- **S4** Add `SessionHandle` port so `SendPromptUseCase` no longer depends on ACP session types.
- **S5** Split `adapters/acp/client.rs` into `transport.rs`, `session_update_mapper.rs`, and `client.rs` (stateful handlers only).
- **S6** Cover `session_update_mapper` with 11 stateless unit tests.
- **S7** Add `docs/backend-architecture.md` with dependency-direction diagram and layer responsibilities.
- **S8** Promote the launcher closure to a `SessionLauncher` port (Strategy). `AcpAgentRunner` implements it directly; `launch_agent_run` helper and `FnOnce` boilerplate are gone.

Closes #11.

## Test plan
- [x] `cargo test --lib` — 32 tests pass (including 11 new mapper tests and 3 launcher use-case tests)
- [x] `tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Manual smoke: start `claude-code` run, send follow-up, cancel, respond to a permission

## Follow-ups (to be filed as separate issues)
- Typed UseCase error enum (replace `Result<_, String>` with domain-oriented errors, map to string at the Tauri boundary).
- Terminal-handler extraction (split `client.rs` terminal methods into a focused module once further scenarios drive the need).
- Permission-handler extraction (same rationale for the manual-approval flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)