### PR TITLE
Introduce origin-based workspaces

### DIFF
--- a/docs/workspace-plan.md
+++ b/docs/workspace-plan.md
@@ -1,0 +1,615 @@
+# Workspace 도입 계획
+
+## 1. 목표
+
+ACP Agent Workbench에 **workspace** 개념을 도입한다.
+
+workspace는 하나의 GitHub repository origin에 대응하는 상위 작업 컨텍스트다. 사용자는 workspace를 선택한 뒤, 그 아래에서 여러 작업을 동시에 실행할 수 있다.
+
+지원해야 하는 사용 시나리오:
+
+- 하나의 GitHub repo를 workspace로 등록한다.
+- 같은 workspace 아래에서 여러 작업을 서로 다른 디렉토리에서 실행한다.
+  - 예: `frontend/` 작업과 `src-tauri/` 작업을 동시에 진행
+- 같은 workspace 아래에서 같은 디렉토리를 대상으로 여러 작업을 병렬 실행한다.
+  - 예: 동일 repo root에서 `codex`는 구현, `claude-code`는 테스트 보강
+- 작업별 실행 이력, 권한 요청, follow-up queue, agent 설정은 분리된다.
+- workspace 단위로 repo origin, 로컬 checkout/worktree, 최근 작업 목록, 기본 agent 설정을 관리한다.
+
+## 2. 용어 정리
+
+현재 코드와 README에서는 실행 디렉토리 입력을 `Workspace`라고 부르고 있지만, 실제 의미는 `AgentRunRequest.cwd`다. 새 모델에서는 이 용어를 분리한다.
+
+| 용어 | 의미 | 예 |
+| --- | --- | --- |
+| Workspace | 하나의 GitHub repo origin에 대응하는 장기 컨텍스트 | `git@github.com:org/project.git` |
+| Repository origin | workspace를 식별하는 원격 저장소 URL. canonical form으로 정규화 | `https://github.com/org/project.git` |
+| Checkout | workspace의 로컬 clone 또는 worktree root | `/Users/me/work/project` |
+| Work directory | 특정 작업/run이 실행되는 디렉토리. checkout 내부 경로 | `/Users/me/work/project/src-tauri` |
+| Task | 사용자가 해결하려는 작업 단위. 탭 UI와 1:1로 매핑 가능 | "권한 브로커 테스트 추가" |
+| Run | agent 프로세스의 한 실행 세션. task 아래에 여러 번 생길 수 있음 | `runId` |
+
+결론:
+
+- UI의 현재 `Workspace` 입력은 `Working directory` 또는 `Run directory`로 이름을 바꾼다.
+- 새 `Workspace`는 repo origin을 기준으로 하는 별도 엔티티로 둔다.
+- `TabState`는 task/run UI 상태를 계속 소유하되, `workspaceId`와 `workdir`을 참조한다.
+
+## 3. 현재 구조 요약
+
+### 3.1 백엔드
+
+Rust/Tauri 백엔드는 hexagonal 구조다.
+
+| 영역 | 현재 상태 |
+| --- | --- |
+| `domain/run.rs` | `AgentRunRequest`가 `cwd: Option<String>`을 포함 |
+| `adapters/acp/runner.rs` | `cwd`를 workspace path처럼 정규화하고 ACP session `cwd`로 전달 |
+| `adapters/acp/client.rs` | ACP tool 요청의 path 접근을 runner workspace 내부로 제한 |
+| `adapters/session_registry.rs` | `runId` 기준으로 동시 run을 관리 |
+| `ports/session_registry.rs` | run 생명주기만 다루며 repo/workspace 개념 없음 |
+
+### 3.2 프런트엔드
+
+| 영역 | 현재 상태 |
+| --- | --- |
+| `features/agent-run/model.ts` | `TabState`가 `cwd`, `goal`, agent 설정, run 상태를 모두 보유 |
+| `features/agent-run/useAgentRun.ts` | 탭의 `cwd`를 `AgentRunRequest.cwd`로 전달 |
+| `widgets/workbench-tabs/TabBar.tsx` | task/run을 탭으로 표현 |
+| `widgets/run-panel/RunPanel.tsx` | `cwd` 입력을 실행 설정으로 노출 |
+
+현재 구현은 이미 "여러 탭, 여러 run"을 감당하는 방향으로 정리되어 있으므로, workspace 도입은 **탭 위의 repo 컨텍스트 추가**로 접근한다.
+
+## 4. 핵심 설계 이슈
+
+| # | 이슈 | 해결 방향 |
+| --- | --- | --- |
+| A | 기존 `Workspace` UI 용어와 새 workspace 개념 충돌 | 기존 입력은 `Working directory`로 변경. 새 workspace는 origin 기반 엔티티로 분리 |
+| B | 같은 repo를 URL 형식만 다르게 등록할 수 있음 | origin canonicalization 도입. `git@github.com:org/repo.git`, `https://github.com/org/repo`를 같은 키로 정규화 |
+| C | workdir이 workspace checkout 밖을 가리킬 수 있음 | 백엔드에서 `workdir`이 선택한 checkout 내부인지 검증 |
+| D | 같은 디렉토리 병렬 작업은 파일 충돌 가능 | 허용하되 UI에 "shared directory" 상태를 표시하고, 선택적으로 directory lease/경고 제공 |
+| E | 서로 다른 디렉토리 작업은 checkout 하나로 충분할 수 있음 | 기본은 같은 checkout 내부의 하위 디렉토리 사용 |
+| F | 강한 격리가 필요한 병렬 작업은 별도 worktree가 필요 | workspace 아래에 여러 checkout/worktree를 등록할 수 있게 확장 |
+| G | run 이벤트 라우팅은 runId 기준으로 이미 가능 | task/tab에 `workspaceId`, `workdir`만 추가하고 기존 run 라우팅 유지 |
+| H | workspace 목록/최근 상태를 앱 재시작 후 복원해야 함 | local app data에 workspace/task metadata 저장 |
+| I | GitHub origin이 없는 로컬 디렉토리도 있을 수 있음 | 1차 범위에서는 "GitHub origin 필수". 후속으로 local-only workspace 고려 |
+
+## 5. 제안 도메인 모델
+
+### 5.1 Workspace
+
+```rust
+pub struct Workspace {
+    pub id: WorkspaceId,
+    pub name: String,
+    pub origin: GitOrigin,
+    pub default_checkout_id: Option<CheckoutId>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct GitOrigin {
+    pub raw_url: String,
+    pub canonical_url: String,
+    pub host: String,
+    pub owner: String,
+    pub repo: String,
+}
+```
+
+`Workspace.id`는 canonical origin 기반으로 안정적으로 생성한다.
+
+예:
+
+```text
+workspaceId = sha256("github.com/org/repo").prefix(16)
+```
+
+이 방식이면 같은 origin을 다른 로컬 경로에서 열어도 같은 workspace로 인식할 수 있다.
+
+### 5.2 Checkout
+
+```rust
+pub struct WorkspaceCheckout {
+    pub id: CheckoutId,
+    pub workspace_id: WorkspaceId,
+    pub path: PathBuf,
+    pub kind: CheckoutKind,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+    pub is_default: bool,
+}
+
+pub enum CheckoutKind {
+    Clone,
+    Worktree,
+}
+```
+
+초기 구현은 사용자가 이미 clone한 디렉토리를 등록하는 방식으로 충분하다. 자동 clone/worktree 생성은 후속 단계로 둔다.
+
+### 5.3 Task
+
+프런트의 `TabState`를 task UI 상태로 계속 사용하되, workspace 참조를 추가한다.
+
+```ts
+export type TabState = {
+  id: string;
+  title: string;
+  workspaceId: string | null;
+  checkoutId: string | null;
+  workdir: string;
+
+  selectedAgentId: string;
+  goal: string;
+  customCommand: string;
+  stdioBufferLimitMb: number;
+  autoAllow: boolean;
+  idleTimeoutSec: number;
+
+  activeRunId: string | null;
+  sessionActive: boolean;
+  awaitingResponse: boolean;
+  followUpQueue: FollowUpQueueItem[];
+  items: TimelineItem[];
+};
+```
+
+기존 `cwd`는 `workdir`로 이름을 바꾸거나, 호환성을 위해 API 경계에서는 `cwd`로만 변환한다.
+
+### 5.4 Run
+
+`AgentRunRequest`에 workspace 식별자를 추가한다.
+
+```rust
+pub struct AgentRunRequest {
+    pub goal: String,
+    pub agent_id: String,
+    pub workspace_id: Option<String>,
+    pub checkout_id: Option<String>,
+    pub cwd: Option<String>,
+    pub agent_command: Option<String>,
+    pub stdio_buffer_limit_mb: Option<usize>,
+    pub auto_allow: Option<bool>,
+    pub run_id: Option<String>,
+}
+```
+
+호환성을 위해 `workspace_id`가 없으면 기존처럼 `cwd`만으로 실행할 수 있게 둔다. 다만 새 UI 경로에서는 항상 workspace를 선택해 전달한다.
+
+## 6. 실행 디렉토리 정책
+
+workspace 아래 작업은 세 가지 모드로 나눈다.
+
+| 모드 | 설명 | 기본 정책 |
+| --- | --- | --- |
+| Same checkout, different directories | 같은 checkout 안의 서로 다른 하위 디렉토리에서 작업 | 기본 허용 |
+| Same checkout, same directory | 같은 디렉토리에서 병렬 작업 | 허용 + 충돌 경고 |
+| Separate worktrees | 같은 origin의 별도 worktree에서 작업 | 후속 구현. 충돌 위험 낮음 |
+
+### 6.1 path 검증
+
+백엔드는 run 시작 전에 다음을 검증한다.
+
+1. `workspaceId`가 존재한다.
+2. `checkoutId`가 workspace에 속한다.
+3. `cwd`를 canonicalize한 경로가 checkout root 내부다.
+4. 경로가 존재하지 않으면 생성 여부를 정책으로 결정한다.
+   - 1차: 존재하지 않으면 에러
+   - 후속: checkout 내부 하위 경로는 생성 허용 옵션 제공
+
+### 6.2 같은 디렉토리 병렬 실행
+
+같은 디렉토리 병렬 작업은 실제로 유용하지만, 두 agent가 같은 파일을 동시에 수정할 수 있다. 1차 구현에서는 강제 차단하지 않는다.
+
+대신 프런트에서 다음 정보를 보여준다.
+
+- 같은 workspace/workdir에서 실행 중인 task 개수
+- 실행 중 agent 목록
+- "shared directory" badge
+- 선택적 확인: 이미 실행 중인 작업이 있는 디렉토리에서 run 시작 시 confirm
+
+후속 단계에서 `DirectoryLease`를 추가할 수 있다.
+
+```rust
+pub struct DirectoryLease {
+    pub workspace_id: WorkspaceId,
+    pub checkout_id: CheckoutId,
+    pub workdir: PathBuf,
+    pub run_id: String,
+    pub mode: LeaseMode,
+}
+
+pub enum LeaseMode {
+    Shared,
+    Exclusive,
+}
+```
+
+초기값은 `Shared`다. `Exclusive`는 위험한 작업, release 작업, 대규모 refactor에서 선택할 수 있게 한다.
+
+## 7. 백엔드 변경 계획
+
+### 7.1 새 도메인/포트
+
+추가 파일:
+
+- `src-tauri/src/domain/workspace.rs`
+- `src-tauri/src/ports/workspace_store.rs`
+- `src-tauri/src/application/list_workspaces.rs`
+- `src-tauri/src/application/register_workspace.rs`
+- `src-tauri/src/application/resolve_workdir.rs`
+
+`WorkspaceStore` 포트:
+
+```rust
+pub trait WorkspaceStore: Clone + Send + Sync + 'static {
+    fn list_workspaces(&self) -> impl Future<Output = Result<Vec<Workspace>>> + Send;
+    fn get_workspace(&self, id: &str) -> impl Future<Output = Result<Option<Workspace>>> + Send;
+    fn upsert_workspace(&self, workspace: Workspace) -> impl Future<Output = Result<()>> + Send;
+    fn list_checkouts(&self, workspace_id: &str) -> impl Future<Output = Result<Vec<WorkspaceCheckout>>> + Send;
+    fn upsert_checkout(&self, checkout: WorkspaceCheckout) -> impl Future<Output = Result<()>> + Send;
+}
+```
+
+1차 adapter는 JSON 파일 저장으로 충분하다.
+
+예상 저장 위치:
+
+```text
+~/Library/Application Support/acp-agent-workbench/workspaces.json
+```
+
+플랫폼별 app data path는 Tauri path API 또는 Rust crate를 통해 얻는다.
+
+### 7.2 Git origin resolver
+
+추가 adapter:
+
+- `src-tauri/src/adapters/git.rs`
+
+책임:
+
+- 선택한 디렉토리에서 `git rev-parse --show-toplevel` 실행
+- `git remote get-url origin` 실행
+- GitHub URL canonicalization
+- 현재 branch/head sha 조회
+
+origin 정규화 예:
+
+| 입력 | canonical |
+| --- | --- |
+| `git@github.com:org/repo.git` | `github.com/org/repo` |
+| `https://github.com/org/repo.git` | `github.com/org/repo` |
+| `https://github.com/org/repo` | `github.com/org/repo` |
+
+GitHub 외 host는 1차에서는 에러 처리하거나 `host/owner/repo` 구조가 확인되는 경우만 허용한다. 요구사항이 "github repo origin"이므로 GitHub만 먼저 지원하는 편이 명확하다.
+
+### 7.3 Run 시작 시 workspace 검증
+
+`StartAgentRunUseCase` 앞단에서 `AgentRunRequest`의 `workspace_id`, `checkout_id`, `cwd`를 검증하고 실제 실행 path를 확정한다.
+
+선택지는 두 가지다.
+
+1. `StartAgentRunUseCase` 안에 `WorkdirResolver` 포트를 주입
+2. Tauri command에서 먼저 `ResolveWorkdirUseCase`를 호출한 뒤 request의 `cwd`를 확정
+
+권장: 1번. 실행 path 검증은 run 시작의 도메인 규칙에 가깝고, Tauri command를 얇게 유지할 수 있다.
+
+```rust
+pub trait WorkdirResolver: Clone + Send + Sync + 'static {
+    fn resolve(
+        &self,
+        workspace_id: Option<&str>,
+        checkout_id: Option<&str>,
+        cwd: Option<&str>,
+    ) -> impl Future<Output = Result<PathBuf>> + Send;
+}
+```
+
+호환성:
+
+- `workspace_id == None`이면 기존 `cwd` 직접 실행 경로를 유지
+- `workspace_id != None`이면 workspace checkout 내부 검증을 강제
+
+### 7.4 Tauri command
+
+추가 command:
+
+| Command | 역할 |
+| --- | --- |
+| `list_workspaces` | 등록된 workspace 목록 반환 |
+| `register_workspace_from_path(path)` | 로컬 repo path를 검사해 workspace/checkouts 등록 |
+| `remove_workspace(workspace_id)` | workspace metadata 제거. 파일 삭제는 하지 않음 |
+| `list_workspace_checkouts(workspace_id)` | checkout/worktree 목록 반환 |
+| `refresh_workspace_checkout(checkout_id)` | branch/head/origin 정보 갱신 |
+| `resolve_workspace_workdir(workspace_id, checkout_id, relative_path)` | UI 검증/preview용 |
+
+후속 command:
+
+| Command | 역할 |
+| --- | --- |
+| `clone_workspace(origin, target_path)` | origin clone 후 등록 |
+| `create_workspace_worktree(workspace_id, branch, path)` | 별도 worktree 생성 |
+| `delete_workspace_worktree(checkout_id)` | worktree 제거. destructive라 별도 확인 필요 |
+
+## 8. 프런트엔드 변경 계획
+
+### 8.1 FSD 배치
+
+추가/변경 영역:
+
+| 경로 | 책임 |
+| --- | --- |
+| `src/entities/workspace/` | Workspace, Checkout 타입 |
+| `src/features/workspace-select/` | workspace 선택/등록 UI |
+| `src/features/workdir-select/` | checkout 및 하위 경로 선택 UI |
+| `src/features/agent-run/model.ts` | `TabState`에 `workspaceId`, `checkoutId`, `workdir` 추가 |
+| `src/widgets/workspace-sidebar/` | workspace 목록과 최근 task 표시 (선택) |
+| `src/widgets/run-panel/RunPanel.tsx` | `cwd` 입력을 workspace-aware workdir 선택으로 변경 |
+
+### 8.2 UI 구조
+
+1차 UI는 현재 화면 구조를 크게 바꾸지 않는다.
+
+```text
+AgentWorkbenchPage
+├── WorkspaceBar
+│   ├── workspace selector
+│   ├── checkout selector
+│   └── workdir selector
+├── TabBar
+└── ActiveTabPanel
+    ├── GoalEditor
+    ├── RunPanel
+    ├── FollowUpComposer
+    ├── FollowUpQueue
+    └── EventStream
+```
+
+`TabBar`는 task list로 유지한다. 같은 workspace 안의 task들이 탭으로 나열되는 형태가 현재 모델과 가장 잘 맞는다.
+
+후속으로 여러 workspace를 동시에 열어야 하면 다음 구조로 확장한다.
+
+```text
+WorkspaceSwitcher
+└── WorkspaceSession
+    ├── tabs
+    └── activeTabId
+```
+
+즉, 전역 store를 `workspaces -> tabs` 계층으로 확장할 수 있다.
+
+### 8.3 Store 모델
+
+1차는 전역 workspace 목록과 탭별 workspace 참조를 추가한다.
+
+```ts
+type WorkbenchState = {
+  workspaces: Workspace[];
+  checkoutsByWorkspaceId: Record<string, WorkspaceCheckout[]>;
+  tabs: TabState[];
+  activeTabId: string;
+
+  loadWorkspaces: () => Promise<void>;
+  registerWorkspaceFromPath: (path: string) => Promise<string>;
+  setTabWorkspace: (tabId: string, workspaceId: string, checkoutId?: string) => void;
+  setTabWorkdir: (tabId: string, workdir: string) => void;
+};
+```
+
+기존 run 이벤트 dispatch는 유지한다.
+
+```ts
+dispatchRunEvent(runId, event)
+```
+
+workspace는 이벤트 라우팅 키가 아니다. 이벤트는 계속 runId로 라우팅하고, runId가 속한 탭이 workspace를 참조한다.
+
+### 8.4 기존 `cwd`와의 호환
+
+`useAgentRun`에서 request 생성 시:
+
+```ts
+const request: AgentRunRequest = {
+  runId,
+  goal: trimmedGoal,
+  agentId: current.selectedAgentId,
+  workspaceId: current.workspaceId ?? undefined,
+  checkoutId: current.checkoutId ?? undefined,
+  cwd: current.workdir.trim() || undefined,
+  agentCommand: current.customCommand.trim() || undefined,
+  stdioBufferLimitMb: clampBuffer(current.stdioBufferLimitMb),
+  autoAllow: current.autoAllow,
+};
+```
+
+레거시 탭은 `workspaceId == null`이고 `cwd`만 전달한다. 새 탭은 workspace 선택 후 `workdir`을 전달한다.
+
+## 9. 데이터 저장
+
+초기 저장은 로컬 JSON 파일로 한다. DB 도입은 검색/히스토리 요구가 커진 뒤 판단한다.
+
+```json
+{
+  "schemaVersion": 1,
+  "workspaces": [
+    {
+      "id": "ws_9d35f0a1f0d9c6a2",
+      "name": "acp-agent-workbench",
+      "origin": {
+        "rawUrl": "git@github.com:org/acp-agent-workbench.git",
+        "canonicalUrl": "github.com/org/acp-agent-workbench",
+        "host": "github.com",
+        "owner": "org",
+        "repo": "acp-agent-workbench"
+      },
+      "defaultCheckoutId": "co_1",
+      "createdAt": "2026-04-19T00:00:00Z",
+      "updatedAt": "2026-04-19T00:00:00Z"
+    }
+  ],
+  "checkouts": [
+    {
+      "id": "co_1",
+      "workspaceId": "ws_9d35f0a1f0d9c6a2",
+      "path": "/Users/yoophi/project/acp-agent-workbench",
+      "kind": "clone",
+      "branch": "main",
+      "headSha": "abc123",
+      "isDefault": true
+    }
+  ]
+}
+```
+
+주의:
+
+- 작업 이력 전체와 이벤트 스트림은 별도 저장 범위로 둔다.
+- 1차 workspace metadata에는 민감한 토큰을 저장하지 않는다.
+- origin URL은 private repo 이름을 포함할 수 있으므로 외부 전송하지 않는다.
+
+## 10. 단계별 구현 계획
+
+### Phase 1. 용어 정리와 호환 필드 추가
+
+- `RunPanel`의 `Workspace` 라벨을 `Working directory`로 변경
+- `TabState.cwd`를 내부적으로 유지하되 문서와 UI에서는 `workdir`로 표현
+- `AgentRunRequest`에 optional `workspaceId`, `checkoutId` 추가
+- 기존 `cwd` 단독 실행이 계속 동작하는지 테스트
+
+완료 기준:
+
+- 기존 단일/다중 탭 run이 회귀 없이 동작
+- UI에서 workspace 용어가 repo 컨텍스트와 충돌하지 않음
+
+### Phase 2. Workspace metadata 저장소 도입
+
+- `domain/workspace.rs` 추가
+- `WorkspaceStore` 포트 추가
+- JSON 파일 기반 `LocalWorkspaceStore` adapter 구현
+- `list_workspaces`, `register_workspace_from_path`, `list_workspace_checkouts` command 추가
+- git origin resolver 구현
+
+완료 기준:
+
+- 로컬 repo path를 등록하면 origin 기준 workspace가 생성됨
+- 같은 origin의 다른 path를 등록하면 같은 workspace 아래 checkout으로 추가됨
+- 앱 재시작 후 workspace 목록이 복원됨
+
+### Phase 3. 탭과 workspace 연결
+
+- `TabState`에 `workspaceId`, `checkoutId`, `workdir` 추가
+- workspace selector와 checkout selector 추가
+- 새 탭 생성 시 현재 workspace/checkouts를 preset으로 복사
+- run 시작 시 workspace/checkouts/workdir 정보를 request에 포함
+
+완료 기준:
+
+- 같은 workspace 아래 여러 탭을 만들 수 있음
+- 탭별로 서로 다른 workdir을 선택해 병렬 실행 가능
+- 탭을 전환해도 workspace/workdir 선택이 유지됨
+
+### Phase 4. Workdir 검증 강제
+
+- `WorkdirResolver` 포트 추가
+- workspace 기반 run은 checkout 내부 경로만 허용
+- checkout 밖 path, 존재하지 않는 path, origin 불일치를 명확한 에러로 surface
+- ACP client의 기존 path sandbox와 resolver 정책을 맞춤
+
+완료 기준:
+
+- workspace run은 checkout 밖에서 실행되지 않음
+- 에러 메시지가 UI에서 어떤 workspace/checkouts/path 문제인지 설명함
+- 기존 `cwd` 단독 legacy run은 유지됨
+
+### Phase 5. 병렬 작업 상태 표시
+
+- 같은 workspace/workdir에서 실행 중인 task 목록 계산
+- `TabBar` 또는 `WorkspaceBar`에 shared directory badge 표시
+- 같은 directory에서 새 run 시작 시 경고 또는 confirm 제공
+- workspace별 active run count, permission pending count 표시
+
+완료 기준:
+
+- 사용자가 같은 디렉토리 병렬 작업 상태를 명확히 볼 수 있음
+- 서로 다른 디렉토리 병렬 작업은 불필요한 경고 없이 실행됨
+
+### Phase 6. Worktree 지원
+
+- `create_workspace_worktree` command 추가
+- worktree checkout 등록
+- task 생성 시 "same checkout" / "new worktree" 선택 제공
+- worktree별 branch/head 상태 표시
+
+완료 기준:
+
+- 같은 origin 아래 여러 worktree를 만들고 task별로 배정 가능
+- 병렬 agent 작업을 파일 충돌 없이 분리할 수 있음
+
+## 11. 테스트 전략
+
+### Rust
+
+- origin canonicalization
+  - SSH/HTTPS/.git suffix normalization
+  - GitHub owner/repo parsing
+- workspace store
+  - upsert workspace
+  - same origin duplicate 방지
+  - checkout 추가/갱신
+- workdir resolver
+  - checkout 내부 path 허용
+  - checkout 밖 path 거부
+  - symlink/canonicalize escape 거부
+- start run integration
+  - workspace request가 resolved cwd로 launcher에 전달되는지
+  - legacy cwd request가 기존처럼 동작하는지
+
+### Frontend
+
+- workspace selector
+  - 목록 로딩
+  - 등록 성공/실패
+  - 탭별 선택 유지
+- run request 생성
+  - workspaceId/checkoutId/workdir 포함
+  - legacy 탭 호환
+- 병렬 상태 표시
+  - 같은 workdir active run badge
+  - 다른 workdir은 badge 미표시
+- 이벤트 라우팅
+  - 기존처럼 runId 기준으로 올바른 탭에 append
+
+## 12. 위험과 대응
+
+| 위험 | 영향 | 대응 |
+| --- | --- | --- |
+| origin 정규화 오류 | 같은 repo가 여러 workspace로 등록됨 | canonicalization 단위 테스트를 먼저 작성 |
+| path 검증 미흡 | agent가 checkout 밖 파일에 접근 | `canonicalize` + prefix 검증을 백엔드에서 강제 |
+| 같은 디렉토리 병렬 수정 충돌 | 사용자 작업 손실 가능 | 1차 경고, 후속 exclusive lease/worktree 권장 |
+| metadata 저장 파일 손상 | workspace 목록 유실 | schemaVersion, atomic write, parse 실패 시 백업 파일 유지 |
+| UI 상태 계층 과도화 | 탭/store 복잡도 증가 | 1차는 `tabs + workspace refs`로 제한, `workspaces -> tabs` 계층화는 후속 |
+| 자동 clone/worktree가 OS별로 불안정 | 구현/권한 복잡도 증가 | 1차는 existing local repo 등록만 지원 |
+
+## 13. 범위 밖
+
+1차 구현에서 제외한다.
+
+- GitHub API 연동
+- PR/issue 목록 연동
+- remote branch 자동 생성
+- 작업 결과 자동 commit/push
+- agent별 파일 lock 강제
+- workspace/task 이벤트 히스토리 영구 저장
+- local-only non-git workspace
+
+## 14. 권장 구현 순서 요약
+
+1. 기존 UI의 `Workspace` 용어를 `Working directory`로 정리한다.
+2. `Workspace`, `Checkout`, origin canonicalization 도메인 타입을 추가한다.
+3. 로컬 repo path 등록 command와 JSON metadata store를 구현한다.
+4. `TabState`에 `workspaceId`, `checkoutId`, `workdir`를 추가한다.
+5. run 시작 전에 workspace 기반 path 검증을 강제한다.
+6. 같은 workspace/workdir 병렬 실행 상태를 UI에 표시한다.
+7. 필요해진 시점에 worktree 생성/관리 기능을 추가한다.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3034,6 +3034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,6 +4071,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,4 +21,4 @@ shell-words = "1.1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tokio = { version = "1.48", features = ["io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
-uuid = { version = "1.18", features = ["v4"] }
+uuid = { version = "1.18", features = ["v4", "v5"] }

