### PR TITLE
Specialize start-run reserve errors

### DIFF
--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -4,7 +4,7 @@ use tokio::{sync::Mutex, task::JoinHandle};
 
 use crate::{
     adapters::{acp::runner::AcpSession, permission_broker::PermissionBroker},
-    ports::session_registry::SessionRegistry,
+    ports::session_registry::{ReserveRunError, SessionRegistry},
 };
 
 const MAX_RUNS_ENV: &str = "ACP_WORKBENCH_MAX_RUNS";
@@ -56,16 +56,14 @@ struct RunContext {
 impl SessionRegistry for AppState {
     type Session = AcpSession;
 
-    async fn reserve_run(&self, run_id: String) -> Result<()> {
+    async fn reserve_run(&self, run_id: String) -> Result<(), ReserveRunError> {
         let mut runs = self.runs.lock().await;
         if runs.contains_key(&run_id) {
-            return Err(anyhow!("duplicate run id: {run_id}"));
+            return Err(ReserveRunError::DuplicateRunId { run_id });
         }
         if let Some(limit) = self.max_concurrent_runs {
             if runs.len() >= limit {
-                return Err(anyhow!(
-                    "concurrent run limit ({limit}) reached; cancel an existing run before starting a new one"
-                ));
+                return Err(ReserveRunError::ConcurrentLimit { limit });
             }
         }
         runs.insert(run_id, RunSlot::Reserved);
@@ -92,7 +90,9 @@ impl SessionRegistry for AppState {
                 ctx.session = Some(session);
                 Ok(())
             }
-            _ => Err(anyhow!("agent run was cancelled before session was attached")),
+            _ => Err(anyhow!(
+                "agent run was cancelled before session was attached"
+            )),
         }
     }
 
@@ -123,7 +123,6 @@ impl SessionRegistry for AppState {
         }
         cancelled
     }
-
 }
 
 #[cfg(test)]
