### PR TITLE
Introduce typed use case errors

### DIFF
--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -45,6 +45,7 @@ pub async fn start_agent_run(
     StartAgentRunUseCase::new(registry)
         .execute(runner, sink, request)
         .await
+        .map_err(String::from)
 }
 
 #[tauri::command]
@@ -59,6 +60,7 @@ pub async fn send_prompt_to_run(
     SendPromptUseCase::new(registry)
         .execute(sink, run_id, prompt)
         .await
+        .map_err(String::from)
 }
 
 #[tauri::command]

--- a/src-tauri/src/application/errors.rs
+++ b/src-tauri/src/application/errors.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum StartAgentRunError {
     ReserveRun(String),
     AttachRunHandle(String),
@@ -20,7 +20,7 @@ impl From<StartAgentRunError> for String {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SendPromptError {
     EmptyPrompt,
     RunNotActive,

--- a/src-tauri/src/application/errors.rs
+++ b/src-tauri/src/application/errors.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartAgentRunError {
+    ReserveRun(String),
+    AttachRunHandle(String),
+}
+
+impl fmt::Display for StartAgentRunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReserveRun(message) | Self::AttachRunHandle(message) => f.write_str(message),
+        }
+    }
+}
+
+impl From<StartAgentRunError> for String {
+    fn from(error: StartAgentRunError) -> Self {
+        error.to_string()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendPromptError {
+    EmptyPrompt,
+    RunNotActive,
+}
+
+impl fmt::Display for SendPromptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyPrompt => f.write_str("prompt is empty"),
+            Self::RunNotActive => f.write_str("agent run is not active"),
+        }
+    }
+}
+
+impl From<SendPromptError> for String {
+    fn from(error: SendPromptError) -> Self {
+        error.to_string()
+    }
+}

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,4 +1,5 @@
 pub mod cancel_agent_run;
+pub mod errors;
 pub mod list_agents;
 pub mod load_goal_file;
 pub mod respond_permission;

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -1,8 +1,8 @@
 use crate::{
+    application::errors::SendPromptError,
     domain::events::RunEvent,
     ports::{
-        event_sink::RunEventSink, session_handle::SessionHandle,
-        session_registry::SessionRegistry,
+        event_sink::RunEventSink, session_handle::SessionHandle, session_registry::SessionRegistry,
     },
 };
 
@@ -33,19 +33,19 @@ where
         sink: S,
         run_id: String,
         prompt: String,