--- a/src-tauri/src/adapters/git.rs
+++ b/src-tauri/src/adapters/git.rs
@@ -1,0 +1,114 @@
+use anyhow::{Result, anyhow, bail};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::{
+    adapters::acp::util::{expand_tilde, normalize_path},
+    domain::workspace::GitOrigin,
+};
+
+#[derive(Clone, Debug)]
+pub struct GitRepository {
+    pub root: PathBuf,
+    pub origin: GitOrigin,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+}
+
+impl GitRepository {
+    pub fn from_path(path: &str) -> Result<Self> {
+        let path = normalize_path(&expand_tilde(path))?;
+        let root = run_git(&path, ["rev-parse", "--show-toplevel"])?;
+        let root = normalize_path(Path::new(root.trim()))?;
+        let raw_origin = run_git(&root, ["remote", "get-url", "origin"])?;
+        let origin = parse_github_origin(raw_origin.trim())?;
+        let branch = run_git(&root, ["branch", "--show-current"])
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let head_sha = run_git(&root, ["rev-parse", "HEAD"])
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        Ok(Self {
+            root,
+            origin,
+            branch,
+            head_sha,
+        })
+    }
+}
+
+pub fn parse_github_origin(raw_url: &str) -> Result<GitOrigin> {
+    let trimmed = raw_url.trim();
+    if trimmed.is_empty() {
+        bail!("git origin is empty");
+    }
+
+    let without_suffix = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let path = if let Some(rest) = without_suffix.strip_prefix("git@github.com:") {
+        rest
+    } else if let Some(rest) = without_suffix.strip_prefix("ssh://git@github.com/") {
+        rest
+    } else if let Some(rest) = without_suffix.strip_prefix("https://github.com/") {
+        rest
+    } else if let Some(rest) = without_suffix.strip_prefix("http://github.com/") {
+        rest
+    } else {
+        bail!("only GitHub origin URLs are supported: {trimmed}");
+    };
+
+    let mut parts = path.split('/').filter(|part| !part.is_empty());
+    let owner = parts
+        .next()
+        .ok_or_else(|| anyhow!("GitHub origin URL is missing owner: {trimmed}"))?;
+    let repo = parts
+        .next()
+        .ok_or_else(|| anyhow!("GitHub origin URL is missing repo: {trimmed}"))?;
+    if parts.next().is_some() {
+        bail!("GitHub origin URL has unexpected path segments: {trimmed}");
+    }
+
+    Ok(GitOrigin {
+        raw_url: trimmed.to_string(),
+        canonical_url: format!("github.com/{owner}/{repo}"),
+        host: "github.com".to_string(),
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    })
+}
+
+fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
+    let output = Command::new("git").args(args).current_dir(cwd).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git command failed: {}", stderr.trim());
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_github_origin;
+
+    #[test]
+    fn parses_github_ssh_origin() {
+        let origin = parse_github_origin("git@github.com:org/repo.git").unwrap();
+        assert_eq!(origin.canonical_url, "github.com/org/repo");
+    }
+
+    #[test]
+    fn parses_github_https_origin() {
+        let origin = parse_github_origin("https://github.com/org/repo").unwrap();
+        assert_eq!(origin.canonical_url, "github.com/org/repo");
+    }
+
+    #[test]
+    fn rejects_non_github_origin() {
+        let err = parse_github_origin("https://gitlab.com/org/repo.git").unwrap_err();
+        assert!(err.to_string().contains("only GitHub"));
+    }
+}

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -1,6 +1,8 @@
 pub mod acp;
 pub mod agent_catalog;
 pub mod fs;
