### PR TITLE
Add focused frontend feature tests

### DIFF
--- a/src/features/agent-run/tabActions.test.ts
+++ b/src/features/agent-run/tabActions.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shared/api", () => ({
+  invokeCommand: vi.fn(),
+  listenEvent: vi.fn(),
+}));
+
+import { invokeCommand } from "../../shared/api";
+import { closeWorkbenchTab } from "./tabActions";
+import { createTabState, useWorkbenchStore } from "./model";
+
+const mockedInvoke = vi.mocked(invokeCommand);
+
+function resetWorkbench(tabs = [createTabState({ id: "tab-1" }, 0)], activeTabId = tabs[0].id) {
+  useWorkbenchStore.setState({
+    workspaces: [],
+    checkoutsByWorkspaceId: {},
+    workspaceError: null,
+    tabs,
+    activeTabId,
+  });
+}
+
+describe("closeWorkbenchTab", () => {
+  beforeEach(() => {
+    resetWorkbench();
+  });
+
+  it("force closes a tab that is already closing with an error", async () => {
+    resetWorkbench([
+      createTabState({ id: "tab-1", closing: true, error: "cancel failed" }, 0),
+      createTabState({ id: "tab-2" }, 1),
+    ]);
+
+    await closeWorkbenchTab("tab-1");
+
+    expect(useWorkbenchStore.getState().tabs.map((tab) => tab.id)).toEqual(["tab-2"]);
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it("ignores a tab that is already closing without an error", async () => {
+    resetWorkbench([
+      createTabState(
+        {
+          id: "tab-1",
+          activeRunId: "run-1",
+          sessionActive: true,
+          closing: true,
+        },
+        0,
+      ),
+      createTabState({ id: "tab-2" }, 1),
+    ]);
+
+    await closeWorkbenchTab("tab-1");
+
+    const tab = useWorkbenchStore.getState().tabs.find((entry) => entry.id === "tab-1");
+    expect(tab?.closing).toBe(true);
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it("marks an active tab as closing and cancels its run", async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    resetWorkbench([
+      createTabState(
+        {
+          id: "tab-1",
+          activeRunId: "run-1",
+          sessionActive: true,
+        },
+        0,
+      ),
+      createTabState({ id: "tab-2" }, 1),
+    ]);
+
+    await closeWorkbenchTab("tab-1");
+
+    const tab = useWorkbenchStore.getState().tabs.find((entry) => entry.id === "tab-1");
+    expect(tab?.closing).toBe(true);
+    expect(mockedInvoke).toHaveBeenCalledWith("cancel_agent_run", { runId: "run-1" });
+  });
+
+  it("closes an idle tab immediately", async () => {
+    resetWorkbench([
+      createTabState({ id: "tab-1" }, 0),
+      createTabState({ id: "tab-2" }, 1),
+    ]);
+
+    await closeWorkbenchTab("tab-1");
+
+    expect(useWorkbenchStore.getState().tabs.map((tab) => tab.id)).toEqual(["tab-2"]);
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/permission-response/usePermissionResponse.test.tsx
+++ b/src/features/permission-response/usePermissionResponse.test.tsx
@@ -1,0 +1,135 @@
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TimelineItem } from "../../entities/message";
+
+vi.mock("../../shared/api", () => ({
+  invokeCommand: vi.fn(),
+  listenEvent: vi.fn(),
+}));
+
+import { invokeCommand } from "../../shared/api";
+import { usePermissionResponse } from "./usePermissionResponse";
+
+const mockedInvoke = vi.mocked(invokeCommand);
+
+type HookResult = ReturnType<typeof usePermissionResponse>;
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+function permissionItem(
+  permissionId: string,
+  requiresResponse = true,
+): TimelineItem {
+  return {
+    id: `${permissionId}-item`,
+    runId: "run-1",
+    group: "permission",
+    title: "permission",
+    body: "",
+    createdAt: 1,
+    event: {
+      type: "permission",
+      permissionId,
+      title: "Allow command?",
+      requiresResponse,
+      options: [
+        { name: "Allow", kind: "allow_once", optionId: "allow-1" },
+        { name: "Deny", kind: "reject_once", optionId: "deny-1" },
+      ],
+    },
+  };
+}
+
+function renderHook(items: TimelineItem[], onError = vi.fn()) {
+  const latest: { current?: HookResult } = {};
+
+  function Probe(props: { currentItems: TimelineItem[] }) {
+    const result = usePermissionResponse(props.currentItems, onError);
+    useEffect(() => {
+      latest.current = result;
+    }, [result]);
+    return null;
+  }
+
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(<Probe currentItems={items} />);
+  });
+
+  return {
+    latest,
+    onError,
+    rerender(nextItems: TimelineItem[]) {
+      act(() => {
+        root?.render(<Probe currentItems={nextItems} />);
+      });
+    },
+  };
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe("usePermissionResponse", () => {
+  it("tracks pending permission responses and sends the selected allow option", () => {
+    mockedInvoke.mockReturnValueOnce(new Promise(() => undefined));
+    const item = permissionItem("perm-1");
+    const { latest } = renderHook([item]);
+
+    act(() => {
+      void latest.current?.respond(item, "allow");
+    });
+
+    expect(latest.current?.isPending("perm-1")).toBe(true);
+    expect(latest.current?.hasOption(item, "allow")).toBe(true);
+    expect(mockedInvoke).toHaveBeenCalledWith("respond_agent_permission", {
+      permissionId: "perm-1",
+      optionId: "allow-1",
+    });
+  });
+
+  it("clears pending state when a terminal permission event arrives", () => {
+    mockedInvoke.mockReturnValueOnce(new Promise(() => undefined));
+    const item = permissionItem("perm-1");
+    const done = permissionItem("perm-1", false);
+    const { latest, rerender } = renderHook([item]);
+
+    act(() => {
+      void latest.current?.respond(item, "reject");
+    });
+    expect(latest.current?.isPending("perm-1")).toBe(true);
+
+    rerender([item, done]);
+
+    expect(latest.current?.isPending("perm-1")).toBe(false);
+    expect(mockedInvoke).toHaveBeenCalledWith("respond_agent_permission", {
+      permissionId: "perm-1",
+      optionId: "deny-1",
+    });
+  });
+
+  it("resets pending state and reports an error when responding fails", async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error("permission failed"));
+    const item = permissionItem("perm-1");
+    const onError = vi.fn();
+    const { latest } = renderHook([item], onError);
+
+    await act(async () => {
+      await latest.current?.respond(item, "allow");
+    });
+
+    expect(latest.current?.isPending("perm-1")).toBe(false);
+    expect(onError).toHaveBeenCalledWith("Error: permission failed");
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,7 @@
 import { beforeEach, vi } from "vitest";
 
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
 // Provide crypto.randomUUID() in the jsdom environment where it is
 // absent by default. Feature code calls it when allocating run ids and
 // queue item ids, and the real implementation is deterministic enough


### PR DESCRIPTION
## Summary
- cover closeWorkbenchTab force-close, closing guard, active-run cancel, and idle close paths
- cover permission response pending state, option selection, terminal-event clearing, and failure reset
- enable React act support in Vitest setup

Closes #18

## Tests
- npm test
- npm run build