### PR TITLE
Add saved prompt quick actions

### DIFF
--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_catalog;
 pub mod fs;
 pub mod git;
 pub mod permission_broker;
+pub mod saved_prompt_store_sqlite;
 pub mod session_registry;
 pub mod sqlite;
 pub mod storage_state;

--- a/src-tauri/src/adapters/saved_prompt_store_sqlite.rs
+++ b/src-tauri/src/adapters/saved_prompt_store_sqlite.rs
@@ -1,0 +1,383 @@
+use anyhow::{Result, anyhow, bail};
+use sqlx::{Row, SqlitePool};
+
+use crate::{
+    domain::{
+        saved_prompt::{
+            CreateSavedPromptInput, SavedPrompt, SavedPromptId, SavedPromptRunMode,
+            SavedPromptScope, UpdateSavedPromptPatch,
+        },
+        workspace::timestamp,
+    },
+    ports::saved_prompt_store::SavedPromptStore,
+};
+
+#[derive(Clone)]
+pub struct SqliteSavedPromptStore {
+    pool: SqlitePool,
+}
+
+impl SqliteSavedPromptStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+impl SavedPromptStore for SqliteSavedPromptStore {
+    async fn list_saved_prompts(&self, workspace_id: Option<&str>) -> Result<Vec<SavedPrompt>> {
+        let rows = match workspace_id.filter(|value| !value.trim().is_empty()) {
+            Some(workspace_id) => {
+                sqlx::query(
+                    r#"
+                    SELECT id, scope, workspace_id, title, body, description, tags_json,
+                           run_mode, created_at, updated_at, last_used_at, use_count
+                    FROM saved_prompts
+                    WHERE scope = 'global' OR workspace_id = ?
+                    ORDER BY CASE WHEN workspace_id = ? THEN 0 ELSE 1 END,
+                             use_count DESC, updated_at DESC, title ASC
+                    "#,
+                )
+                .bind(workspace_id)
+                .bind(workspace_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            None => {
+                sqlx::query(
+                    r#"
+                    SELECT id, scope, workspace_id, title, body, description, tags_json,
+                           run_mode, created_at, updated_at, last_used_at, use_count
+                    FROM saved_prompts
+                    ORDER BY use_count DESC, updated_at DESC, title ASC
+                    "#,
+                )
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+        rows.into_iter().map(saved_prompt_from_row).collect()
+    }
+
+    async fn create_saved_prompt(&self, input: CreateSavedPromptInput) -> Result<SavedPrompt> {
+        validate_prompt_parts(&input.title, &input.body)?;
+        let prompt = SavedPrompt::new(normalize_create_input(input));
+        upsert_saved_prompt(&self.pool, &prompt).await?;
+        Ok(prompt)
+    }
+
+    async fn update_saved_prompt(
+        &self,
+        id: &SavedPromptId,
+        patch: UpdateSavedPromptPatch,
+    ) -> Result<Option<SavedPrompt>> {
+        let Some(mut prompt) = get_saved_prompt(&self.pool, id).await? else {
+            return Ok(None);
+        };
+        if let Some(scope) = patch.scope {
+            prompt.scope = scope;
+        }
+        if let Some(workspace_id) = patch.workspace_id {
+            prompt.workspace_id = workspace_id;
+        }
+        if let Some(title) = patch.title {
+            prompt.title = title;
+        }
+        if let Some(body) = patch.body {
+            prompt.body = body;
+        }
+        if let Some(description) = patch.description {
+            prompt.description = description;
+        }
+        if let Some(tags) = patch.tags {
+            prompt.tags = normalize_tags(tags);
+        }
+        if let Some(run_mode) = patch.run_mode {
+            prompt.run_mode = run_mode;
+        }
+        validate_prompt_parts(&prompt.title, &prompt.body)?;
+        if matches!(prompt.scope, SavedPromptScope::Global) {
+            prompt.workspace_id = None;
+        }
+        prompt.updated_at = timestamp();
+        upsert_saved_prompt(&self.pool, &prompt).await?;
+        Ok(Some(prompt))
+    }
+
+    async fn delete_saved_prompt(&self, id: &SavedPromptId) -> Result<()> {
+        sqlx::query("DELETE FROM saved_prompts WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn record_saved_prompt_used(&self, id: &SavedPromptId) -> Result<Option<SavedPrompt>> {
+        let now = timestamp();
+        sqlx::query(
+            r#"
+            UPDATE saved_prompts
+            SET last_used_at = ?, use_count = use_count + 1, updated_at = ?
+            WHERE id = ?
+            "#,
+        )
+        .bind(&now)
+        .bind(&now)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        get_saved_prompt(&self.pool, id).await
+    }
+}
+
+async fn get_saved_prompt(pool: &SqlitePool, id: &str) -> Result<Option<SavedPrompt>> {
+    let row = sqlx::query(
+        r#"
+        SELECT id, scope, workspace_id, title, body, description, tags_json,
+               run_mode, created_at, updated_at, last_used_at, use_count
+        FROM saved_prompts
+        WHERE id = ?
+        "#,
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(saved_prompt_from_row).transpose()
+}
+
+async fn upsert_saved_prompt(pool: &SqlitePool, prompt: &SavedPrompt) -> Result<()> {
+    let tags_json = serde_json::to_string(&prompt.tags)?;
+    sqlx::query(
+        r#"
+        INSERT INTO saved_prompts (
+            id, scope, workspace_id, title, body, description, tags_json, run_mode,
+            created_at, updated_at, last_used_at, use_count
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            scope = excluded.scope,
+            workspace_id = excluded.workspace_id,
+            title = excluded.title,
+            body = excluded.body,
+            description = excluded.description,
+            tags_json = excluded.tags_json,
+            run_mode = excluded.run_mode,
+            updated_at = excluded.updated_at,
+            last_used_at = excluded.last_used_at,
+            use_count = excluded.use_count
+        "#,
+    )
+    .bind(&prompt.id)
+    .bind(scope_to_db(&prompt.scope))
+    .bind(&prompt.workspace_id)
+    .bind(prompt.title.trim())
+    .bind(prompt.body.trim())
+    .bind(prompt.description.as_deref().map(str::trim))
+    .bind(tags_json)
+    .bind(run_mode_to_db(&prompt.run_mode))
+    .bind(&prompt.created_at)
+    .bind(&prompt.updated_at)
+    .bind(&prompt.last_used_at)
+    .bind(prompt.use_count)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn saved_prompt_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SavedPrompt> {
+    let scope: String = row.try_get("scope")?;
+    let run_mode: String = row.try_get("run_mode")?;
+    let tags_json: String = row.try_get("tags_json")?;
+    Ok(SavedPrompt {
+        id: row.try_get("id")?,
+        scope: scope_from_db(&scope)?,
+        workspace_id: row.try_get("workspace_id")?,
+        title: row.try_get("title")?,
+        body: row.try_get("body")?,
+        description: row.try_get("description")?,
+        tags: serde_json::from_str(&tags_json)?,
+        run_mode: run_mode_from_db(&run_mode)?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+        last_used_at: row.try_get("last_used_at")?,
+        use_count: row.try_get("use_count")?,
+    })
+}
+
+fn normalize_create_input(mut input: CreateSavedPromptInput) -> CreateSavedPromptInput {
+    input.title = input.title.trim().to_string();
+    input.body = input.body.trim().to_string();
+    input.description = input
+        .description
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    input.tags = normalize_tags(input.tags);
+    if matches!(input.scope, SavedPromptScope::Global) {
+        input.workspace_id = None;
+    }
+    input
+}
+
+fn normalize_tags(tags: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for tag in tags {
+        let tag = tag.trim().to_string();
+        if !tag.is_empty() && !normalized.contains(&tag) {
+            normalized.push(tag);
+        }
+    }
+    normalized
+}
+
+fn validate_prompt_parts(title: &str, body: &str) -> Result<()> {
+    if title.trim().is_empty() {
+        bail!("saved prompt title is empty");
+    }
+    if body.trim().is_empty() {
+        bail!("saved prompt body is empty");
+    }
+    Ok(())
+}
+
+fn scope_to_db(scope: &SavedPromptScope) -> &'static str {
+    match scope {
+        SavedPromptScope::Global => "global",
+        SavedPromptScope::Workspace => "workspace",
+    }
+}
+
+fn scope_from_db(value: &str) -> Result<SavedPromptScope> {
+    match value {
+        "global" => Ok(SavedPromptScope::Global),
+        "workspace" => Ok(SavedPromptScope::Workspace),
+        other => Err(anyhow!("unknown saved prompt scope: {other}")),
+    }
+}
+
+fn run_mode_to_db(run_mode: &SavedPromptRunMode) -> &'static str {
+    match run_mode {
+        SavedPromptRunMode::Insert => "insert",
+        SavedPromptRunMode::Send => "send",
+        SavedPromptRunMode::Enqueue => "enqueue",
+    }
+}
+
+fn run_mode_from_db(value: &str) -> Result<SavedPromptRunMode> {
+    match value {
+        "insert" => Ok(SavedPromptRunMode::Insert),
+        "send" => Ok(SavedPromptRunMode::Send),
+        "enqueue" => Ok(SavedPromptRunMode::Enqueue),
+        other => Err(anyhow!("unknown saved prompt run mode: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::sqlite::open_database;
+
+    async fn temp_store() -> SqliteSavedPromptStore {
+        let dir = std::env::temp_dir().join(format!("acp-saved-prompts-{}", uuid::Uuid::new_v4()));
+        let pool = open_database(&dir).await.unwrap();
+        SqliteSavedPromptStore::new(pool)
+    }
+
+    async fn insert_workspace(store: &SqliteSavedPromptStore, id: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO workspaces (
+                id, name, raw_origin_url, canonical_origin_url, host, owner, repo, created_at, updated_at
+            )
+            VALUES (?, 'repo', 'git@github.com:owner/repo.git', ?, 'github.com', 'owner', 'repo', '1', '1')
+            "#,
+        )
+        .bind(id)
+        .bind(format!("github.com/owner/repo-{id}"))
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    }
+
+    fn input(title: &str, workspace_id: Option<&str>) -> CreateSavedPromptInput {
+        CreateSavedPromptInput {
+            scope: if workspace_id.is_some() {
+                SavedPromptScope::Workspace
+            } else {
+                SavedPromptScope::Global
+            },
+            workspace_id: workspace_id.map(str::to_string),
+            title: title.to_string(),
+            body: "Run tests".to_string(),
+            description: None,
+            tags: vec!["test".to_string(), "test".to_string()],
+            run_mode: SavedPromptRunMode::Enqueue,
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_lists_and_records_usage() {
+        let store = temp_store().await;
+        insert_workspace(&store, "ws_1").await;
+        let prompt = store
+            .create_saved_prompt(input("Tests", Some("ws_1")))
+            .await
+            .unwrap();
+
+        let prompts = store.list_saved_prompts(Some("ws_1")).await.unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].tags, vec!["test".to_string()]);
+
+        let used = store
+            .record_saved_prompt_used(&prompt.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(used.use_count, 1);
+        assert!(used.last_used_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn filters_workspace_prompts_with_globals() {
+        let store = temp_store().await;
+        insert_workspace(&store, "ws_1").await;
+        insert_workspace(&store, "ws_2").await;
+        store
+            .create_saved_prompt(input("Global", None))
+            .await
+            .unwrap();
+        store
+            .create_saved_prompt(input("Workspace", Some("ws_1")))
+            .await
+            .unwrap();
+        store
+            .create_saved_prompt(input("Other", Some("ws_2")))
+            .await
+            .unwrap();
+
+        let prompts = store.list_saved_prompts(Some("ws_1")).await.unwrap();
+        let titles: Vec<_> = prompts.into_iter().map(|prompt| prompt.title).collect();
+        assert_eq!(titles, vec!["Workspace".to_string(), "Global".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn updates_and_deletes_prompt() {
+        let store = temp_store().await;
+        let prompt = store.create_saved_prompt(input("Old", None)).await.unwrap();
+        let updated = store
+            .update_saved_prompt(
+                &prompt.id,
+                UpdateSavedPromptPatch {
+                    title: Some("New".to_string()),
+                    run_mode: Some(SavedPromptRunMode::Insert),
+                    ..UpdateSavedPromptPatch::default()
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.title, "New");
+        assert_eq!(updated.run_mode, SavedPromptRunMode::Insert);
+
+        store.delete_saved_prompt(&prompt.id).await.unwrap();
+        assert!(store.list_saved_prompts(None).await.unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/adapters/sqlite.rs
+++ b/src-tauri/src/adapters/sqlite.rs
@@ -6,6 +6,7 @@ use sqlx::{
 use std::{path::Path, time::Duration};
 
 const WORKSPACE_SCHEMA_VERSION: i64 = 1;
+const SAVED_PROMPTS_SCHEMA_VERSION: i64 = 2;
 
 pub async fn open_database(app_data_dir: &Path) -> Result<SqlitePool> {
     tokio::fs::create_dir_all(app_data_dir).await?;
@@ -55,15 +56,25 @@ async fn migrate_database(pool: &SqlitePool) -> Result<()> {
     .execute(pool)
     .await?;
 
+    if !migration_applied(pool, WORKSPACE_SCHEMA_VERSION).await? {
+        migrate_workspace_schema(pool).await?;
+    }
+    if !migration_applied(pool, SAVED_PROMPTS_SCHEMA_VERSION).await? {
+        migrate_saved_prompts_schema(pool).await?;
+    }
+    Ok(())
+}
+
+async fn migration_applied(pool: &SqlitePool, version: i64) -> Result<bool> {
     let applied: Option<(i64,)> =
         sqlx::query_as("SELECT version FROM schema_migrations WHERE version = ?")
-            .bind(WORKSPACE_SCHEMA_VERSION)
+            .bind(version)
             .fetch_optional(pool)
             .await?;
-    if applied.is_some() {
-        return Ok(());
-    }
+    Ok(applied.is_some())
+}
 
+async fn migrate_workspace_schema(pool: &SqlitePool) -> Result<()> {
     let mut tx = pool.begin().await?;
     sqlx::query(
         r#"
@@ -111,6 +122,44 @@ async fn migrate_database(pool: &SqlitePool) -> Result<()> {
     .await?;
     sqlx::query("INSERT INTO schema_migrations (version) VALUES (?)")
         .bind(WORKSPACE_SCHEMA_VERSION)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn migrate_saved_prompts_schema(pool: &SqlitePool) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS saved_prompts (
+            id TEXT PRIMARY KEY,
+            scope TEXT NOT NULL,
+            workspace_id TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            description TEXT,
+            tags_json TEXT NOT NULL DEFAULT '[]',
+            run_mode TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_used_at TEXT,
+            use_count INTEGER NOT NULL DEFAULT 0
+        )
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_saved_prompts_scope_workspace
+        ON saved_prompts(scope, workspace_id, updated_at DESC)
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("INSERT INTO schema_migrations (version) VALUES (?)")
+        .bind(SAVED_PROMPTS_SCHEMA_VERSION)
         .execute(&mut *tx)
         .await?;
     tx.commit().await?;

--- a/src-tauri/src/adapters/storage_state.rs
+++ b/src-tauri/src/adapters/storage_state.rs
@@ -3,7 +3,8 @@ use sqlx::SqlitePool;
 use std::path::PathBuf;
 
 use crate::adapters::{
-    sqlite::open_database, workspace_store_migration::migrate_json_workspace_store,
+    saved_prompt_store_sqlite::SqliteSavedPromptStore, sqlite::open_database,
+    workspace_store_migration::migrate_json_workspace_store,
     workspace_store_sqlite::SqliteWorkspaceStore,
 };
 
@@ -32,5 +33,9 @@ impl StorageState {
 
     pub fn workspace_store(&self) -> SqliteWorkspaceStore {
         SqliteWorkspaceStore::new(self.pool())
+    }
+
+    pub fn saved_prompt_store(&self) -> SqliteSavedPromptStore {
+        SqliteSavedPromptStore::new(self.pool())
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -15,9 +15,12 @@ use crate::{
     domain::{
         agent::AgentDescriptor,
         run::{AgentRun, AgentRunRequest},
+        saved_prompt::{
+            CreateSavedPromptInput, SavedPrompt, SavedPromptId, UpdateSavedPromptPatch,
+        },
         workspace::{RegisteredWorkspace, Workspace, WorkspaceCheckout},
     },
-    ports::workspace_store::WorkspaceStore,
+    ports::{saved_prompt_store::SavedPromptStore, workspace_store::WorkspaceStore},
 };
 
 #[tauri::command]
@@ -176,5 +179,66 @@ pub async fn resolve_workspace_workdir(
         )
         .await
         .map(|path| path.map(|value| value.to_string_lossy().to_string()))
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn list_saved_prompts(
+    storage: State<'_, StorageState>,
+    workspace_id: Option<String>,
+) -> Result<Vec<SavedPrompt>, String> {
+    storage
+        .saved_prompt_store()
+        .list_saved_prompts(workspace_id.as_deref())
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn create_saved_prompt(
+    storage: State<'_, StorageState>,
+    input: CreateSavedPromptInput,
+) -> Result<SavedPrompt, String> {
+    storage
+        .saved_prompt_store()
+        .create_saved_prompt(input)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn update_saved_prompt(
+    storage: State<'_, StorageState>,
+    id: SavedPromptId,
+    patch: UpdateSavedPromptPatch,
+) -> Result<Option<SavedPrompt>, String> {
+    storage
+        .saved_prompt_store()
+        .update_saved_prompt(&id, patch)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn delete_saved_prompt(
+    storage: State<'_, StorageState>,
+    id: SavedPromptId,
+) -> Result<(), String> {
+    storage
+        .saved_prompt_store()
+        .delete_saved_prompt(&id)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn record_saved_prompt_used(
+    storage: State<'_, StorageState>,
+    id: SavedPromptId,
+) -> Result<Option<SavedPrompt>, String> {
+    storage
+        .saved_prompt_store()
+        .record_saved_prompt_used(&id)
+        .await
         .map_err(|err| err.to_string())
 }

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
 pub mod events;
 pub mod run;
+pub mod saved_prompt;
 pub mod workspace;

--- a/src-tauri/src/domain/saved_prompt.rs
+++ b/src-tauri/src/domain/saved_prompt.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::workspace::{WorkspaceId, timestamp};
+
+pub type SavedPromptId = String;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SavedPrompt {
+    pub id: SavedPromptId,
+    pub scope: SavedPromptScope,
+    pub workspace_id: Option<WorkspaceId>,
+    pub title: String,
+    pub body: String,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub run_mode: SavedPromptRunMode,
+    pub created_at: String,
+    pub updated_at: String,
+    pub last_used_at: Option<String>,
+    pub use_count: i64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SavedPromptScope {
+    Global,
+    Workspace,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SavedPromptRunMode {
+    Insert,
+    Send,
+    Enqueue,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSavedPromptInput {
+    pub scope: SavedPromptScope,
+    pub workspace_id: Option<WorkspaceId>,
+    pub title: String,
+    pub body: String,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub run_mode: SavedPromptRunMode,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateSavedPromptPatch {
+    pub scope: Option<SavedPromptScope>,
+    pub workspace_id: Option<Option<WorkspaceId>>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub description: Option<Option<String>>,
+    pub tags: Option<Vec<String>>,
+    pub run_mode: Option<SavedPromptRunMode>,
+}
+
+impl SavedPrompt {
+    pub fn new(input: CreateSavedPromptInput) -> Self {
+        let now = timestamp();
+        Self {
+            id: format!("sp_{}", Uuid::new_v4().simple()),
+            scope: input.scope,
+            workspace_id: input.workspace_id,
+            title: input.title,
+            body: input.body,
+            description: input.description,
+            tags: input.tags,
+            run_mode: input.run_mode,
+            created_at: now.clone(),
+            updated_at: now,
+            last_used_at: None,
+            use_count: 0,
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,9 +7,11 @@ use adapters::{
     session_registry::AppState,
     storage_state::StorageState,
     tauri::commands::{
-        cancel_agent_run, list_agents, list_workspace_checkouts, list_workspaces, load_goal_file,
-        refresh_workspace_checkout, register_workspace_from_path, remove_workspace,
-        resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run, start_agent_run,
+        cancel_agent_run, create_saved_prompt, delete_saved_prompt, list_agents,
+        list_saved_prompts, list_workspace_checkouts, list_workspaces, load_goal_file,
+        record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
+        remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
+        start_agent_run, update_saved_prompt,
     },
 };
 use tauri::Manager;
@@ -36,7 +38,12 @@ pub fn run() {
             remove_workspace,
             list_workspace_checkouts,
             refresh_workspace_checkout,
-            resolve_workspace_workdir
+            resolve_workspace_workdir,
+            list_saved_prompts,
+            create_saved_prompt,
+            update_saved_prompt,
+            delete_saved_prompt,
+            record_saved_prompt_used
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_catalog;
 pub mod event_sink;
 pub mod goal_file;
 pub mod permission;
+pub mod saved_prompt_store;
 pub mod session_handle;
 pub mod session_launcher;
 pub mod session_registry;

--- a/src-tauri/src/ports/saved_prompt_store.rs
+++ b/src-tauri/src/ports/saved_prompt_store.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use std::future::Future;
+
+use crate::domain::saved_prompt::{
+    CreateSavedPromptInput, SavedPrompt, SavedPromptId, UpdateSavedPromptPatch,
+};
+
+pub trait SavedPromptStore: Clone + Send + Sync + 'static {
+    fn list_saved_prompts(
+        &self,
+        workspace_id: Option<&str>,
+    ) -> impl Future<Output = Result<Vec<SavedPrompt>>> + Send;
+
+    fn create_saved_prompt(
+        &self,
+        input: CreateSavedPromptInput,
+    ) -> impl Future<Output = Result<SavedPrompt>> + Send;
+
+    fn update_saved_prompt(
+        &self,
+        id: &SavedPromptId,
+        patch: UpdateSavedPromptPatch,
+    ) -> impl Future<Output = Result<Option<SavedPrompt>>> + Send;
+
+    fn delete_saved_prompt(&self, id: &SavedPromptId) -> impl Future<Output = Result<()>> + Send;
+
+    fn record_saved_prompt_used(
+        &self,
+        id: &SavedPromptId,
+    ) -> impl Future<Output = Result<Option<SavedPrompt>>> + Send;
+}

--- a/src/entities/saved-prompt/index.ts
+++ b/src/entities/saved-prompt/index.ts
@@ -1,0 +1,7 @@
+export type {
+  CreateSavedPromptInput,
+  SavedPrompt,
+  SavedPromptRunMode,
+  SavedPromptScope,
+  UpdateSavedPromptPatch,
+} from "./model";

--- a/src/entities/saved-prompt/model.ts
+++ b/src/entities/saved-prompt/model.ts
@@ -1,0 +1,31 @@
+export type SavedPromptScope = "global" | "workspace";
+export type SavedPromptRunMode = "insert" | "send" | "enqueue";
+
+export type SavedPrompt = {
+  id: string;
+  scope: SavedPromptScope;
+  workspaceId?: string | null;
+  title: string;
+  body: string;
+  description?: string | null;
+  tags: string[];
+  runMode: SavedPromptRunMode;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt?: string | null;
+  useCount: number;
+};
+
+export type CreateSavedPromptInput = {
+  scope: SavedPromptScope;
+  workspaceId?: string | null;
+  title: string;
+  body: string;
+  description?: string | null;
+  tags: string[];
+  runMode: SavedPromptRunMode;
+};
+
+export type UpdateSavedPromptPatch = Partial<
+  Pick<CreateSavedPromptInput, "scope" | "workspaceId" | "title" | "body" | "description" | "tags" | "runMode">
+>;

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -1,5 +1,6 @@
 import type { AgentDescriptor } from "../../entities/agent";
 import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message";
+import type { CreateSavedPromptInput, SavedPrompt, UpdateSavedPromptPatch } from "../../entities/saved-prompt";
 import type { RegisteredWorkspace, Workspace, WorkspaceCheckout } from "../../entities/workspace";
 import { invokeCommand, listenEvent } from "../../shared/api";
 
@@ -45,4 +46,24 @@ export function resolveWorkspaceWorkdir(args: {
   cwd?: string | null;
 }) {
   return invokeCommand<string | null>("resolve_workspace_workdir", args);
+}
+
+export function listSavedPrompts(workspaceId?: string | null) {
+  return invokeCommand<SavedPrompt[]>("list_saved_prompts", { workspaceId });
+}
+
+export function createSavedPrompt(input: CreateSavedPromptInput) {
+  return invokeCommand<SavedPrompt>("create_saved_prompt", { input });
+}
+
+export function updateSavedPrompt(id: string, patch: UpdateSavedPromptPatch) {
+  return invokeCommand<SavedPrompt | null>("update_saved_prompt", { id, patch });
+}
+
+export function deleteSavedPrompt(id: string) {
+  return invokeCommand<void>("delete_saved_prompt", { id });
+}
+
+export function recordSavedPromptUsed(id: string) {
+  return invokeCommand<SavedPrompt | null>("record_saved_prompt_used", { id });
 }

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -19,7 +19,12 @@ export { type FollowUpQueueItem } from "./model";
 export {
   listWorkspaceCheckouts,
   listWorkspaces,
+  createSavedPrompt,
+  deleteSavedPrompt,
+  listSavedPrompts,
+  recordSavedPromptUsed,
   refreshWorkspaceCheckout,
   registerWorkspaceFromPath,
   resolveWorkspaceWorkdir,
+  updateSavedPrompt,
 } from "./api";

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -6,6 +6,7 @@ import {
   startAgentRun,
 } from "./api";
 import type { AgentRunRequest, EventGroup, TimelineItem } from "../../entities/message";
+import type { SavedPromptRunMode } from "../../entities/saved-prompt";
 import { useWorkbenchStore, type TabState, type FollowUpQueueItem } from "./model";
 
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
@@ -119,6 +120,25 @@ export function useAgentRun(tabId: string) {
     store.patchTab(tabId, { followUpDraft: "" });
   }, [tabId]);
 
+  const applySavedPrompt = useCallback(
+    (body: string, runMode: SavedPromptRunMode) => {
+      const store = useWorkbenchStore.getState();
+      const current = store.tabs.find((t) => t.id === tabId);
+      const trimmed = body.trim();
+      if (!current || !trimmed) return;
+      if (!current.sessionActive) {
+        store.patchTab(tabId, { goal: trimmed });
+        return;
+      }
+      if (runMode === "insert") {
+        store.patchTab(tabId, { followUpDraft: trimmed });
+        return;
+      }
+      store.enqueueFollowUp(tabId, trimmed);
+    },
+    [tabId],
+  );
+
   const cancelFollowUp = useCallback(
     (id: string) => useWorkbenchStore.getState().removeFollowUp(tabId, id),
     [tabId],
@@ -187,6 +207,7 @@ export function useAgentRun(tabId: string) {
     run,
     cancel,
     send,
+    applySavedPrompt,
     items,
     visibleItems,
     filter,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -4,6 +4,7 @@ import { EventStream } from "../../widgets/event-stream";
 import { FollowUpComposer } from "../../widgets/follow-up-composer";
 import { FollowUpQueue } from "../../widgets/follow-up-queue";
 import { RunPanel } from "../../widgets/run-panel";
+import { SavedPromptsPanel } from "../../widgets/saved-prompts";
 import { TabBar } from "../../widgets/workbench-tabs";
 import { WorkspaceBar } from "../../widgets/workspace-bar";
 
@@ -68,6 +69,12 @@ export function AgentWorkbenchPage() {
             sessionActive={state.sessionActive}
             awaitingResponse={state.awaitingResponse}
             queueLength={state.followUpQueue.length}
+          />
+          <SavedPromptsPanel
+            workspaceId={state.workspaceId}
+            sessionActive={state.sessionActive}
+            onApply={state.applySavedPrompt}
+            onError={state.setError}
           />
           <FollowUpQueue
             items={state.followUpQueue}

--- a/src/widgets/saved-prompts/SavedPromptsPanel.tsx
+++ b/src/widgets/saved-prompts/SavedPromptsPanel.tsx
@@ -1,0 +1,236 @@
+import { Plus, Save, Trash2, Wand2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { SavedPrompt, SavedPromptRunMode, SavedPromptScope } from "../../entities/saved-prompt";
+import {
+  createSavedPrompt,
+  deleteSavedPrompt,
+  listSavedPrompts,
+  recordSavedPromptUsed,
+  updateSavedPrompt,
+} from "../../features/agent-run";
+import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect, Textarea } from "../../shared/ui";
+
+type SavedPromptsPanelProps = {
+  workspaceId?: string | null;
+  sessionActive: boolean;
+  onApply: (body: string, runMode: SavedPromptRunMode) => void;
+  onError: (error: string | null) => void;
+};
+
+type FormState = {
+  id: string | null;
+  scope: SavedPromptScope;
+  title: string;
+  body: string;
+  tags: string;
+  runMode: SavedPromptRunMode;
+};
+
+const emptyForm: FormState = {
+  id: null,
+  scope: "global",
+  title: "",
+  body: "",
+  tags: "",
+  runMode: "enqueue",
+};
+
+export function SavedPromptsPanel({ workspaceId, sessionActive, onApply, onError }: SavedPromptsPanelProps) {
+  const [prompts, setPrompts] = useState<SavedPrompt[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [expanded, setExpanded] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      setPrompts(await listSavedPrompts(workspaceId));
+      onError(null);
+    } catch (err) {
+      onError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, [workspaceId]);
+
+  const quickPrompts = useMemo(() => prompts.slice(0, 4), [prompts]);
+  const canSave = form.title.trim().length > 0 && form.body.trim().length > 0;
+
+  async function applyPrompt(prompt: SavedPrompt) {
+    try {
+      onApply(prompt.body, prompt.runMode);
+      await recordSavedPromptUsed(prompt.id);
+      await load();
+    } catch (err) {
+      onError(String(err));
+    }
+  }
+
+  async function savePrompt() {
+    if (!canSave) return;
+    const payload = {
+      scope: form.scope,
+      workspaceId: form.scope === "workspace" ? workspaceId : null,
+      title: form.title,
+      body: form.body,
+      tags: form.tags.split(",").map((tag) => tag.trim()).filter(Boolean),
+      runMode: form.runMode,
+    };
+    try {
+      if (form.id) {
+        await updateSavedPrompt(form.id, payload);
+      } else {
+        await createSavedPrompt(payload);
+      }
+      setForm(emptyForm);
+      setExpanded(false);
+      await load();
+      onError(null);
+    } catch (err) {
+      onError(String(err));
+    }
+  }
+
+  async function removePrompt(id: string) {
+    try {
+      await deleteSavedPrompt(id);
+      if (form.id === id) setForm(emptyForm);
+      await load();
+    } catch (err) {
+      onError(String(err));
+    }
+  }
+
+  function editPrompt(prompt: SavedPrompt) {
+    setForm({
+      id: prompt.id,
+      scope: prompt.scope,
+      title: prompt.title,
+      body: prompt.body,
+      tags: prompt.tags.join(", "),
+      runMode: prompt.runMode,
+    });
+    setExpanded(true);
+  }
+
+  return (
+    <Card as="section" aria-labelledby="saved-prompts-heading">
+      <CardHeader>
+        <CardTitleBlock>
+          <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Quick prompts</p>
+          <CardTitle id="saved-prompts-heading">Saved prompts</CardTitle>
+        </CardTitleBlock>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          icon={<Plus size={16} />}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? "Close" : "New"}
+        </Button>
+      </CardHeader>
+      <CardContent className="grid gap-3 pt-6">
+        <div className="flex flex-wrap gap-2">
+          {quickPrompts.length > 0 ? (
+            quickPrompts.map((prompt) => (
+              <Button
+                key={prompt.id}
+                type="button"
+                variant="secondary"
+                size="sm"
+                icon={<Wand2 size={16} />}
+                disabled={loading}
+                onClick={() => void applyPrompt(prompt)}
+                title={prompt.body}
+              >
+                {prompt.title}
+              </Button>
+            ))
+          ) : (
+            <span className="text-sm text-muted-foreground">No saved prompts yet.</span>
+          )}
+        </div>
+
+        {expanded ? (
+          <div className="grid gap-2 rounded-md border border-border p-3">
+            <div className="grid grid-cols-[1fr_150px_150px] gap-2 max-lg:grid-cols-1">
+              <Input
+                value={form.title}
+                placeholder="Prompt title"
+                onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+              />
+              <NativeSelect
+                value={form.scope}
+                disabled={!workspaceId}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, scope: event.target.value as SavedPromptScope }))
+                }
+              >
+                <option value="global">Global</option>
+                <option value="workspace">Workspace</option>
+              </NativeSelect>
+              <NativeSelect
+                value={form.runMode}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, runMode: event.target.value as SavedPromptRunMode }))
+                }
+              >
+                <option value="insert">Insert</option>
+                <option value="send">Send</option>
+                <option value="enqueue">Enqueue</option>
+              </NativeSelect>
+            </div>
+            <Textarea
+              className="min-h-[90px] resize-y"
+              value={form.body}
+              placeholder={sessionActive ? "Follow-up prompt body" : "Goal prompt body"}
+              onChange={(event) => setForm((current) => ({ ...current, body: event.target.value }))}
+            />
+            <Input
+              value={form.tags}
+              placeholder="Tags, comma separated"
+              onChange={(event) => setForm((current) => ({ ...current, tags: event.target.value }))}
+            />
+            <div className="flex flex-wrap justify-between gap-2">
+              <div className="flex flex-wrap gap-2">
+                {prompts.map((prompt) => (
+                  <Button key={prompt.id} type="button" variant="ghost" size="sm" onClick={() => editPrompt(prompt)}>
+                    {prompt.title}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                {form.id ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    icon={<Trash2 size={16} />}
+                    onClick={() => void removePrompt(form.id!)}
+                  >
+                    Delete
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  icon={<Save size={16} />}
+                  disabled={!canSave || loading}
+                  onClick={() => void savePrompt()}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/widgets/saved-prompts/index.ts
+++ b/src/widgets/saved-prompts/index.ts
@@ -1,0 +1,1 @@
+export { SavedPromptsPanel } from "./SavedPromptsPanel";


### PR DESCRIPTION
## Summary
- add SQLite-backed saved prompt persistence with CRUD and usage tracking
- expose saved prompt Tauri commands and frontend API types
- add a saved prompts panel for quick insert/send/enqueue actions plus create/edit/delete workflows

Closes #40

## Verification
- cargo test
- npm run build
- npm test -- --run
- npm run check:fsd