+pub mod git;
 pub mod permission_broker;
 pub mod session_registry;
 pub mod tauri;
+pub mod workspace_store;

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,22 +1,23 @@
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 
 use crate::{
     adapters::{
-        acp::runner::AcpAgentRunner,
-        agent_catalog::ConfigurableAgentCatalog,
-        fs::LocalGoalFileReader,
-        session_registry::AppState,
-        tauri::event_sink::TauriRunEventSink,
+        acp::runner::AcpAgentRunner, agent_catalog::ConfigurableAgentCatalog,
+        fs::LocalGoalFileReader, session_registry::AppState, tauri::event_sink::TauriRunEventSink,
+        workspace_store::LocalWorkspaceStore,
     },
     application::{
         cancel_agent_run::CancelAgentRunUseCase, list_agents::ListAgentsUseCase,
-        load_goal_file::LoadGoalFileUseCase, respond_permission::RespondPermissionUseCase,
-        send_prompt::SendPromptUseCase, start_agent_run::StartAgentRunUseCase,
+        load_goal_file::LoadGoalFileUseCase, resolve_workdir::ResolveWorkdirUseCase,
+        respond_permission::RespondPermissionUseCase, send_prompt::SendPromptUseCase,
+        start_agent_run::StartAgentRunUseCase,
     },
     domain::{
         agent::AgentDescriptor,
         run::{AgentRun, AgentRunRequest},
+        workspace::{RegisteredWorkspace, Workspace, WorkspaceCheckout},
     },
+    ports::workspace_store::WorkspaceStore,
 };
 
 #[tauri::command]