@@ -136,7 +135,7 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::AppState;
-    use crate::ports::session_registry::SessionRegistry;
+    use crate::ports::session_registry::{ReserveRunError, SessionRegistry};
 
     #[tokio::test]
     async fn reserve_run_allows_multiple_distinct_run_ids() {
@@ -160,7 +159,12 @@ mod tests {
             .reserve_run("run-a".into())
             .await
             .expect_err("duplicate reservation must fail");
-        assert!(err.to_string().contains("duplicate run id"));
+        assert_eq!(
+            err,
+            ReserveRunError::DuplicateRunId {
+                run_id: "run-a".into()
+            }
+        );
     }
 
     #[tokio::test]
@@ -182,7 +186,7 @@ mod tests {
             .reserve_run("run-b".into())
             .await
             .expect_err("second run should be rejected by the limit");
-        assert!(err.to_string().contains("concurrent run limit"));
+        assert_eq!(err, ReserveRunError::ConcurrentLimit { limit: 1 });
         assert!(state.cancel_run("run-a").await);
         state
             .reserve_run("run-b".into())
@@ -198,6 +202,11 @@ mod tests {
             .reserve_run("run-a".into())
             .await
             .expect_err("duplicate id must fail");
-        assert!(err.to_string().contains("duplicate run id"));
+        assert_eq!(
+            err,
+            ReserveRunError::DuplicateRunId {
+                run_id: "run-a".into()
+            }
+        );
     }
 }

--- a/src-tauri/src/application/cancel_agent_run.rs
+++ b/src-tauri/src/application/cancel_agent_run.rs
@@ -45,7 +45,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ports::session_registry::SessionRegistry;
+    use crate::ports::session_registry::{ReserveRunError, SessionRegistry};
     use anyhow::Result;
     use std::sync::{Arc, Mutex as StdMutex};
     use tokio::sync::Mutex;
@@ -62,7 +62,7 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, _: String) -> Result<()> {
+        async fn reserve_run(&self, _: String) -> Result<(), ReserveRunError> {
             Ok(())
         }
         async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {

--- a/src-tauri/src/application/errors.rs
+++ b/src-tauri/src/application/errors.rs
@@ -1,15 +1,18 @@
 use std::fmt;
 
+use crate::ports::session_registry::ReserveRunError;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum StartAgentRunError {
-    ReserveRun(String),
+    ReserveRun(ReserveRunError),
     AttachRunHandle(String),
 }
 
 impl fmt::Display for StartAgentRunError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::ReserveRun(message) | Self::AttachRunHandle(message) => f.write_str(message),
+            Self::ReserveRun(error) => error.fmt(f),
+            Self::AttachRunHandle(message) => f.write_str(message),
         }
     }
 }

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -65,7 +65,7 @@ where
 mod tests {
     use super::*;
     use crate::application::errors::SendPromptError;
-    use crate::ports::session_registry::SessionRegistry;
+    use crate::ports::session_registry::{ReserveRunError, SessionRegistry};
     use anyhow::{Result, anyhow};
     use std::{
         collections::HashMap,
@@ -121,7 +121,7 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, _: String) -> Result<()> {
+        async fn reserve_run(&self, _: String) -> Result<(), ReserveRunError> {
             Ok(())
         }
         async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -46,7 +46,7 @@ where
         self.registry
             .reserve_run(run.id.clone())
             .await
-            .map_err(|err| StartAgentRunError::ReserveRun(err.to_string()))?;
+            .map_err(StartAgentRunError::ReserveRun)?;
 
         let registry = self.registry.clone();
         let run_id = run.id.clone();
@@ -111,7 +111,7 @@ mod tests {
     use crate::application::errors::StartAgentRunError;
     use crate::domain::events::{LifecycleStatus, RunEvent};
     use crate::ports::session_launcher::{AbortFuture, DriverFuture, RunCommander};
-    use crate::ports::session_registry::SessionRegistry;
+    use crate::ports::session_registry::{ReserveRunError, SessionRegistry};
     use anyhow::{Result, anyhow};
     use std::{
         collections::HashMap,
@@ -136,15 +136,15 @@ mod tests {
         finished: Vec<String>,
         sessions: HashMap<String, Arc<FakeSession>>,
         handles: HashMap<String, JoinHandle<()>>,
-        fail_reserve_run: bool,
+        reserve_run_error: Option<ReserveRunError>,
         fail_attach_run_handle: bool,
         fail_attach_session: bool,
     }
 
     impl FakeRegistry {
-        async fn with_failing_reserve_run() -> Self {
+        async fn with_failing_reserve_run(error: ReserveRunError) -> Self {
             let reg = Self::default();
-            reg.inner.lock().await.fail_reserve_run = true;
+            reg.inner.lock().await.reserve_run_error = Some(error);
             reg
         }
 
@@ -164,10 +164,10 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, run_id: String) -> Result<()> {
+        async fn reserve_run(&self, run_id: String) -> Result<(), ReserveRunError> {
             let mut state = self.inner.lock().await;
-            if state.fail_reserve_run {
-                return Err(anyhow!("simulated reserve_run failure"));
+            if let Some(error) = state.reserve_run_error.clone() {
+                return Err(error);
             }
             state.reserved.push(run_id);
             Ok(())
@@ -347,7 +347,10 @@ mod tests {
 
     #[tokio::test]
     async fn returns_typed_error_when_reserve_run_fails() {
-        let registry = FakeRegistry::with_failing_reserve_run().await;
+        let registry = FakeRegistry::with_failing_reserve_run(ReserveRunError::DuplicateRunId {
+            run_id: "run-1".into(),
+        })
+        .await;
         let sink = CollectingSink::default();
         let c = counters();
         let launcher = FakeLauncher::success(&c);
@@ -358,8 +361,32 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(StartAgentRunError::ReserveRun(message))
-                if message == "simulated reserve_run failure"
+            Err(StartAgentRunError::ReserveRun(ReserveRunError::DuplicateRunId { run_id }))
+                if run_id == "run-1"
+        ));
+        let state = registry.inner.lock().await;
+        assert!(state.reserved.is_empty());
+        assert!(state.handles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_typed_error_when_reserve_run_hits_concurrent_limit() {
+        let registry =
+            FakeRegistry::with_failing_reserve_run(ReserveRunError::ConcurrentLimit { limit: 1 })
+                .await;
+        let sink = CollectingSink::default();
+        let c = counters();
+        let launcher = FakeLauncher::success(&c);
+
+        let result = StartAgentRunUseCase::new(registry.clone())
+            .execute(launcher, sink, make_request())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(StartAgentRunError::ReserveRun(
+                ReserveRunError::ConcurrentLimit { limit: 1 }
+            ))
         ));
         let state = registry.inner.lock().await;
         assert!(state.reserved.is_empty());

--- a/src-tauri/src/ports/session_registry.rs
+++ b/src-tauri/src/ports/session_registry.rs
@@ -1,6 +1,27 @@
 use anyhow::Result;
+use std::fmt;
 use std::{future::Future, sync::Arc};
 use tokio::task::JoinHandle;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReserveRunError {
+    DuplicateRunId { run_id: String },
+    ConcurrentLimit { limit: usize },
+}
+
+impl fmt::Display for ReserveRunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateRunId { run_id } => write!(f, "duplicate run id: {run_id}"),
+            Self::ConcurrentLimit { limit } => write!(
+                f,
+                "concurrent run limit ({limit}) reached; cancel an existing run before starting a new one"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ReserveRunError {}
 
 /// Storage for in-flight agent runs and their sessions.
 ///
@@ -12,7 +33,10 @@ use tokio::task::JoinHandle;
 pub trait SessionRegistry: Clone + Send + Sync + 'static {
     type Session: Send + Sync + 'static;
 
-    fn reserve_run(&self, run_id: String) -> impl Future<Output = Result<()>> + Send;
+    fn reserve_run(
+        &self,
+        run_id: String,
+    ) -> impl Future<Output = Result<(), ReserveRunError>> + Send;
 
     fn attach_run_handle(
         &self,


### PR DESCRIPTION
## Summary
- add typed reserve-run failure variants for duplicate run ids and concurrency limits
- preserve existing user-facing Tauri error strings through Display
- assert reserve failure variants directly in registry and start-run tests

Closes #32

## Tests
- cargo test