### PR TITLE
Migrate JSON workspaces to SQLite

### DIFF
--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -9,4 +9,5 @@ pub mod storage_state;
 pub mod tauri;
 #[allow(dead_code)]
 pub mod workspace_store;
+pub mod workspace_store_migration;
 pub mod workspace_store_sqlite;

--- a/src-tauri/src/adapters/storage_state.rs
+++ b/src-tauri/src/adapters/storage_state.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use sqlx::SqlitePool;
 use std::path::PathBuf;
 
-use crate::adapters::{sqlite::open_database, workspace_store_sqlite::SqliteWorkspaceStore};
+use crate::adapters::{
+    sqlite::open_database, workspace_store_migration::migrate_json_workspace_store,
+    workspace_store_sqlite::SqliteWorkspaceStore,
+};
 
 #[derive(Clone)]
 pub struct StorageState {
@@ -14,6 +17,7 @@ pub struct StorageState {
 impl StorageState {
     pub async fn open(app_data_dir: PathBuf) -> Result<Self> {
         let pool = open_database(&app_data_dir).await?;
+        migrate_json_workspace_store(&pool, &app_data_dir).await?;
         Ok(Self { pool, app_data_dir })
     }
 

--- a/src-tauri/src/adapters/workspace_store_migration.rs
+++ b/src-tauri/src/adapters/workspace_store_migration.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use sqlx::SqlitePool;
+use std::path::Path;
+
+use crate::{
+    adapters::{
+        workspace_store::LocalWorkspaceStore, workspace_store_sqlite::SqliteWorkspaceStore,
+    },
+    ports::workspace_store::WorkspaceStore,
+};
+
+const LEGACY_WORKSPACES_FILE: &str = "workspaces.json";
+const MIGRATED_WORKSPACES_FILE: &str = "workspaces.json.migrated";
+
+pub async fn migrate_json_workspace_store(pool: &SqlitePool, app_data_dir: &Path) -> Result<()> {
+    let legacy_path = app_data_dir.join(LEGACY_WORKSPACES_FILE);
+    if !legacy_path.exists() {
+        return Ok(());
+    }
+
+    let sqlite_store = SqliteWorkspaceStore::new(pool.clone());
+    if !sqlite_store.list_workspaces().await?.is_empty() {
+        return Ok(());
+    }
+
+    let json_store = LocalWorkspaceStore::new(app_data_dir.to_path_buf());
+    let workspaces = json_store.list_workspaces().await?;
+    if workspaces.is_empty() {
+        mark_legacy_file_migrated(&legacy_path, app_data_dir).await?;
+        return Ok(());
+    }
+
+    for workspace in workspaces {
+        let checkouts = json_store.list_checkouts(&workspace.id).await?;
+        sqlite_store
+            .import_workspace_with_checkouts(workspace, checkouts)
+            .await?;
+    }
+    mark_legacy_file_migrated(&legacy_path, app_data_dir).await
+}
+
+async fn mark_legacy_file_migrated(legacy_path: &Path, app_data_dir: &Path) -> Result<()> {
+    let migrated_path = app_data_dir.join(MIGRATED_WORKSPACES_FILE);
+    if migrated_path.exists() {
+        tokio::fs::remove_file(&migrated_path).await?;
+    }
+    tokio::fs::rename(legacy_path, migrated_path).await?;
+    Ok(())
+}

--- a/src-tauri/src/adapters/workspace_store_sqlite.rs
+++ b/src-tauri/src/adapters/workspace_store_sqlite.rs
@@ -53,6 +53,20 @@ impl SqliteWorkspaceStore {
             checkout,
         })
     }
+
+    pub async fn import_workspace_with_checkouts(
+        &self,
+        workspace: Workspace,
+        checkouts: Vec<WorkspaceCheckout>,
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        upsert_workspace(&mut tx, &workspace).await?;
+        for checkout in checkouts {
+            upsert_checkout(&mut tx, &checkout).await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
 }
 
 impl WorkspaceStore for SqliteWorkspaceStore {


### PR DESCRIPTION
## Summary
- import legacy workspaces.json into SQLite on storage startup when the database is empty
- preserve migrated JSON data by renaming workspaces.json to workspaces.json.migrated after successful import
- add an import path on SqliteWorkspaceStore for workspace/checkouts migration

## Verification
- cargo test

Stacked on #37.
