### PR TITLE
Enforce backend architecture boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check frontend FSD boundaries
         run: npm run check:fsd
 
+      - name: Check backend architecture boundaries
+        run: npm run check:backend-boundaries
+
       - name: Build frontend
         run: npm run build
 

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -74,6 +74,8 @@ flowchart LR
 - **application**은 유스케이스 오케스트레이션을 소유한다. `SessionRegistry`, `SessionHandle`, `RunEventSink` 같은 포트를 통해 일한다. 테스트에서는 fake port로 대체 가능.
 - **adapters**는 포트를 구현하면서 Tauri, ACP JSON-RPC, subprocess, 파일시스템, 권한 결정 등 외부 프로토콜을 격리한다.
 
+이 방향은 CI에서 `npm run check:backend-boundaries`로 검사한다. 스크립트는 `src-tauri/src/domain`, `src-tauri/src/ports`, `src-tauri/src/application`의 Rust 소스에서 금지된 `crate::...` 레이어 참조를 찾고, 예를 들어 `application/`이 `crate::adapters`를 참조하면 실패한다. 스크립트 자체의 샘플 규칙 검증은 `npm run check:backend-boundaries:self-test`로 실행한다.
+
 ## 주요 포트
 
 | 포트 | 책임 |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc && vite build",
     "check:fsd": "node scripts/check-fsd-boundaries.mjs",
     "check:fsd:self-test": "node scripts/check-fsd-boundaries.mjs --self-test",
+    "check:backend-boundaries": "node scripts/check-backend-boundaries.mjs",
+    "check:backend-boundaries:self-test": "node scripts/check-backend-boundaries.mjs --self-test",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",

--- a/scripts/check-backend-boundaries.mjs
+++ b/scripts/check-backend-boundaries.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const backendSrc = path.join(root, "src-tauri", "src");
+const runSelfTest = process.argv.includes("--self-test");
+const sourceExtensions = new Set([".rs"]);
+const layerRules = new Map([
+  ["domain", new Set(["ports", "application", "adapters"])],
+  ["ports", new Set(["application", "adapters"])],
+  ["application", new Set(["adapters"])],
+]);
+
+const violations = [];
+
+if (runSelfTest) {
+  runBoundarySelfTest();
+} else {
+  for (const file of walk(backendSrc)) {
+    const layer = getLayer(file);
+    if (!layerRules.has(layer)) continue;
+    validateSource(toPosix(path.relative(root, file)), layer, fs.readFileSync(file, "utf8"));
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Backend boundary check failed:\n");
+  for (const violation of violations) {
+    console.error(`- ${violation.file}`);
+    console.error(`  ${violation.message}`);
+  }
+  process.exit(1);
+}
+
+console.log("Backend boundary check passed.");
+
+function runBoundarySelfTest() {
+  const cases = [
+    {
+      name: "domain cannot import ports",
+      layer: "domain",
+      source: "use crate::ports::event_sink::RunEventSink;",
+      expected: 1,
+    },
+    {
+      name: "ports can import domain",
+      layer: "ports",
+      source: "use crate::domain::events::RunEvent;",
+      expected: 0,
+    },
+    {
+      name: "application cannot import grouped adapters",
+      layer: "application",
+      source: "use crate::{adapters::session_registry::AppState, ports::session_registry::SessionRegistry};",
+      expected: 1,
+    },
+    {
+      name: "application can import ports and domain",
+      layer: "application",
+      source: "use crate::{domain::run::AgentRun, ports::session_registry::SessionRegistry};",
+      expected: 0,
+    },
+    {
+      name: "non-use fully qualified adapter path is rejected",
+      layer: "application",
+      source: "let _ = crate::adapters::session_registry::AppState::default();",
+      expected: 1,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const before = violations.length;
+    validateSource(`${testCase.layer}/sample.rs`, testCase.layer, testCase.source);
+    const added = violations.length - before;
+    if (added !== testCase.expected) {
+      throw new Error(
+        `Self-test failed for "${testCase.name}": expected ${testCase.expected} violation(s), got ${added}.`,
+      );
+    }
+    violations.splice(before, added);
+  }
+
+  console.log("Backend boundary self-test passed.");
+}
+
+function validateSource(file, layer, source) {
+  const forbiddenLayers = layerRules.get(layer) ?? new Set();
+  for (const forbidden of forbiddenLayers) {
+    if (referencesCrateLayer(source, forbidden)) {
+      violations.push({
+        file,
+        message: `${layer}/ cannot depend on crate::${forbidden}. Allowed direction is domain -> ports -> application -> adapters.`,
+      });
+    }
+  }
+}
+
+function referencesCrateLayer(source, layer) {
+  return (
+    new RegExp(String.raw`\bcrate::${layer}\s*(?:::|\{)`).test(source) ||
+    collectCrateUseBodies(source).some((body) => groupedUseReferencesLayer(body, layer))
+  );
+}
+
+function collectCrateUseBodies(source) {
+  const bodies = [];
+  const useCrate = /\buse\s+crate::([\s\S]*?);/g;
+  for (const match of source.matchAll(useCrate)) {
+    bodies.push(match[1]);
+  }
+  return bodies;
+}
+
+function groupedUseReferencesLayer(body, layer) {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith("{")) return false;
+  return new RegExp(String.raw`(?:^|[,{]\s*)${layer}\s*(?:::|\{)`).test(trimmed);
+}
+
+function* walk(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else if (sourceExtensions.has(path.extname(entry.name))) {
+      yield fullPath;
+    }
+  }
+}
+
+function getLayer(file) {
+  const relative = toPosix(path.relative(backendSrc, file));
+  return relative.split("/")[0];
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}

--- a/src-tauri/src/application/resolve_workdir.rs
+++ b/src-tauri/src/application/resolve_workdir.rs
@@ -1,10 +1,10 @@
 use anyhow::{Result, anyhow, bail};
-use std::path::{Path, PathBuf};
-
-use crate::{
-    adapters::acp::util::{expand_tilde, normalize_path},
-    ports::workspace_store::WorkspaceStore,
+use std::{
+    env,
+    path::{Path, PathBuf},
 };
+
+use crate::ports::workspace_store::WorkspaceStore;
 
 #[derive(Clone)]
 pub struct ResolveWorkdirUseCase<S>
@@ -75,5 +75,36 @@ where
             );
         }
         Ok(Some(resolved))
+    }
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Some(home) = env::var_os("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn normalize_path(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        Ok(path.canonicalize()?)
+    } else if let Some(parent) = path.parent() {
+        let parent = if parent.as_os_str().is_empty() {
+            env::current_dir()?
+        } else if parent.exists() {
+            parent.canonicalize()?
+        } else {
+            normalize_path(parent)?
+        };
+        Ok(parent.join(path.file_name().unwrap_or_default()))
+    } else {
+        Ok(env::current_dir()?.join(path))
     }
 }


### PR DESCRIPTION
## Summary
- add a backend boundary check for Rust layer dependencies
- wire the check into CI and npm scripts
- remove the existing application-to-adapter path utility dependency
- document the enforcement command in backend architecture docs

Closes #22

## Tests
- npm run check:backend-boundaries:self-test
- npm run check:backend-boundaries
- npm run check:fsd
- cargo test