### PR TITLE
Store workspaces in SQLite

### DIFF
--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -7,4 +7,6 @@ pub mod session_registry;
 pub mod sqlite;
 pub mod storage_state;
 pub mod tauri;
+#[allow(dead_code)]
 pub mod workspace_store;
+pub mod workspace_store_sqlite;

--- a/src-tauri/src/adapters/storage_state.rs
+++ b/src-tauri/src/adapters/storage_state.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 use std::path::PathBuf;
 
-use crate::adapters::sqlite::open_database;
+use crate::adapters::{sqlite::open_database, workspace_store_sqlite::SqliteWorkspaceStore};
 
 #[derive(Clone)]
-#[allow(dead_code)]
 pub struct StorageState {
     pool: SqlitePool,
+    #[allow(dead_code)]
     app_data_dir: PathBuf,
 }
 
@@ -17,7 +17,6 @@ impl StorageState {
         Ok(Self { pool, app_data_dir })
     }
 
-    #[allow(dead_code)]
     pub fn pool(&self) -> SqlitePool {
         self.pool.clone()
     }
@@ -25,5 +24,9 @@ impl StorageState {
     #[allow(dead_code)]
     pub fn app_data_dir(&self) -> PathBuf {
         self.app_data_dir.clone()
+    }
+
+    pub fn workspace_store(&self) -> SqliteWorkspaceStore {
+        SqliteWorkspaceStore::new(self.pool())
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,10 +1,10 @@
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, State};
 
 use crate::{
     adapters::{
         acp::runner::AcpAgentRunner, agent_catalog::ConfigurableAgentCatalog,
-        fs::LocalGoalFileReader, session_registry::AppState, tauri::event_sink::TauriRunEventSink,
-        workspace_store::LocalWorkspaceStore,
+        fs::LocalGoalFileReader, session_registry::AppState, storage_state::StorageState,
+        tauri::event_sink::TauriRunEventSink,
     },
     application::{
         cancel_agent_run::CancelAgentRunUseCase, list_agents::ListAgentsUseCase,
@@ -36,9 +36,10 @@ pub fn load_goal_file(path: String) -> Result<String, String> {
 pub async fn start_agent_run(
     app: AppHandle,
     state: State<'_, AppState>,
+    storage: State<'_, StorageState>,
     mut request: AgentRunRequest,
 ) -> Result<AgentRun, String> {
-    let workspace_store = workspace_store(&app)?;
+    let workspace_store = storage.workspace_store();
     let resolved_cwd = ResolveWorkdirUseCase::new(workspace_store)
         .execute(
             request.workspace_id.as_deref(),
@@ -104,8 +105,9 @@ pub async fn respond_agent_permission(
 }
 
 #[tauri::command]
-pub async fn list_workspaces(app: AppHandle) -> Result<Vec<Workspace>, String> {
-    workspace_store(&app)?
+pub async fn list_workspaces(storage: State<'_, StorageState>) -> Result<Vec<Workspace>, String> {
+    storage
+        .workspace_store()
         .list_workspaces()
         .await
         .map_err(|err| err.to_string())
@@ -113,18 +115,23 @@ pub async fn list_workspaces(app: AppHandle) -> Result<Vec<Workspace>, String> {
 
 #[tauri::command]
 pub async fn register_workspace_from_path(
-    app: AppHandle,
+    storage: State<'_, StorageState>,
     path: String,
 ) -> Result<RegisteredWorkspace, String> {
-    workspace_store(&app)?
+    storage
+        .workspace_store()
         .register_from_path(&path)
         .await
         .map_err(|err| err.to_string())
 }
 
 #[tauri::command]
-pub async fn remove_workspace(app: AppHandle, workspace_id: String) -> Result<(), String> {
-    workspace_store(&app)?
+pub async fn remove_workspace(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+) -> Result<(), String> {
+    storage
+        .workspace_store()
         .remove_workspace(&workspace_id)
         .await
         .map_err(|err| err.to_string())
@@ -132,10 +139,11 @@ pub async fn remove_workspace(app: AppHandle, workspace_id: String) -> Result<()
 
 #[tauri::command]
 pub async fn list_workspace_checkouts(
-    app: AppHandle,
+    storage: State<'_, StorageState>,
     workspace_id: String,
 ) -> Result<Vec<WorkspaceCheckout>, String> {
-    workspace_store(&app)?
+    storage
+        .workspace_store()
         .list_checkouts(&workspace_id)
         .await
         .map_err(|err| err.to_string())
@@ -143,10 +151,11 @@ pub async fn list_workspace_checkouts(
 
 #[tauri::command]
 pub async fn refresh_workspace_checkout(
-    app: AppHandle,
+    storage: State<'_, StorageState>,
     checkout_id: String,
 ) -> Result<Option<WorkspaceCheckout>, String> {
-    workspace_store(&app)?
+    storage
+        .workspace_store()
         .refresh_checkout(&checkout_id)
         .await
         .map_err(|err| err.to_string())
@@ -154,12 +163,12 @@ pub async fn refresh_workspace_checkout(
 
 #[tauri::command]
 pub async fn resolve_workspace_workdir(
-    app: AppHandle,
+    storage: State<'_, StorageState>,
     workspace_id: Option<String>,
     checkout_id: Option<String>,
     cwd: Option<String>,
 ) -> Result<Option<String>, String> {
-    ResolveWorkdirUseCase::new(workspace_store(&app)?)
+    ResolveWorkdirUseCase::new(storage.workspace_store())
         .execute(
             workspace_id.as_deref(),
             checkout_id.as_deref(),
@@ -168,9 +177,4 @@ pub async fn resolve_workspace_workdir(
         .await
         .map(|path| path.map(|value| value.to_string_lossy().to_string()))
         .map_err(|err| err.to_string())
-}
-
-fn workspace_store(app: &AppHandle) -> Result<LocalWorkspaceStore, String> {
-    let app_data_dir = app.path().app_data_dir().map_err(|err| err.to_string())?;
-    Ok(LocalWorkspaceStore::new(app_data_dir))
 }

--- a/src-tauri/src/adapters/workspace_store_sqlite.rs
+++ b/src-tauri/src/adapters/workspace_store_sqlite.rs
@@ -1,0 +1,258 @@
+use anyhow::{Result, anyhow};
+use sqlx::{Row, SqlitePool};
+use std::path::PathBuf;
+
+use crate::{
+    adapters::git::GitRepository,
+    domain::workspace::{
+        CheckoutId, CheckoutKind, GitOrigin, RegisteredWorkspace, Workspace, WorkspaceCheckout,
+        WorkspaceId, timestamp,
+    },
+    ports::workspace_store::WorkspaceStore,
+};
+
+#[derive(Clone)]
+pub struct SqliteWorkspaceStore {
+    pool: SqlitePool,
+}
+
+impl SqliteWorkspaceStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn register_from_path(&self, path: &str) -> Result<RegisteredWorkspace> {
+        let repo = GitRepository::from_path(path)?;
+        let mut workspace = Workspace::from_origin(repo.origin.clone());
+        let checkout = WorkspaceCheckout::new(
+            workspace.id.clone(),
+            &repo.origin.canonical_url,
+            repo.root,
+            repo.branch,
+            repo.head_sha,
+            true,
+        );
+
+        if let Some(existing) = self.get_workspace(&workspace.id).await? {
+            workspace.created_at = existing.created_at;
+            workspace.default_checkout_id = existing
+                .default_checkout_id
+                .or_else(|| Some(checkout.id.clone()));
+        } else {
+            workspace.default_checkout_id = Some(checkout.id.clone());
+        }
+        workspace.updated_at = timestamp();
+
+        let mut tx = self.pool.begin().await?;
+        upsert_workspace(&mut tx, &workspace).await?;
+        upsert_checkout(&mut tx, &checkout).await?;
+        tx.commit().await?;
+
+        Ok(RegisteredWorkspace {
+            workspace,
+            checkout,
+        })
+    }
+}
+
+impl WorkspaceStore for SqliteWorkspaceStore {
+    async fn list_workspaces(&self) -> Result<Vec<Workspace>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, name, raw_origin_url, canonical_origin_url, host, owner, repo,
+                   default_checkout_id, created_at, updated_at
+            FROM workspaces
+            ORDER BY updated_at DESC, name ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(workspace_from_row).collect()
+    }
+
+    async fn get_workspace(&self, id: &str) -> Result<Option<Workspace>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, name, raw_origin_url, canonical_origin_url, host, owner, repo,
+                   default_checkout_id, created_at, updated_at
+            FROM workspaces
+            WHERE id = ?
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(workspace_from_row).transpose()
+    }
+
+    async fn list_checkouts(&self, workspace_id: &str) -> Result<Vec<WorkspaceCheckout>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, workspace_id, path, kind, branch, head_sha, is_default
+            FROM workspace_checkouts
+            WHERE workspace_id = ?
+            ORDER BY is_default DESC, path ASC
+            "#,
+        )
+        .bind(workspace_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(checkout_from_row).collect()
+    }
+
+    async fn get_checkout(&self, id: &str) -> Result<Option<WorkspaceCheckout>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, workspace_id, path, kind, branch, head_sha, is_default
+            FROM workspace_checkouts
+            WHERE id = ?
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(checkout_from_row).transpose()
+    }
+
+    async fn remove_workspace(&self, workspace_id: &WorkspaceId) -> Result<()> {
+        sqlx::query("DELETE FROM workspaces WHERE id = ?")
+            .bind(workspace_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn refresh_checkout(
+        &self,
+        checkout_id: &CheckoutId,
+    ) -> Result<Option<WorkspaceCheckout>> {
+        let Some(mut checkout) = self.get_checkout(checkout_id).await? else {
+            return Ok(None);
+        };
+        let repo = GitRepository::from_path(&checkout.path.to_string_lossy())?;
+        checkout.branch = repo.branch;
+        checkout.head_sha = repo.head_sha;
+        let mut tx = self.pool.begin().await?;
+        upsert_checkout(&mut tx, &checkout).await?;
+        tx.commit().await?;
+        Ok(Some(checkout))
+    }
+}
+
+async fn upsert_workspace(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    workspace: &Workspace,
+) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO workspaces (
+            id, name, raw_origin_url, canonical_origin_url, host, owner, repo,
+            default_checkout_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            raw_origin_url = excluded.raw_origin_url,
+            canonical_origin_url = excluded.canonical_origin_url,
+            host = excluded.host,
+            owner = excluded.owner,
+            repo = excluded.repo,
+            default_checkout_id = excluded.default_checkout_id,
+            updated_at = excluded.updated_at
+        "#,
+    )
+    .bind(&workspace.id)
+    .bind(&workspace.name)
+    .bind(&workspace.origin.raw_url)
+    .bind(&workspace.origin.canonical_url)
+    .bind(&workspace.origin.host)
+    .bind(&workspace.origin.owner)
+    .bind(&workspace.origin.repo)
+    .bind(&workspace.default_checkout_id)
+    .bind(&workspace.created_at)
+    .bind(&workspace.updated_at)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn upsert_checkout(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    checkout: &WorkspaceCheckout,
+) -> Result<()> {
+    let now = timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO workspace_checkouts (
+            id, workspace_id, path, kind, branch, head_sha, is_default, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            workspace_id = excluded.workspace_id,
+            path = excluded.path,
+            kind = excluded.kind,
+            branch = excluded.branch,
+            head_sha = excluded.head_sha,
+            is_default = excluded.is_default,
+            updated_at = excluded.updated_at
+        "#,
+    )
+    .bind(&checkout.id)
+    .bind(&checkout.workspace_id)
+    .bind(checkout.path.to_string_lossy().to_string())
+    .bind(checkout_kind_to_db(&checkout.kind))
+    .bind(&checkout.branch)
+    .bind(&checkout.head_sha)
+    .bind(checkout.is_default)
+    .bind(&now)
+    .bind(&now)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+fn workspace_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Workspace> {
+    Ok(Workspace {
+        id: row.try_get("id")?,
+        name: row.try_get("name")?,
+        origin: GitOrigin {
+            raw_url: row.try_get("raw_origin_url")?,
+            canonical_url: row.try_get("canonical_origin_url")?,
+            host: row.try_get("host")?,
+            owner: row.try_get("owner")?,
+            repo: row.try_get("repo")?,
+        },
+        default_checkout_id: row.try_get("default_checkout_id")?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+    })
+}
+
+fn checkout_from_row(row: sqlx::sqlite::SqliteRow) -> Result<WorkspaceCheckout> {
+    let kind: String = row.try_get("kind")?;
+    let path: String = row.try_get("path")?;
+    Ok(WorkspaceCheckout {
+        id: row.try_get("id")?,
+        workspace_id: row.try_get("workspace_id")?,
+        path: PathBuf::from(path),
+        kind: checkout_kind_from_db(&kind)?,
+        branch: row.try_get("branch")?,
+        head_sha: row.try_get("head_sha")?,
+        is_default: row.try_get("is_default")?,
+    })
+}
+
+fn checkout_kind_to_db(kind: &CheckoutKind) -> &'static str {
+    match kind {
+        CheckoutKind::Clone => "clone",
+        CheckoutKind::Worktree => "worktree",
+    }
+}
+
+fn checkout_kind_from_db(value: &str) -> Result<CheckoutKind> {
+    match value {
+        "clone" => Ok(CheckoutKind::Clone),
+        "worktree" => Ok(CheckoutKind::Worktree),
+        other => Err(anyhow!("unknown checkout kind: {other}")),
+    }
+}


### PR DESCRIPTION
## Summary
- add SqliteWorkspaceStore implementing the existing WorkspaceStore port
- switch workspace-related Tauri commands and run workdir resolution to StorageState
- keep the existing JSON workspace store available for the follow-up migration stack

## Verification
- cargo test

Stacked on #36.
