### PR TITLE
Narrow frontend agent-run public store API

### DIFF
--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -1,8 +1,11 @@
-export { closeWorkbenchTab } from "./tabActions";
 export { installAgentRuntime } from "./runtime";
-export { useAgentRun } from "./useAgentRun";
 export {
-  useWorkbenchStore,
-  type FollowUpQueueItem,
-  type TabState,
-} from "./model";
+  activateWorkbenchTab,
+  closeWorkbenchTab,
+  createWorkbenchTab,
+  useActiveTabId,
+  useTabList,
+  type WorkbenchTabListItem,
+} from "./tabApi";
+export { useAgentRun } from "./useAgentRun";
+export { type FollowUpQueueItem } from "./model";

--- a/src/features/agent-run/tabApi.ts
+++ b/src/features/agent-run/tabApi.ts
@@ -1,0 +1,36 @@
+import { useWorkbenchStore, type TabState } from "./model";
+import { closeWorkbenchTab } from "./tabActions";
+
+export type WorkbenchTabListItem = Readonly<
+  Pick<
+    TabState,
+    | "id"
+    | "title"
+    | "goal"
+    | "sessionActive"
+    | "awaitingResponse"
+    | "idleRemainingSec"
+    | "error"
+    | "unreadCount"
+    | "permissionPending"
+    | "closing"
+  >
+>;
+
+export function useActiveTabId() {
+  return useWorkbenchStore((state) => state.activeTabId);
+}
+
+export function useTabList(): WorkbenchTabListItem[] {
+  return useWorkbenchStore((state) => state.tabs);
+}
+
+export function createWorkbenchTab() {
+  return useWorkbenchStore.getState().addTab();
+}
+
+export function activateWorkbenchTab(tabId: string) {
+  useWorkbenchStore.getState().activateTab(tabId);
+}
+
+export { closeWorkbenchTab };

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -1,4 +1,4 @@
-import { useAgentRun, useWorkbenchStore } from "../../features/agent-run";
+import { useActiveTabId, useAgentRun } from "../../features/agent-run";
 import { GoalEditor } from "../../features/goal-input";
 import { EventStream } from "../../widgets/event-stream";
 import { FollowUpComposer } from "../../widgets/follow-up-composer";
@@ -7,7 +7,7 @@ import { RunPanel } from "../../widgets/run-panel";
 import { TabBar } from "../../widgets/workbench-tabs";
 
 export function AgentWorkbenchPage() {
-  const activeTabId = useWorkbenchStore((s) => s.activeTabId);
+  const activeTabId = useActiveTabId();
   const state = useAgentRun(activeTabId);
 
   return (

--- a/src/widgets/workbench-tabs/TabBar.tsx
+++ b/src/widgets/workbench-tabs/TabBar.tsx
@@ -1,5 +1,12 @@
 import { useCallback } from "react";
-import { closeWorkbenchTab, useWorkbenchStore, type TabState } from "../../features/agent-run";
+import {
+  activateWorkbenchTab,
+  closeWorkbenchTab,
+  createWorkbenchTab,
+  useActiveTabId,
+  useTabList,
+  type WorkbenchTabListItem,
+} from "../../features/agent-run";
 import { cn } from "../../shared/lib";
 import { Badge, Button } from "../../shared/ui";
 
@@ -11,7 +18,7 @@ type TabStatus =
   | "idle-countdown"
   | "closing";
 
-function resolveStatus(tab: TabState): TabStatus {
+function resolveStatus(tab: WorkbenchTabListItem): TabStatus {
   if (tab.closing) return "closing";
   if (tab.error) return "error";
   if (!tab.sessionActive) return "idle";
@@ -37,7 +44,7 @@ function statusLabel(status: TabStatus) {
   }
 }
 
-function tabDisplayTitle(tab: TabState) {
+function tabDisplayTitle(tab: WorkbenchTabListItem) {
   if (tab.title && tab.title.trim().length > 0) return tab.title;
   const goalPreview = tab.goal.trim().split(/\s+/).slice(0, 5).join(" ");
   return goalPreview || "빈 탭";
@@ -61,15 +68,15 @@ function statusClassName(status: TabStatus) {
 }
 
 export function TabBar() {
-  const tabs = useWorkbenchStore((state) => state.tabs);
-  const activeTabId = useWorkbenchStore((state) => state.activeTabId);
+  const tabs = useTabList();
+  const activeTabId = useActiveTabId();
 
   const handleActivate = useCallback((tabId: string) => {
-    useWorkbenchStore.getState().activateTab(tabId);
+    activateWorkbenchTab(tabId);
   }, []);
 
   const handleAdd = useCallback(() => {
-    useWorkbenchStore.getState().addTab();
+    createWorkbenchTab();
   }, []);
 
   const handleClose = useCallback((tabId: string) => {


### PR DESCRIPTION
## Summary
- Add public agent-run tab selector/action APIs for active tab, tab list, create, activate, and close
- Update the workbench page and tab bar to stop importing the raw Zustand store
- Keep the raw store available only to the feature internals while preserving current tab behavior

## Verification
- Confirmed external app/page/widget/entity/shared layers no longer import `useWorkbenchStore` or `TabState`
- `npm run build`
- `cargo test`

Closes #17