@@ -35,8 +36,21 @@ pub fn load_goal_file(path: String) -> Result<String, String> {
 pub async fn start_agent_run(
     app: AppHandle,
     state: State<'_, AppState>,
-    request: AgentRunRequest,
+    mut request: AgentRunRequest,
 ) -> Result<AgentRun, String> {
+    let workspace_store = workspace_store(&app)?;
+    let resolved_cwd = ResolveWorkdirUseCase::new(workspace_store)
+        .execute(
+            request.workspace_id.as_deref(),
+            request.checkout_id.as_deref(),
+            request.cwd.as_deref(),
+        )
+        .await
+        .map_err(|err| err.to_string())?;
+    if let Some(cwd) = resolved_cwd {
+        request.cwd = Some(cwd.to_string_lossy().to_string());
+    }
+
     let sink = TauriRunEventSink::new(app);
     let permissions = state.permissions();
     let registry = state.inner().clone();
@@ -87,4 +101,76 @@ pub async fn respond_agent_permission(
         .execute(&permission_id, option_id)
         .await
         .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn list_workspaces(app: AppHandle) -> Result<Vec<Workspace>, String> {
+    workspace_store(&app)?
+        .list_workspaces()
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn register_workspace_from_path(
+    app: AppHandle,
+    path: String,
+) -> Result<RegisteredWorkspace, String> {
+    workspace_store(&app)?
+        .register_from_path(&path)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn remove_workspace(app: AppHandle, workspace_id: String) -> Result<(), String> {
+    workspace_store(&app)?
+        .remove_workspace(&workspace_id)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn list_workspace_checkouts(
+    app: AppHandle,
+    workspace_id: String,
+) -> Result<Vec<WorkspaceCheckout>, String> {
+    workspace_store(&app)?
+        .list_checkouts(&workspace_id)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn refresh_workspace_checkout(
+    app: AppHandle,
+    checkout_id: String,
+) -> Result<Option<WorkspaceCheckout>, String> {
+    workspace_store(&app)?
+        .refresh_checkout(&checkout_id)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn resolve_workspace_workdir(
+    app: AppHandle,
+    workspace_id: Option<String>,
+    checkout_id: Option<String>,
+    cwd: Option<String>,
+) -> Result<Option<String>, String> {
+    ResolveWorkdirUseCase::new(workspace_store(&app)?)
+        .execute(
+            workspace_id.as_deref(),
+            checkout_id.as_deref(),
+            cwd.as_deref(),
+        )
+        .await
+        .map(|path| path.map(|value| value.to_string_lossy().to_string()))
+        .map_err(|err| err.to_string())
+}
+
+fn workspace_store(app: &AppHandle) -> Result<LocalWorkspaceStore, String> {
+    let app_data_dir = app.path().app_data_dir().map_err(|err| err.to_string())?;
+    Ok(LocalWorkspaceStore::new(app_data_dir))
 }

--- a/src-tauri/src/adapters/workspace_store.rs
+++ b/src-tauri/src/adapters/workspace_store.rs
@@ -1,0 +1,205 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
+};
+use tokio::sync::Mutex;
+
+use crate::{
+    adapters::git::GitRepository,
+    domain::workspace::{
+        CheckoutId, RegisteredWorkspace, Workspace, WorkspaceCheckout, WorkspaceId, timestamp,
+    },
+    ports::workspace_store::WorkspaceStore,
+};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone)]
+pub struct LocalWorkspaceStore {
+    path: PathBuf,
+    lock: Arc<Mutex<()>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceStoreFile {
+    schema_version: u32,
+    workspaces: Vec<Workspace>,
+    checkouts: Vec<WorkspaceCheckout>,
+}
+
+impl LocalWorkspaceStore {
+    pub fn new(app_data_dir: PathBuf) -> Self {
+        Self {
+            path: app_data_dir.join("workspaces.json"),
+            lock: shared_store_lock(),
+        }
+    }
+
+    pub async fn register_from_path(&self, path: &str) -> Result<RegisteredWorkspace> {
+        let repo = GitRepository::from_path(path)?;
+        let mut workspace = Workspace::from_origin(repo.origin.clone());
+        let checkout = WorkspaceCheckout::new(
+            workspace.id.clone(),
+            &repo.origin.canonical_url,
+            repo.root,
+            repo.branch,
+            repo.head_sha,
+            true,
+        );
+
+        let _guard = self.lock.lock().await;
+        let mut file = self.read_file_unlocked()?;
+        if let Some(existing) = file
+            .workspaces
+            .iter()
+            .find(|entry| entry.id == workspace.id)
+        {
+            workspace.created_at = existing.created_at.clone();
+            workspace.default_checkout_id = existing
+                .default_checkout_id
+                .clone()
+                .or_else(|| Some(checkout.id.clone()));
+        } else {
+            workspace.default_checkout_id = Some(checkout.id.clone());
+        }
+        workspace.updated_at = timestamp();
+
+        upsert_by_id(&mut file.workspaces, workspace.clone(), |entry| {
+            entry.id.clone()
+        });
+        upsert_by_id(&mut file.checkouts, checkout.clone(), |entry| {
+            entry.id.clone()
+        });
+        self.write_file_unlocked(&file)?;
+
+        Ok(RegisteredWorkspace {
+            workspace,
+            checkout,
+        })
+    }
+
+    async fn update_checkout_from_git(
+        &self,
+        checkout_id: &CheckoutId,
+    ) -> Result<Option<WorkspaceCheckout>> {
+        let _guard = self.lock.lock().await;
+        let mut file = self.read_file_unlocked()?;
+        let Some(index) = file
+            .checkouts
+            .iter()
+            .position(|checkout| checkout.id == *checkout_id)
+        else {
+            return Ok(None);
+        };
+        let path = file.checkouts[index].path.to_string_lossy().to_string();
+        let repo = GitRepository::from_path(&path)?;
+        file.checkouts[index].branch = repo.branch;
+        file.checkouts[index].head_sha = repo.head_sha;
+        let checkout = file.checkouts[index].clone();
+        self.write_file_unlocked(&file)?;
+        Ok(Some(checkout))
+    }
+
+    fn read_file_unlocked(&self) -> Result<WorkspaceStoreFile> {
+        if !self.path.exists() {
+            return Ok(WorkspaceStoreFile {
+                schema_version: SCHEMA_VERSION,
+                ..WorkspaceStoreFile::default()
+            });
+        }
+        let raw = fs::read_to_string(&self.path)?;
+        let mut file: WorkspaceStoreFile = serde_json::from_str(&raw)?;
+        if file.schema_version == 0 {
+            file.schema_version = SCHEMA_VERSION;
+        }
+        Ok(file)
+    }
+
+    fn write_file_unlocked(&self, file: &WorkspaceStoreFile) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let raw = serde_json::to_string_pretty(file)?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, raw)?;
+        fs::rename(tmp, &self.path)?;
+        Ok(())
+    }
+}
+
+fn shared_store_lock() -> Arc<Mutex<()>> {
+    static LOCK: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
+    LOCK.get_or_init(Arc::default).clone()
+}
+
+impl WorkspaceStore for LocalWorkspaceStore {
+    async fn list_workspaces(&self) -> Result<Vec<Workspace>> {
+        let _guard = self.lock.lock().await;
+        Ok(self.read_file_unlocked()?.workspaces)
+    }
+
+    async fn get_workspace(&self, id: &str) -> Result<Option<Workspace>> {
+        let _guard = self.lock.lock().await;
+        Ok(self
+            .read_file_unlocked()?
+            .workspaces
+            .into_iter()
+            .find(|workspace| workspace.id == id))
+    }
+
+    async fn list_checkouts(&self, workspace_id: &str) -> Result<Vec<WorkspaceCheckout>> {
+        let _guard = self.lock.lock().await;
+        Ok(self
+            .read_file_unlocked()?
+            .checkouts
+            .into_iter()
+            .filter(|checkout| checkout.workspace_id == workspace_id)
+            .collect())
+    }
+
+    async fn get_checkout(&self, id: &str) -> Result<Option<WorkspaceCheckout>> {
+        let _guard = self.lock.lock().await;
+        Ok(self
+            .read_file_unlocked()?
+            .checkouts
+            .into_iter()
+            .find(|checkout| checkout.id == id))
+    }
+
+    async fn remove_workspace(&self, workspace_id: &WorkspaceId) -> Result<()> {
+        let _guard = self.lock.lock().await;
+        let mut file = self.read_file_unlocked()?;
+        file.workspaces
+            .retain(|workspace| workspace.id != *workspace_id);
+        file.checkouts
+            .retain(|checkout| checkout.workspace_id != *workspace_id);
+        self.write_file_unlocked(&file)
+    }
+
+    async fn refresh_checkout(
+        &self,
+        checkout_id: &CheckoutId,
+    ) -> Result<Option<WorkspaceCheckout>> {
+        self.update_checkout_from_git(checkout_id).await
+    }
+}
+
+fn upsert_by_id<T, F>(items: &mut Vec<T>, item: T, id: F)
+where
+    F: Fn(&T) -> String,
+{
+    let item_id = id(&item);
+    match items.iter().position(|entry| id(entry) == item_id) {
+        Some(index) => items[index] = item,
+        None => items.push(item),
+    }
+}
+
+#[allow(dead_code)]
+fn store_path(base: &Path) -> PathBuf {
+    base.join("workspaces.json")
+}

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -2,6 +2,7 @@ pub mod cancel_agent_run;
 pub mod errors;
 pub mod list_agents;
 pub mod load_goal_file;
+pub mod resolve_workdir;
 pub mod respond_permission;
 pub mod send_prompt;
 pub mod start_agent_run;

--- a/src-tauri/src/application/resolve_workdir.rs
+++ b/src-tauri/src/application/resolve_workdir.rs
@@ -1,0 +1,79 @@
+use anyhow::{Result, anyhow, bail};
+use std::path::{Path, PathBuf};
+
+use crate::{
+    adapters::acp::util::{expand_tilde, normalize_path},
+    ports::workspace_store::WorkspaceStore,
+};
+
+#[derive(Clone)]
+pub struct ResolveWorkdirUseCase<S>
+where
+    S: WorkspaceStore,
+{
+    store: S,
+}
+
+impl<S> ResolveWorkdirUseCase<S>
+where
+    S: WorkspaceStore,
+{
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    pub async fn execute(
+        self,
+        workspace_id: Option<&str>,
+        checkout_id: Option<&str>,
+        cwd: Option<&str>,
+    ) -> Result<Option<PathBuf>> {
+        let Some(workspace_id) = workspace_id.filter(|value| !value.trim().is_empty()) else {
+            return Ok(cwd.map(|value| expand_tilde(value)));
+        };
+        let workspace = self
+            .store
+            .get_workspace(workspace_id)
+            .await?
+            .ok_or_else(|| anyhow!("workspace not found: {workspace_id}"))?;
+
+        let checkout_id = checkout_id
+            .filter(|value| !value.trim().is_empty())
+            .or(workspace.default_checkout_id.as_deref())
+            .ok_or_else(|| anyhow!("workspace has no checkout: {workspace_id}"))?;
+
+        let checkout = self
+            .store
+            .get_checkout(checkout_id)
+            .await?
+            .ok_or_else(|| anyhow!("checkout not found: {checkout_id}"))?;
+
+        if checkout.workspace_id != workspace.id {
+            bail!("checkout {checkout_id} does not belong to workspace {workspace_id}");
+        }
+
+        let root = checkout.path.canonicalize()?;
+        let requested = cwd
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(expand_tilde)
+            .unwrap_or_else(|| root.clone());
+        let target = if requested.is_absolute() {
+            requested
+        } else {
+            root.join(requested)
+        };
+        if !target.exists() {
+            bail!("working directory does not exist: {}", target.display());
+        }
+        let resolved = normalize_path(Path::new(&target))?;
+        if resolved != root && !resolved.starts_with(&root) {
+            bail!(
+                "working directory must be inside checkout {}: {}",
+                root.display(),
+                resolved.display()
+            );
+        }
+        Ok(Some(resolved))
+    }
+}

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -306,6 +306,8 @@ mod tests {
         AgentRunRequest {
             goal: "hello".into(),
             agent_id: "agent".into(),
+            workspace_id: None,
+            checkout_id: None,
             cwd: None,
             agent_command: None,
             stdio_buffer_limit_mb: None,

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,3 +1,4 @@
 pub mod agent;
 pub mod events;
 pub mod run;
+pub mod workspace;

--- a/src-tauri/src/domain/run.rs
+++ b/src-tauri/src/domain/run.rs
@@ -6,6 +6,8 @@ use uuid::Uuid;
 pub struct AgentRunRequest {
     pub goal: String,
     pub agent_id: String,
+    pub workspace_id: Option<String>,
+    pub checkout_id: Option<String>,
     pub cwd: Option<String>,
     pub agent_command: Option<String>,
     pub stdio_buffer_limit_mb: Option<usize>,

--- a/src-tauri/src/domain/workspace.rs
+++ b/src-tauri/src/domain/workspace.rs
@@ -1,0 +1,116 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use uuid::Uuid;
+
+pub type WorkspaceId = String;
+pub type CheckoutId = String;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Workspace {
+    pub id: WorkspaceId,
+    pub name: String,
+    pub origin: GitOrigin,
+    pub default_checkout_id: Option<CheckoutId>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitOrigin {
+    pub raw_url: String,
+    pub canonical_url: String,
+    pub host: String,
+    pub owner: String,
+    pub repo: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceCheckout {
+    pub id: CheckoutId,
+    pub workspace_id: WorkspaceId,
+    pub path: PathBuf,
+    pub kind: CheckoutKind,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+    pub is_default: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum CheckoutKind {
+    Clone,
+    Worktree,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisteredWorkspace {
+    pub workspace: Workspace,
+    pub checkout: WorkspaceCheckout,
+}
+
+impl Workspace {
+    pub fn from_origin(origin: GitOrigin) -> Self {
+        let now = timestamp();
+        Self {
+            id: workspace_id(&origin.canonical_url),
+            name: origin.repo.clone(),
+            origin,
+            default_checkout_id: None,
+            created_at: now.clone(),
+            updated_at: now,
+        }
+    }
+}
+
+impl WorkspaceCheckout {
+    pub fn new(
+        workspace_id: WorkspaceId,
+        canonical_origin: &str,
+        path: PathBuf,
+        branch: Option<String>,
+        head_sha: Option<String>,
+        is_default: bool,
+    ) -> Self {
+        Self {
+            id: checkout_id(canonical_origin, &path),
+            workspace_id,
+            path,
+            kind: CheckoutKind::Clone,
+            branch,
+            head_sha,
+            is_default,
+        }
+    }
+}
+
+pub fn workspace_id(canonical_origin: &str) -> WorkspaceId {
+    format!("ws_{}", deterministic_id(canonical_origin))
+}
+
+pub fn checkout_id(canonical_origin: &str, path: &PathBuf) -> CheckoutId {
+    format!(
+        "co_{}",
+        deterministic_id(&format!("{}:{}", canonical_origin, path.display()))
+    )
+}
+
+pub fn timestamp() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    format!("{secs}")
+}
+
+fn deterministic_id(value: &str) -> String {
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, value.as_bytes())
+        .simple()
+        .to_string()
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,8 +6,9 @@ mod ports;
 use adapters::{
     session_registry::AppState,
     tauri::commands::{
-        cancel_agent_run, list_agents, load_goal_file, respond_agent_permission, send_prompt_to_run,
-        start_agent_run,
+        cancel_agent_run, list_agents, list_workspace_checkouts, list_workspaces, load_goal_file,
+        refresh_workspace_checkout, register_workspace_from_path, remove_workspace,
+        resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run, start_agent_run,
     },
 };
 
@@ -21,7 +22,13 @@ pub fn run() {
             start_agent_run,
             send_prompt_to_run,
             cancel_agent_run,
-            respond_agent_permission
+            respond_agent_permission,
+            list_workspaces,
+            register_workspace_from_path,
+            remove_workspace,
+            list_workspace_checkouts,
+            refresh_workspace_checkout,
+            resolve_workspace_workdir
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -5,3 +5,4 @@ pub mod permission;
 pub mod session_handle;
 pub mod session_launcher;
 pub mod session_registry;
+pub mod workspace_store;

--- a/src-tauri/src/ports/workspace_store.rs
+++ b/src-tauri/src/ports/workspace_store.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use std::future::Future;
+
+use crate::domain::workspace::{CheckoutId, Workspace, WorkspaceCheckout, WorkspaceId};
+
+pub trait WorkspaceStore: Clone + Send + Sync + 'static {
+    fn list_workspaces(&self) -> impl Future<Output = Result<Vec<Workspace>>> + Send;
+
+    fn get_workspace(&self, id: &str) -> impl Future<Output = Result<Option<Workspace>>> + Send;
+
+    fn list_checkouts(
+        &self,
+        workspace_id: &str,
+    ) -> impl Future<Output = Result<Vec<WorkspaceCheckout>>> + Send;
+
+    fn get_checkout(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = Result<Option<WorkspaceCheckout>>> + Send;
+
+    fn remove_workspace(
+        &self,
+        workspace_id: &WorkspaceId,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    fn refresh_checkout(
+        &self,
+        checkout_id: &CheckoutId,
+    ) -> impl Future<Output = Result<Option<WorkspaceCheckout>>> + Send;
+}

--- a/src/entities/message/model.ts
+++ b/src/entities/message/model.ts
@@ -2,6 +2,8 @@ export type AgentRunRequest = {
   runId?: string;
   goal: string;
   agentId: string;
+  workspaceId?: string;
+  checkoutId?: string;
   cwd?: string;
   agentCommand?: string;
   stdioBufferLimitMb?: number;

--- a/src/entities/workspace/index.ts
+++ b/src/entities/workspace/index.ts
@@ -1,0 +1,1 @@
+export type { GitOrigin, RegisteredWorkspace, Workspace, WorkspaceCheckout } from "./model";

--- a/src/entities/workspace/model.ts
+++ b/src/entities/workspace/model.ts
@@ -1,0 +1,31 @@
+export type GitOrigin = {
+  rawUrl: string;
+  canonicalUrl: string;
+  host: string;
+  owner: string;
+  repo: string;
+};
+
+export type Workspace = {
+  id: string;
+  name: string;
+  origin: GitOrigin;
+  defaultCheckoutId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type WorkspaceCheckout = {
+  id: string;
+  workspaceId: string;
+  path: string;
+  kind: "clone" | "worktree";
+  branch?: string | null;
+  headSha?: string | null;
+  isDefault: boolean;
+};
+
+export type RegisteredWorkspace = {
+  workspace: Workspace;
+  checkout: WorkspaceCheckout;
+};

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -1,5 +1,6 @@
 import type { AgentDescriptor } from "../../entities/agent";
 import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message";
+import type { RegisteredWorkspace, Workspace, WorkspaceCheckout } from "../../entities/workspace";
 import { invokeCommand, listenEvent } from "../../shared/api";
 
 export function listAgents() {
@@ -20,4 +21,28 @@ export function sendPromptToRun(runId: string, prompt: string) {
 
 export function listenRunEvents(callback: (event: RunEventEnvelope) => void) {
   return listenEvent<RunEventEnvelope>("agent-run-event", callback);
+}
+
+export function listWorkspaces() {
+  return invokeCommand<Workspace[]>("list_workspaces");
+}
+
+export function registerWorkspaceFromPath(path: string) {
+  return invokeCommand<RegisteredWorkspace>("register_workspace_from_path", { path });
+}
+
+export function listWorkspaceCheckouts(workspaceId: string) {
+  return invokeCommand<WorkspaceCheckout[]>("list_workspace_checkouts", { workspaceId });
+}
+
+export function refreshWorkspaceCheckout(checkoutId: string) {
+  return invokeCommand<WorkspaceCheckout | null>("refresh_workspace_checkout", { checkoutId });
+}
+
+export function resolveWorkspaceWorkdir(args: {
+  workspaceId?: string | null;
+  checkoutId?: string | null;
+  cwd?: string | null;
+}) {
+  return invokeCommand<string | null>("resolve_workspace_workdir", args);
 }

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -3,9 +3,23 @@ export {
   activateWorkbenchTab,
   closeWorkbenchTab,
   createWorkbenchTab,
+  setTabWorkdir,
+  setTabWorkspace,
+  setWorkbenchWorkspaces,
+  setWorkspaceCheckouts,
+  setWorkspaceError,
+  upsertWorkspaceRegistration,
   useActiveTabId,
   useTabList,
+  useWorkspaceState,
   type WorkbenchTabListItem,
 } from "./tabApi";
 export { useAgentRun } from "./useAgentRun";
 export { type FollowUpQueueItem } from "./model";
+export {
+  listWorkspaceCheckouts,
+  listWorkspaces,
+  refreshWorkspaceCheckout,
+  registerWorkspaceFromPath,
+  resolveWorkspaceWorkdir,
+} from "./api";

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { toTimelineItem, type EventGroup, type RunEvent, type TimelineItem } from "../../entities/message";
+import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
 
@@ -13,6 +14,8 @@ export type FollowUpQueueItem = {
 export type TabState = {
   id: string;
   title: string;
+  workspaceId: string | null;
+  checkoutId: string | null;
   selectedAgentId: string;
   goal: string;
   cwd: string;
@@ -35,14 +38,23 @@ export type TabState = {
 };
 
 type WorkbenchState = {
+  workspaces: Workspace[];
+  checkoutsByWorkspaceId: Record<string, WorkspaceCheckout[]>;
+  workspaceError: string | null;
   tabs: TabState[];
   activeTabId: string;
+  setWorkspaces: (workspaces: Workspace[]) => void;
+  setWorkspaceCheckouts: (workspaceId: string, checkouts: WorkspaceCheckout[]) => void;
+  upsertWorkspaceRegistration: (workspace: Workspace, checkout: WorkspaceCheckout) => void;
+  setWorkspaceError: (error: string | null) => void;
   addTab: (preset?: Partial<TabState>) => string;
   closeTab: (tabId: string) => string | null;
   forceCloseTab: (tabId: string) => string | null;
   activateTab: (tabId: string) => void;
   renameTab: (tabId: string, title: string) => void;
   patchTab: (tabId: string, patch: Partial<TabState>) => void;
+  setTabWorkspace: (tabId: string, workspaceId: string | null, checkoutId?: string | null) => void;
+  setTabWorkdir: (tabId: string, workdir: string) => void;
   enqueueFollowUp: (tabId: string, text: string) => void;
   removeFollowUp: (tabId: string, id: string) => void;
   dequeueFollowUp: (tabId: string) => FollowUpQueueItem | undefined;
@@ -65,6 +77,8 @@ export function createTabState(preset: Partial<TabState> = {}, index = 0): TabSt
   return {
     id: preset.id ?? createId("tab"),
     title: preset.title ?? defaultTabTitle(index),
+    workspaceId: preset.workspaceId ?? null,
+    checkoutId: preset.checkoutId ?? null,
     selectedAgentId: preset.selectedAgentId ?? "claude-code",
     goal: preset.goal ?? defaultGoal,
     cwd: preset.cwd ?? "~/tmp/acp-tauri-agent-workspace",
@@ -115,12 +129,61 @@ function mergeStreamedText(items: TimelineItem[], item: TimelineItem): TimelineI
 const initialTab = createTabState({}, 0);
 
 export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
+  workspaces: [],
+  checkoutsByWorkspaceId: {},
+  workspaceError: null,
   tabs: [initialTab],
   activeTabId: initialTab.id,
 
+  setWorkspaces: (workspaces) =>
+    set((state) => {
+      const knownIds = new Set(workspaces.map((workspace) => workspace.id));
+      return {
+        workspaces,
+        checkoutsByWorkspaceId: Object.fromEntries(
+          Object.entries(state.checkoutsByWorkspaceId).filter(([workspaceId]) =>
+            knownIds.has(workspaceId),
+          ),
+        ),
+      };
+    }),
+
+  setWorkspaceCheckouts: (workspaceId, checkouts) =>
+    set((state) => ({
+      checkoutsByWorkspaceId: {
+        ...state.checkoutsByWorkspaceId,
+        [workspaceId]: checkouts,
+      },
+    })),
+
+  upsertWorkspaceRegistration: (workspace, checkout) =>
+    set((state) => {
+      const workspaces = upsertItem(state.workspaces, workspace, (entry) => entry.id);
+      const currentCheckouts = state.checkoutsByWorkspaceId[workspace.id] ?? [];
+      return {
+        workspaces,
+        checkoutsByWorkspaceId: {
+          ...state.checkoutsByWorkspaceId,
+          [workspace.id]: upsertItem(currentCheckouts, checkout, (entry) => entry.id),
+        },
+        workspaceError: null,
+      };
+    }),
+
+  setWorkspaceError: (workspaceError) => set({ workspaceError }),
+
   addTab: (preset) => {
     const state = get();
-    const tab = createTabState(preset, state.tabs.length);
+    const activeTab = state.tabs.find((entry) => entry.id === state.activeTabId);
+    const tab = createTabState(
+      {
+        workspaceId: activeTab?.workspaceId ?? null,
+        checkoutId: activeTab?.checkoutId ?? null,
+        cwd: activeTab?.cwd,
+        ...preset,
+      },
+      state.tabs.length,
+    );
     set({ tabs: [...state.tabs, tab], activeTabId: tab.id });
     return tab.id;
   },
@@ -192,6 +255,33 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
   patchTab: (tabId, patch) =>
     set((state) => ({
       tabs: replaceTab(state.tabs, tabId, (tab) => ({ ...tab, ...patch })),
+    })),
+
+  setTabWorkspace: (tabId, workspaceId, checkoutId) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => {
+        const nextWorkspaceId = workspaceId;
+        const checkouts = nextWorkspaceId
+          ? (state.checkoutsByWorkspaceId[nextWorkspaceId] ?? [])
+          : [];
+        const selectedCheckout =
+          checkoutId ??
+          checkouts.find((entry) => entry.isDefault)?.id ??
+          checkouts[0]?.id ??
+          null;
+        const checkout = checkouts.find((entry) => entry.id === selectedCheckout);
+        return {
+          ...tab,
+          workspaceId: nextWorkspaceId,
+          checkoutId: selectedCheckout,
+          cwd: checkout?.path ?? tab.cwd,
+        };
+      }),
+    })),
+
+  setTabWorkdir: (tabId, workdir) =>
+    set((state) => ({
+      tabs: replaceTab(state.tabs, tabId, (tab) => ({ ...tab, cwd: workdir })),
     })),
 
   enqueueFollowUp: (tabId, text) =>
@@ -353,4 +443,11 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
 
 export function selectTab(state: WorkbenchState, tabId: string): TabState | undefined {
   return state.tabs.find((t) => t.id === tabId);
+}
+
+function upsertItem<T>(items: T[], item: T, getId: (item: T) => string): T[] {
+  const id = getId(item);
+  const index = items.findIndex((entry) => getId(entry) === id);
+  if (index === -1) return [...items, item];
+  return [...items.slice(0, index), item, ...items.slice(index + 1)];
 }

--- a/src/features/agent-run/tabApi.ts
+++ b/src/features/agent-run/tabApi.ts
@@ -1,3 +1,4 @@
+import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
 import { useWorkbenchStore, type TabState } from "./model";
 import { closeWorkbenchTab } from "./tabActions";
 
@@ -7,6 +8,9 @@ export type WorkbenchTabListItem = Readonly<
     | "id"
     | "title"
     | "goal"
+    | "workspaceId"
+    | "checkoutId"
+    | "cwd"
     | "sessionActive"
     | "awaitingResponse"
     | "idleRemainingSec"
@@ -34,3 +38,64 @@ export function activateWorkbenchTab(tabId: string) {
 }
 
 export { closeWorkbenchTab };
+
+export function useWorkspaceState(tabId: string) {
+  return useWorkbenchStore((state) => {
+    const tab = state.tabs.find((entry) => entry.id === tabId);
+    const selectedWorkspace = state.workspaces.find((entry) => entry.id === tab?.workspaceId);
+    const checkouts = tab?.workspaceId
+      ? (state.checkoutsByWorkspaceId[tab.workspaceId] ?? [])
+      : [];
+    const selectedCheckout = checkouts.find((entry) => entry.id === tab?.checkoutId);
+    const activeSameWorkdirCount = tab
+      ? state.tabs.filter(
+          (entry) =>
+            entry.id !== tab.id &&
+            entry.sessionActive &&
+            entry.workspaceId === tab.workspaceId &&
+            entry.checkoutId === tab.checkoutId &&
+            entry.cwd === tab.cwd,
+        ).length
+      : 0;
+
+    return {
+      workspaces: state.workspaces,
+      checkouts,
+      selectedWorkspace,
+      selectedCheckout,
+      workspaceId: tab?.workspaceId ?? null,
+      checkoutId: tab?.checkoutId ?? null,
+      workdir: tab?.cwd ?? "",
+      workspaceError: state.workspaceError,
+      activeSameWorkdirCount,
+    };
+  });
+}
+
+export function setWorkbenchWorkspaces(workspaces: Workspace[]) {
+  useWorkbenchStore.getState().setWorkspaces(workspaces);
+}
+
+export function setWorkspaceCheckouts(workspaceId: string, checkouts: WorkspaceCheckout[]) {
+  useWorkbenchStore.getState().setWorkspaceCheckouts(workspaceId, checkouts);
+}
+
+export function upsertWorkspaceRegistration(workspace: Workspace, checkout: WorkspaceCheckout) {
+  useWorkbenchStore.getState().upsertWorkspaceRegistration(workspace, checkout);
+}
+
+export function setWorkspaceError(error: string | null) {
+  useWorkbenchStore.getState().setWorkspaceError(error);
+}
+
+export function setTabWorkspace(
+  tabId: string,
+  workspaceId: string | null,
+  checkoutId?: string | null,
+) {
+  useWorkbenchStore.getState().setTabWorkspace(tabId, workspaceId, checkoutId);
+}
+
+export function setTabWorkdir(tabId: string, workdir: string) {
+  useWorkbenchStore.getState().setTabWorkdir(tabId, workdir);
+}

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -52,6 +52,27 @@ export function useAgentRun(tabId: string) {
       patch({ error: "Goal is empty." });
       return;
     }
+    const sameWorkdirRuns = useWorkbenchStore
+      .getState()
+      .tabs.filter(
+        (entry) =>
+          entry.id !== current.id &&
+          entry.sessionActive &&
+          entry.workspaceId === current.workspaceId &&
+          entry.checkoutId === current.checkoutId &&
+          entry.cwd === current.cwd,
+      ).length;
+    if (
+      sameWorkdirRuns > 0 &&
+      current.workspaceId &&
+      !window.confirm(
+        `There ${sameWorkdirRuns === 1 ? "is" : "are"} ${sameWorkdirRuns} active run${
+          sameWorkdirRuns === 1 ? "" : "s"
+        } in this working directory. Start another run anyway?`,
+      )
+    ) {
+      return;
+    }
     const runId = crypto.randomUUID();
     useWorkbenchStore.getState().beginRun(tabId, runId);
 
@@ -59,6 +80,8 @@ export function useAgentRun(tabId: string) {
       runId,
       goal: trimmedGoal,
       agentId: current.selectedAgentId,
+      workspaceId: current.workspaceId ?? undefined,
+      checkoutId: current.checkoutId ?? undefined,
       cwd: current.cwd.trim() || undefined,
       agentCommand: current.customCommand.trim() || undefined,
       stdioBufferLimitMb: Math.min(512, Math.max(1, current.stdioBufferLimitMb || 50)),
@@ -134,6 +157,8 @@ export function useAgentRun(tabId: string) {
     agents,
     agentsLoading: agentsQuery.isLoading,
     selectedAgent,
+    workspaceId: tab?.workspaceId ?? null,
+    checkoutId: tab?.checkoutId ?? null,
     selectedAgentId: tab?.selectedAgentId ?? "",
     setSelectedAgentId,
     goal: tab?.goal ?? "",

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -5,6 +5,7 @@ import { FollowUpComposer } from "../../widgets/follow-up-composer";
 import { FollowUpQueue } from "../../widgets/follow-up-queue";
 import { RunPanel } from "../../widgets/run-panel";
 import { TabBar } from "../../widgets/workbench-tabs";
+import { WorkspaceBar } from "../../widgets/workspace-bar";
 
 export function AgentWorkbenchPage() {
   const activeTabId = useActiveTabId();
@@ -28,6 +29,7 @@ export function AgentWorkbenchPage() {
         ) : null}
       </header>
 
+      <WorkspaceBar tabId={activeTabId} disabled={state.sessionActive} />
       <TabBar />
 
       <div className="grid min-h-0 flex-1 grid-cols-[minmax(360px,0.43fr)_minmax(520px,1fr)] items-stretch gap-4 max-lg:grid-cols-1">

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -75,7 +75,7 @@ export function RunPanel({
         </label>
 
         <label className="grid gap-2">
-          <span className="text-sm font-medium">Workspace</span>
+          <span className="text-sm font-medium">Working directory</span>
           <Input value={cwd} onChange={(event) => onCwdChange(event.target.value)} />
         </label>
 

--- a/src/widgets/workspace-bar/WorkspaceBar.tsx
+++ b/src/widgets/workspace-bar/WorkspaceBar.tsx
@@ -1,0 +1,203 @@
+import { FolderGit2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  listWorkspaceCheckouts,
+  listWorkspaces,
+  registerWorkspaceFromPath,
+  setTabWorkdir,
+  setTabWorkspace,
+  setWorkbenchWorkspaces,
+  setWorkspaceCheckouts,
+  setWorkspaceError,
+  upsertWorkspaceRegistration,
+  useWorkspaceState,
+} from "../../features/agent-run";
+import { Badge, Button, Input, NativeSelect } from "../../shared/ui";
+
+type WorkspaceBarProps = {
+  tabId: string;
+  disabled?: boolean;
+};
+
+export function WorkspaceBar({ tabId, disabled = false }: WorkspaceBarProps) {
+  const state = useWorkspaceState(tabId);
+  const [repoPath, setRepoPath] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const selectedWorkspaceId = state.workspaceId ?? "";
+  const selectedCheckoutId = state.checkoutId ?? "";
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const workspaces = await listWorkspaces();
+      setWorkbenchWorkspaces(workspaces);
+      await Promise.all(
+        workspaces.map(async (workspace) => {
+          const checkouts = await listWorkspaceCheckouts(workspace.id);
+          setWorkspaceCheckouts(workspace.id, checkouts);
+        }),
+      );
+      setWorkspaceError(null);
+    } catch (err) {
+      setWorkspaceError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const checkoutOptions = state.checkouts;
+  const workdirPlaceholder = useMemo(
+    () => state.selectedCheckout?.path ?? "Select a workspace checkout",
+    [state.selectedCheckout?.path],
+  );
+
+  const handleRegister = useCallback(async () => {
+    const trimmed = repoPath.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    try {
+      const registered = await registerWorkspaceFromPath(trimmed);
+      upsertWorkspaceRegistration(registered.workspace, registered.checkout);
+      setTabWorkspace(tabId, registered.workspace.id, registered.checkout.id);
+      setTabWorkdir(tabId, registered.checkout.path);
+      setRepoPath("");
+      setWorkspaceError(null);
+    } catch (err) {
+      setWorkspaceError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [repoPath, tabId]);
+
+  const handleWorkspaceChange = useCallback(
+    async (workspaceId: string) => {
+      if (!workspaceId) {
+        setTabWorkspace(tabId, null, null);
+        return;
+      }
+      try {
+        const checkouts = await listWorkspaceCheckouts(workspaceId);
+        setWorkspaceCheckouts(workspaceId, checkouts);
+        const checkout = checkouts.find((entry) => entry.isDefault) ?? checkouts[0];
+        setTabWorkspace(tabId, workspaceId, checkout?.id ?? null);
+      } catch (err) {
+        setWorkspaceError(String(err));
+      }
+    },
+    [tabId],
+  );
+
+  const handleCheckoutChange = useCallback(
+    (checkoutId: string) => {
+      const checkout = checkoutOptions.find((entry) => entry.id === checkoutId);
+      setTabWorkspace(tabId, selectedWorkspaceId || null, checkoutId || null);
+      if (checkout) setTabWorkdir(tabId, checkout.path);
+    },
+    [checkoutOptions, selectedWorkspaceId, tabId],
+  );
+
+  return (
+    <section className="mb-4 grid gap-3 rounded-lg border bg-card/80 p-3 shadow-sm">
+      <div className="grid grid-cols-[minmax(180px,0.8fr)_minmax(180px,0.8fr)_minmax(240px,1.2fr)] gap-3 max-lg:grid-cols-1">
+        <label className="grid gap-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Workspace
+          </span>
+          <NativeSelect
+            value={selectedWorkspaceId}
+            disabled={disabled || loading}
+            onChange={(event) => void handleWorkspaceChange(event.target.value)}
+          >
+            <option value="">Legacy working directory</option>
+            {state.workspaces.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>
+                {workspace.name} ({workspace.origin.owner}/{workspace.origin.repo})
+              </option>
+            ))}
+          </NativeSelect>
+        </label>
+
+        <label className="grid gap-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Checkout
+          </span>
+          <NativeSelect
+            value={selectedCheckoutId}
+            disabled={disabled || loading || !selectedWorkspaceId}
+            onChange={(event) => handleCheckoutChange(event.target.value)}
+          >
+            <option value="">Default checkout</option>
+            {checkoutOptions.map((checkout) => (
+              <option key={checkout.id} value={checkout.id}>
+                {checkout.branch || "detached"} · {checkout.path}
+              </option>
+            ))}
+          </NativeSelect>
+        </label>
+
+        <label className="grid gap-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Working Directory
+          </span>
+          <Input
+            value={state.workdir}
+            placeholder={workdirPlaceholder}
+            disabled={disabled}
+            onChange={(event) => setTabWorkdir(tabId, event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-[minmax(260px,1fr)_auto_auto] items-center gap-2 max-lg:grid-cols-1">
+        <Input
+          value={repoPath}
+          disabled={disabled || loading}
+          placeholder="Register local GitHub repo path"
+          onChange={(event) => setRepoPath(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") void handleRegister();
+          }}
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          icon={<FolderGit2 size={16} />}
+          disabled={disabled || loading || !repoPath.trim()}
+          onClick={() => void handleRegister()}
+        >
+          Register
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          icon={<RefreshCw size={16} />}
+          disabled={loading}
+          onClick={() => void load()}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      <div className="flex min-h-6 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        {state.selectedWorkspace ? (
+          <span>{state.selectedWorkspace.origin.canonicalUrl}</span>
+        ) : (
+          <span>Runs without a selected workspace use the working directory directly.</span>
+        )}
+        {state.activeSameWorkdirCount > 0 ? (
+          <Badge variant="secondary">
+            shared directory +{state.activeSameWorkdirCount}
+          </Badge>
+        ) : null}
+        {state.workspaceError ? (
+          <span className="font-medium text-destructive">{state.workspaceError}</span>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/widgets/workspace-bar/index.ts
+++ b/src/widgets/workspace-bar/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceBar } from "./WorkspaceBar";


### PR DESCRIPTION
## Summary
- add an origin-based Workspace/Checkout domain model, GitHub origin resolver, JSON metadata store, and Tauri workspace commands
- resolve workspace-backed run directories before starting an agent run and reject paths outside the selected checkout
- add frontend workspace entities, store state, workspace bar UI, tab workspace binding, and shared-directory run warning
- document the workspace rollout plan in docs/workspace-plan.md

## Verification
- cargo test
- npm run build
- npm test
- npm run check:fsd