-    ) -> Result<(), String>
+    ) -> Result<(), SendPromptError>
     where
         S: RunEventSink,
     {
         let trimmed = prompt.trim().to_string();
         if trimmed.is_empty() {
-            return Err("prompt is empty".into());
+            return Err(SendPromptError::EmptyPrompt);
         }
         let session = self
             .registry
             .active_session(&run_id)
             .await
-            .ok_or_else(|| "agent run is not active".to_string())?;
+            .ok_or(SendPromptError::RunNotActive)?;
         let sink_for_task = sink.clone();
         tokio::spawn(async move {
             if let Err(err) = session.send_prompt(sink_for_task.clone(), trimmed).await {
@@ -64,6 +64,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::errors::SendPromptError;
     use crate::ports::session_registry::SessionRegistry;
     use anyhow::{Result, anyhow};
     use std::{
@@ -162,7 +163,7 @@ mod tests {
             .execute(sink.clone(), "run-a".into(), "   ".into())
             .await;
 
-        assert_eq!(result, Err("prompt is empty".into()));
+        assert_eq!(result, Err(SendPromptError::EmptyPrompt));
         assert!(sink.events.lock().unwrap().is_empty());
     }
 
@@ -175,7 +176,7 @@ mod tests {
             .execute(sink, "missing".into(), "hi".into())
             .await;
 
-        assert_eq!(result, Err("agent run is not active".into()));
+        assert_eq!(result, Err(SendPromptError::RunNotActive));
     }
 
     #[tokio::test]

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -1,4 +1,5 @@
 use crate::{
+    application::errors::StartAgentRunError,
     domain::{
         events::RunEvent,
         run::{AgentRun, AgentRunRequest},
@@ -36,7 +37,7 @@ where
         launcher: L,
         sink: S,
         request: AgentRunRequest,
-    ) -> Result<AgentRun, String>
+    ) -> Result<AgentRun, StartAgentRunError>
     where
         L: SessionLauncher<Session = R::Session>,
         S: RunEventSink,
@@ -45,7 +46,7 @@ where
         self.registry
             .reserve_run(run.id.clone())
             .await
-            .map_err(|err| err.to_string())?;
+            .map_err(|err| StartAgentRunError::ReserveRun(err.to_string()))?;
 
         let registry = self.registry.clone();
         let run_id = run.id.clone();
@@ -89,7 +90,7 @@ where
         self.registry
             .attach_run_handle(&run.id, handle)
             .await
-            .map_err(|err| err.to_string())?;
+            .map_err(|err| StartAgentRunError::AttachRunHandle(err.to_string()))?;
 
         Ok(run)
     }
@@ -107,6 +108,7 @@ fn build_run(request: &AgentRunRequest) -> AgentRun {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::errors::StartAgentRunError;
     use crate::domain::events::{LifecycleStatus, RunEvent};
     use crate::ports::session_launcher::{AbortFuture, DriverFuture, RunCommander};
     use crate::ports::session_registry::SessionRegistry;
@@ -134,10 +136,24 @@ mod tests {
         finished: Vec<String>,
         sessions: HashMap<String, Arc<FakeSession>>,
         handles: HashMap<String, JoinHandle<()>>,
+        fail_reserve_run: bool,
+        fail_attach_run_handle: bool,
         fail_attach_session: bool,
     }
 
     impl FakeRegistry {
+        async fn with_failing_reserve_run() -> Self {
+            let reg = Self::default();
+            reg.inner.lock().await.fail_reserve_run = true;
+            reg
+        }
+
+        async fn with_failing_attach_run_handle() -> Self {
+            let reg = Self::default();
+            reg.inner.lock().await.fail_attach_run_handle = true;
+            reg
+        }
+
         async fn with_failing_attach() -> Self {
             let reg = Self::default();
             reg.inner.lock().await.fail_attach_session = true;
@@ -149,24 +165,25 @@ mod tests {
         type Session = FakeSession;
 
         async fn reserve_run(&self, run_id: String) -> Result<()> {
-            self.inner.lock().await.reserved.push(run_id);
+            let mut state = self.inner.lock().await;
+            if state.fail_reserve_run {
+                return Err(anyhow!("simulated reserve_run failure"));
+            }
+            state.reserved.push(run_id);
             Ok(())
         }
 
         async fn attach_run_handle(&self, run_id: &str, handle: JoinHandle<()>) -> Result<()> {
-            self.inner
-                .lock()
-                .await
-                .handles
-                .insert(run_id.to_string(), handle);
+            let mut state = self.inner.lock().await;
+            if state.fail_attach_run_handle {
+                handle.abort();
+                return Err(anyhow!("simulated attach_run_handle failure"));
+            }
+            state.handles.insert(run_id.to_string(), handle);
             Ok(())
         }
 
-        async fn attach_session(
-            &self,
-            run_id: &str,
-            session: Arc<FakeSession>,
-        ) -> Result<()> {
+        async fn attach_session(&self, run_id: &str, session: Arc<FakeSession>) -> Result<()> {
             let mut state = self.inner.lock().await;
             if state.fail_attach_session {
                 return Err(anyhow!("simulated attach_session failure"));
@@ -324,6 +341,48 @@ mod tests {
         let state = registry.inner.lock().await;
         assert_eq!(state.reserved, vec!["run-1".to_string()]);
         assert_eq!(state.finished, vec!["run-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn returns_typed_error_when_reserve_run_fails() {
+        let registry = FakeRegistry::with_failing_reserve_run().await;
+        let sink = CollectingSink::default();
+        let c = counters();
+        let launcher = FakeLauncher::success(&c);
+
+        let result = StartAgentRunUseCase::new(registry.clone())
+            .execute(launcher, sink, make_request())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(StartAgentRunError::ReserveRun(message))
+                if message == "simulated reserve_run failure"
+        ));
+        let state = registry.inner.lock().await;
+        assert!(state.reserved.is_empty());
+        assert!(state.handles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_typed_error_when_attach_run_handle_fails() {
+        let registry = FakeRegistry::with_failing_attach_run_handle().await;
+        let sink = CollectingSink::default();
+        let c = counters();
+        let launcher = FakeLauncher::success(&c);
+
+        let result = StartAgentRunUseCase::new(registry.clone())
+            .execute(launcher, sink, make_request())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(StartAgentRunError::AttachRunHandle(message))
+                if message == "simulated attach_run_handle failure"
+        ));
+        let state = registry.inner.lock().await;
+        assert_eq!(state.reserved, vec!["run-1".to_string()]);
+        assert!(state.handles.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add typed application error enums for start-agent-run and send-prompt use cases
- keep Tauri command responses unchanged by converting typed errors to strings at the adapter boundary
- update use case tests to assert typed variants and cover start-run registry failure paths

## Tests
- cargo test

Closes #20