### PR TITLE
Add frontend FSD import-boundary check

### DIFF
--- a/docs/frontend-fsd.md
+++ b/docs/frontend-fsd.md
@@ -29,6 +29,18 @@ app -> pages -> widgets -> features -> entities -> shared
 
 Same-slice imports can use relative paths for internal implementation files. For example, `features/agent-run/runtime.ts` can import `./model` directly.
 
+Run the automated boundary check before opening frontend architecture PRs:
+
+```bash
+npm run check:fsd
+```
+
+The check validates local static imports under `src/` and fails when:
+
+- a lower layer imports upward, such as `features` importing `widgets`;
+- `shared` imports an app-specific layer;
+- a cross-slice import into `entities`, `features`, or `widgets` bypasses that slice's public `index.ts` API.
+
 ## Public APIs
 
 Each externally consumed slice should expose a small public API through `index.ts`.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "check:fsd": "node scripts/check-fsd-boundaries.mjs",
+    "check:fsd:self-test": "node scripts/check-fsd-boundaries.mjs --self-test",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs"

--- a/scripts/check-fsd-boundaries.mjs
+++ b/scripts/check-fsd-boundaries.mjs
@@ -55,6 +55,8 @@ if (violations.length > 0) {
 console.log("FSD boundary check passed.");
 
 function runBoundarySelfTest() {
+  runSpecifierParserSelfTest();
+
   const cases = [
     {
       name: "shared cannot import entities",
@@ -106,6 +108,36 @@ function runBoundarySelfTest() {
   console.log("FSD boundary self-test passed.");
 }
 
+function runSpecifierParserSelfTest() {
+  const source = `
+    import React from "react";
+    import { eventGroups } from "../../entities/message";
+    import type { TimelineItem } from "../../entities/message";
+    import "../../app/styles.css";
+    const lazy = import("../../widgets/event-stream");
+    export { useAgentRun } from "../../features/agent-run";
+    export type { AgentDescriptor } from "../../entities/agent";
+    export * from "../../shared/ui";
+  `;
+  const actual = collectImportSpecifiers(source);
+  const expected = [
+    "react",
+    "../../entities/message",
+    "../../entities/message",
+    "../../app/styles.css",
+    "../../widgets/event-stream",
+    "../../features/agent-run",
+    "../../entities/agent",
+    "../../shared/ui",
+  ];
+
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Self-test failed for import specifier parsing: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}.`,
+    );
+  }
+}
+
 function validateImport(relativeFile, specifier, fromFile, imported) {
   const fromModule = getModuleInfo(fromFile);
   const toModule = getModuleInfo(imported);
@@ -127,9 +159,10 @@ function* walk(directory) {
 
 function collectImportSpecifiers(source) {
   const specifiers = [];
-  const importFrom = /import\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/g;
-  const sideEffectImport = /import\s+["']([^"']+)["']/g;
+  const importFrom = /^\s*import\s+(?!["'(])(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/gm;
+  const sideEffectImport = /^\s*import\s+["']([^"']+)["']/gm;
   const dynamicImport = /import\s*\(\s*["']([^"']+)["']\s*\)/g;
+  const reExportFrom = /^\s*export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s+from\s+["']([^"']+)["']/gm;
 
   for (const match of source.matchAll(importFrom)) {
     specifiers.push(match[1]);
@@ -138,6 +171,9 @@ function collectImportSpecifiers(source) {
     specifiers.push(match[1]);
   }
   for (const match of source.matchAll(dynamicImport)) {
+    specifiers.push(match[1]);
+  }
+  for (const match of source.matchAll(reExportFrom)) {
     specifiers.push(match[1]);
   }
 

--- a/scripts/check-fsd-boundaries.mjs
+++ b/scripts/check-fsd-boundaries.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const srcRoot = path.join(root, "src");
+const runSelfTest = process.argv.includes("--self-test");
+const sourceExtensions = new Set([".ts", ".tsx"]);
+const layerOrder = new Map([
+  ["shared", 0],
+  ["entities", 1],
+  ["features", 2],
+  ["widgets", 3],
+  ["pages", 4],
+  ["app", 5],
+]);
+
+const publicApiOnlyLayers = new Set(["entities", "features", "widgets"]);
+
+const violations = [];
+
+if (runSelfTest) {
+  runBoundarySelfTest();
+} else {
+  for (const file of walk(srcRoot)) {
+    const relativeFile = toPosix(path.relative(root, file));
+    const source = fs.readFileSync(file, "utf8");
+    const froms = collectImportSpecifiers(source);
+    for (const specifier of froms) {
+      if (!isLocalImport(specifier)) continue;
+      const imported = resolveImport(file, specifier);
+      if (!imported) continue;
+      const fromModule = getModuleInfo(file);
+      const toModule = getModuleInfo(imported);
+      if (!fromModule || !toModule) continue;
+
+      validateLayerDirection(relativeFile, specifier, fromModule, toModule);
+      validatePublicApi(relativeFile, specifier, fromModule, toModule, imported);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("FSD boundary check failed:\n");
+  for (const violation of violations) {
+    console.error(`- ${violation.file}`);
+    console.error(`  import ${JSON.stringify(violation.specifier)}`);
+    console.error(`  ${violation.message}`);
+  }
+  process.exit(1);
+}
+
+console.log("FSD boundary check passed.");
+
+function runBoundarySelfTest() {
+  const cases = [
+    {
+      name: "shared cannot import entities",
+      fromFile: path.join(srcRoot, "shared", "api", "tauri.ts"),
+      imported: path.join(srcRoot, "entities", "message", "index.ts"),
+      specifier: "../../entities/message",
+      expected: 1,
+    },
+    {
+      name: "features cannot import widgets",
+      fromFile: path.join(srcRoot, "features", "agent-run", "api.ts"),
+      imported: path.join(srcRoot, "widgets", "event-stream", "index.ts"),
+      specifier: "../../widgets/event-stream",
+      expected: 1,
+    },
+    {
+      name: "widgets must use feature public API",
+      fromFile: path.join(srcRoot, "widgets", "event-stream", "EventStream.tsx"),
+      imported: path.join(srcRoot, "features", "permission-response", "usePermissionResponse.ts"),
+      specifier: "../../features/permission-response/usePermissionResponse",
+      expected: 1,
+    },
+    {
+      name: "widgets can import feature public API",
+      fromFile: path.join(srcRoot, "widgets", "event-stream", "EventStream.tsx"),
+      imported: path.join(srcRoot, "features", "permission-response", "index.ts"),
+      specifier: "../../features/permission-response",
+      expected: 0,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const before = violations.length;
+    validateImport(
+      path.relative(root, testCase.fromFile),
+      testCase.specifier,
+      testCase.fromFile,
+      testCase.imported,
+    );
+    const added = violations.length - before;
+    if (added !== testCase.expected) {
+      throw new Error(
+        `Self-test failed for "${testCase.name}": expected ${testCase.expected} violation(s), got ${added}.`,
+      );
+    }
+    violations.splice(before, added);
+  }
+
+  console.log("FSD boundary self-test passed.");
+}
+
+function validateImport(relativeFile, specifier, fromFile, imported) {
+  const fromModule = getModuleInfo(fromFile);
+  const toModule = getModuleInfo(imported);
+  if (!fromModule || !toModule) return;
+  validateLayerDirection(toPosix(relativeFile), specifier, fromModule, toModule);
+  validatePublicApi(toPosix(relativeFile), specifier, fromModule, toModule, imported);
+}
+
+function* walk(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else if (sourceExtensions.has(path.extname(entry.name))) {
+      yield fullPath;
+    }
+  }
+}
+
+function collectImportSpecifiers(source) {
+  const specifiers = [];
+  const importFrom = /import\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/g;
+  const sideEffectImport = /import\s+["']([^"']+)["']/g;
+  const dynamicImport = /import\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const match of source.matchAll(importFrom)) {
+    specifiers.push(match[1]);
+  }
+  for (const match of source.matchAll(sideEffectImport)) {
+    specifiers.push(match[1]);
+  }
+  for (const match of source.matchAll(dynamicImport)) {
+    specifiers.push(match[1]);
+  }
+
+  return specifiers;
+}
+
+function isLocalImport(specifier) {
+  return specifier.startsWith(".");
+}
+
+function resolveImport(fromFile, specifier) {
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile());
+}
+
+function getModuleInfo(file) {
+  const relative = toPosix(path.relative(srcRoot, file));
+  const segments = relative.split("/");
+  const layer = segments[0];
+  if (!layerOrder.has(layer)) return undefined;
+
+  return {
+    layer,
+    order: layerOrder.get(layer),
+    slice: getSliceName(layer, segments),
+    relative,
+  };
+}
+
+function getSliceName(layer, segments) {
+  if (layer === "app") return "app";
+  if (layer === "shared") return segments[1] ?? "shared";
+  return segments[1] ?? layer;
+}
+
+function validateLayerDirection(file, specifier, fromModule, toModule) {
+  if (fromModule.layer === toModule.layer) return;
+  if (fromModule.order >= toModule.order) return;
+
+  violations.push({
+    file,
+    specifier,
+    message: `${fromModule.layer} cannot import upward from ${toModule.layer}. Allowed direction is app -> pages -> widgets -> features -> entities -> shared.`,
+  });
+}
+
+function validatePublicApi(file, specifier, fromModule, toModule, imported) {
+  if (fromModule.layer === toModule.layer && fromModule.slice === toModule.slice) return;
+  if (!publicApiOnlyLayers.has(toModule.layer)) return;
+  if (isSlicePublicApi(imported, toModule)) return;
+
+  violations.push({
+    file,
+    specifier,
+    message: `Cross-slice imports from ${toModule.layer}/${toModule.slice} must use its public index.ts API.`,
+  });
+}
+
+function isSlicePublicApi(imported, moduleInfo) {
+  const expected = path.join(srcRoot, moduleInfo.layer, moduleInfo.slice, "index.ts");
+  return path.normalize(imported) === path.normalize(expected);
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}


### PR DESCRIPTION
## Summary

- Add a dependency-free Node script that validates frontend Feature-Sliced Design import boundaries.
- Enforce layer direction for local imports under `src/`: `app -> pages -> widgets -> features -> entities -> shared`.
- Reject cross-slice deep imports into `entities`, `features`, and `widgets` when a public `index.ts` exists.
- Add npm scripts for the check and self-test mode.
- Document the check in `docs/frontend-fsd.md`.

Closes #16

## Tests

- `npm run check:fsd`
- `npm run check:fsd:self-test`
- `npm run build`
- `git diff --check`
