### PR TITLE
Extract ACP client handlers

### DIFF
--- a/src-tauri/src/adapters/acp/client.rs
+++ b/src-tauri/src/adapters/acp/client.rs
@@ -1,32 +1,22 @@
 use anyhow::{Context, Result, anyhow, bail};
 use serde_json::{Value, json};
-use std::{collections::HashMap, fs, path::PathBuf, process::Stdio, sync::Arc};
-use tokio::{
-    io::AsyncReadExt,
-    process::{Child, Command},
-    sync::Mutex,
-};
-use uuid::Uuid;
+use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
+use tokio::sync::Mutex;
 
 use crate::{
     adapters::acp::{
+        permission_flow,
         session_update_mapper::{MappedSessionUpdate, map_session_update},
+        terminal::TerminalHandler,
         transport::RpcPeer,
         util::{
-            clean_tool_title, display_command, expand_tilde, extract_locations, normalize_path,
-            select_lines, string_param,
+            clean_tool_title, expand_tilde, extract_locations, normalize_path, select_lines,
+            string_param,
         },
     },
-    domain::events::{LifecycleStatus, PermissionOption, RunEvent},
+    domain::events::{LifecycleStatus, RunEvent},
     ports::{event_sink::RunEventSink, permission::PermissionDecisionPort},
 };
-
-struct TerminalState {
-    child: Arc<Mutex<Child>>,
-    output: Arc<Mutex<Vec<u8>>>,
-    output_limit: usize,
-    reader_task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
-}
 
 pub struct AcpClient<S, P>
 where
@@ -37,7 +27,7 @@ where
     workspace: PathBuf,
     auto_allow: bool,
     permission_decisions: P,
-    terminals: Mutex<HashMap<String, TerminalState>>,
+    terminals: TerminalHandler,
     last_tool_signature: Mutex<Option<(String, String, Vec<String>)>>,
     pending_tool_locations: Mutex<HashMap<String, Vec<String>>>,
     sink: S,
@@ -60,7 +50,7 @@ where
             workspace,
             auto_allow,
             permission_decisions,
-            terminals: Mutex::new(HashMap::new()),
+            terminals: TerminalHandler::new(),
             last_tool_signature: Mutex::new(None),
             pending_tool_locations: Mutex::new(HashMap::new()),
             sink,
@@ -132,84 +122,14 @@ where
     }
 
     async fn request_permission(&self, params: Value) -> Result<Value> {
-        let options = params
-            .get("options")
-            .and_then(Value::as_array)
-            .ok_or_else(|| anyhow!("permission request missing options"))?;
-        let tool_call = params.get("toolCall").cloned().unwrap_or(Value::Null);
-        let title = clean_tool_title(tool_call.get("title").and_then(Value::as_str));
-        let mapped_options = options
-            .iter()
-            .map(|option| PermissionOption {
-                name: option
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string(),
-                kind: option
-                    .get("kind")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string(),
-                option_id: option
-                    .get("optionId")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string(),
-            })
-            .collect::<Vec<_>>();
-        let permission_id = Uuid::new_v4().to_string();
-        let selected = if self.auto_allow {
-            select_permission_option(options, true)
-                .ok_or_else(|| anyhow!("No allow permission option was offered by the agent."))?
-                .to_owned()
-        } else {
-            let receiver = self
-                .permission_decisions
-                .create_waiter(self.run_id.clone(), permission_id.clone())
-                .await;
-            self.emit(RunEvent::Permission {
-                permission_id: Some(permission_id.clone()),
-                title: title.clone(),
-                input: tool_call.get("rawInput").cloned(),
-                options: mapped_options.clone(),
-                selected: None,
-                requires_response: true,
-            });
-            let decision = receiver
-                .await
-                .map_err(|_| anyhow!("permission response channel closed"))?;
-            let selected = options
-                .iter()
-                .find(|option| {
-                    option.get("optionId").and_then(Value::as_str)
-                        == Some(decision.option_id.as_str())
-                })
-                .ok_or_else(|| anyhow!("permission response selected an unknown option"))?;
-            selected.to_owned()
-        };
-        let selected_name = selected
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string();
-        let option_id = selected
-            .get("optionId")
-            .and_then(Value::as_str)
-            .ok_or_else(|| anyhow!("selected permission option is missing optionId"))?;
-        self.emit(RunEvent::Permission {
-            permission_id: if self.auto_allow {
-                None
-            } else {
-                Some(permission_id)
-            },
-            title,
-            input: tool_call.get("rawInput").cloned(),
-            options: mapped_options,
-            selected: Some(selected_name),
-            requires_response: false,
-        });
-        Ok(json!({"outcome": {"outcome": "selected", "optionId": option_id}}))
+        permission_flow::request_permission(
+            params,
+            &self.run_id,
+            self.auto_allow,
+            &self.permission_decisions,
+            |event| self.emit(event),
+        )
+        .await
     }
 
     async fn session_update(&self, params: Value) {
@@ -323,154 +243,32 @@ where
     }
 
     async fn create_terminal(&self, params: Value) -> Result<Value> {
-        let command = string_param(&params, "command")?;
-        let args = params
-            .get("args")
-            .and_then(Value::as_array)
-            .map(|items| {
-                items
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-        let working_dir = if let Some(cwd) = params.get("cwd").and_then(Value::as_str) {
-            self.resolve_inside_workspace(cwd)?
-        } else {
-            self.workspace.clone()
-        };
-        let mut cmd = Command::new(command);
-        cmd.args(&args)
-            .current_dir(&working_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        if let Some(env_items) = params.get("env").and_then(Value::as_array) {
-            for item in env_items {
-                if let (Some(name), Some(value)) = (
-                    item.get("name").and_then(Value::as_str),
-                    item.get("value").and_then(Value::as_str),
-                ) {
-                    cmd.env(name, value);
-                }
-            }
-        }
-
-        let mut child = cmd
-            .spawn()
-            .with_context(|| format!("spawning terminal command {command}"))?;
-        let terminal_id = Uuid::new_v4().to_string();
-        let output_limit = params
-            .get("outputByteLimit")
-            .and_then(Value::as_u64)
-            .unwrap_or(256_000) as usize;
-
-        self.emit(RunEvent::Terminal {
-            operation: "create".into(),
-            terminal_id: Some(terminal_id.clone()),
-            message: format!(
-                "{} (cwd={})",
-                display_command(command, &args),
-                working_dir.display()
-            ),
-        });
-
-        let output = Arc::new(Mutex::new(Vec::new()));
-        let mut stdout = child.stdout.take();
-        let mut stderr = child.stderr.take();
-        let reader_output = Arc::clone(&output);
-        let reader_task = tokio::spawn(async move {
-            let out_task = async {
-                if let Some(stdout) = stdout.as_mut() {
-                    capture_output(stdout, Arc::clone(&reader_output), output_limit).await;
-                }
-            };
-            let err_task = async {
-                if let Some(stderr) = stderr.as_mut() {
-                    capture_output(stderr, Arc::clone(&reader_output), output_limit).await;
-                }
-            };
-            tokio::join!(out_task, err_task);
-        });
-
-        self.terminals.lock().await.insert(
-            terminal_id.clone(),
-            TerminalState {
-                child: Arc::new(Mutex::new(child)),
-                output,
-                output_limit,
-                reader_task: Arc::new(Mutex::new(Some(reader_task))),
-            },
-        );
-        Ok(json!({"terminalId": terminal_id}))
+        self.terminals
+            .create(
+                params,
+                self.workspace.clone(),
+                |path| self.resolve_inside_workspace(path),
+                |event| self.emit(event),
+            )
+            .await
     }
 
     async fn terminal_output(&self, params: Value) -> Result<Value> {
-        let terminal_id = string_param(&params, "terminalId")?;
-        let terminals = self.terminals.lock().await;
-        let state = terminals
-            .get(terminal_id)
-            .ok_or_else(|| anyhow!("unknown terminal id: {terminal_id}"))?;
-        let output = terminal_text(state).await;
-        let truncated = state.output.lock().await.len() >= state.output_limit;
-        let exit_status = terminal_exit_status(state).await?;
-        Ok(json!({"output": output, "truncated": truncated, "exitStatus": exit_status}))
+        self.terminals.output(params).await
     }
 
     async fn wait_for_terminal_exit(&self, params: Value) -> Result<Value> {
-        let terminal_id = string_param(&params, "terminalId")?;
-        let (child, reader_task) = {
-            let terminals = self.terminals.lock().await;
-            let state = terminals
-                .get(terminal_id)
-                .ok_or_else(|| anyhow!("unknown terminal id: {terminal_id}"))?;
-            (Arc::clone(&state.child), Arc::clone(&state.reader_task))
-        };
-        let status = child.lock().await.wait().await?;
-        if let Some(reader_task) = reader_task.lock().await.take() {
-            let _ = reader_task.await;
-        }
-        self.emit(RunEvent::Terminal {
-            operation: "exit".into(),
-            terminal_id: Some(terminal_id.to_string()),
-            message: format!("{:?}", status.code()),
-        });
-        Ok(exit_status_json(
-            status.code(),
-            unix_signal_from_status(&status),
-        ))
+        self.terminals
+            .wait_for_exit(params, |event| self.emit(event))
+            .await
     }
 
     async fn kill_terminal(&self, params: Value) -> Result<Value> {
-        let terminal_id = string_param(&params, "terminalId")?;
-        let terminals = self.terminals.lock().await;
-        let state = terminals
-            .get(terminal_id)
-            .ok_or_else(|| anyhow!("unknown terminal id: {terminal_id}"))?;
-        let child = state.child.lock().await;
-        if let Some(pid) = child.id() {
-            #[cfg(unix)]
-            unsafe {
-                libc::kill(pid as i32, libc::SIGTERM);
-            }
-        }
-        self.emit(RunEvent::Terminal {
-            operation: "kill".into(),
-            terminal_id: Some(terminal_id.to_string()),
-            message: "SIGTERM sent".into(),
-        });
-        Ok(json!({}))
+        self.terminals.kill(params, |event| self.emit(event)).await
     }
 
     async fn release_terminal(&self, params: Value) -> Result<Value> {
-        let terminal_id = string_param(&params, "terminalId")?;
-        if let Some(state) = self.terminals.lock().await.remove(terminal_id) {
-            if let Some(reader_task) = state.reader_task.lock().await.take() {
-                reader_task.abort();
-            }
-        }
-        Ok(json!({}))
+        self.terminals.release(params).await
     }
 
     fn resolve_inside_workspace(&self, path: &str) -> Result<PathBuf> {
@@ -486,122 +284,9 @@ where
     }
 }
 
-fn select_permission_option<'a>(options: &'a [Value], auto_allow: bool) -> Option<&'a Value> {
-    if auto_allow {
-        for desired in ["allow_once", "allow_always"] {
-            if let Some(option) = options
-                .iter()
-                .find(|option| option.get("kind").and_then(Value::as_str) == Some(desired))
-            {
-                return Some(option);
-            }
-        }
-    }
-    options.iter().find(|option| {
-        option
-            .get("kind")
-            .and_then(Value::as_str)
-            .is_some_and(|kind| kind.starts_with("allow"))
-    })
-}
-
-async fn capture_output<R>(reader: &mut R, output: Arc<Mutex<Vec<u8>>>, limit: usize)
-where
-    R: AsyncReadExt + Unpin,
-{
-    let mut buf = [0_u8; 4096];
-    loop {
-        let Ok(read) = reader.read(&mut buf).await else {
-            return;
-        };
-        if read == 0 {
-            return;
-        }
-        let mut output = output.lock().await;
-        output.extend_from_slice(&buf[..read]);
-        if output.len() > limit {
-            let excess = output.len() - limit;
-            output.drain(..excess);
-        }
-    }
-}
-
-async fn terminal_text(state: &TerminalState) -> String {
-    String::from_utf8_lossy(&state.output.lock().await).into_owned()
-}
-
-async fn terminal_exit_status(state: &TerminalState) -> Result<Value> {
-    let mut child = state.child.lock().await;
-    if let Some(status) = child.try_wait()? {
-        Ok(exit_status_json(
-            status.code(),
-            unix_signal_from_status(&status),
-        ))
-    } else {
-        Ok(Value::Null)
-    }
-}
-
-fn exit_status_json(code: Option<i32>, signal: Option<i32>) -> Value {
-    if let Some(code) = code {
-        json!({"exitCode": code})
-    } else if let Some(signal) = signal {
-        json!({"signal": signal.to_string()})
-    } else {
-        Value::Null
-    }
-}
-
-#[cfg(unix)]
-fn unix_signal_from_status(status: &std::process::ExitStatus) -> Option<i32> {
-    use std::os::unix::process::ExitStatusExt;
-    status.signal()
-}
-
-#[cfg(not(unix))]
-fn unix_signal_from_status(_status: &std::process::ExitStatus) -> Option<i32> {
-    None
-}
-
 pub fn lifecycle(status: LifecycleStatus, message: impl Into<String>) -> RunEvent {
     RunEvent::Lifecycle {
         status,
         message: message.into(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::select_permission_option;
-    use serde_json::json;
-
-    #[test]
-    fn auto_allow_prefers_allow_once_before_allow_always() {
-        let options = vec![
-            json!({"kind": "allow_always", "optionId": "always"}),
-            json!({"kind": "allow_once", "optionId": "once"}),
-        ];
-
-        let selected = select_permission_option(&options, true).expect("permission option");
-
-        assert_eq!(
-            selected.get("optionId").and_then(|value| value.as_str()),
-            Some("once")
-        );
-    }
-
-    #[test]
-    fn manual_mode_still_selects_first_allow_option_as_fallback() {
-        let options = vec![
-            json!({"kind": "reject_once", "optionId": "reject"}),
-            json!({"kind": "allow_always", "optionId": "always"}),
-        ];
-
-        let selected = select_permission_option(&options, false).expect("permission option");
-
-        assert_eq!(
-            selected.get("optionId").and_then(|value| value.as_str()),
-            Some("always")
-        );
     }
 }

--- a/src-tauri/src/adapters/acp/mod.rs
+++ b/src-tauri/src/adapters/acp/mod.rs
@@ -1,5 +1,7 @@
 pub mod client;
+mod permission_flow;
 pub mod runner;
 pub mod session_update_mapper;
+mod terminal;
 pub mod transport;
 pub mod util;

--- a/src-tauri/src/adapters/acp/permission_flow.rs
+++ b/src-tauri/src/adapters/acp/permission_flow.rs
@@ -1,0 +1,153 @@
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::{
+    adapters::acp::util::clean_tool_title,
+    domain::events::{PermissionOption, RunEvent},
+    ports::permission::PermissionDecisionPort,
+};
+
+pub async fn request_permission<P, F>(
+    params: Value,
+    run_id: &str,
+    auto_allow: bool,
+    permission_decisions: &P,
+    emit: F,
+) -> Result<Value>
+where
+    P: PermissionDecisionPort,
+    F: Fn(RunEvent),
+{
+    let options = params
+        .get("options")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("permission request missing options"))?;
+    let tool_call = params.get("toolCall").cloned().unwrap_or(Value::Null);
+    let title = clean_tool_title(tool_call.get("title").and_then(Value::as_str));
+    let mapped_options = options
+        .iter()
+        .map(|option| PermissionOption {
+            name: option
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            kind: option
+                .get("kind")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            option_id: option
+                .get("optionId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    let permission_id = Uuid::new_v4().to_string();
+    let selected = if auto_allow {
+        select_permission_option(options, true)
+            .ok_or_else(|| anyhow!("No allow permission option was offered by the agent."))?
+            .to_owned()
+    } else {
+        let receiver = permission_decisions
+            .create_waiter(run_id.to_string(), permission_id.clone())
+            .await;
+        emit(RunEvent::Permission {
+            permission_id: Some(permission_id.clone()),
+            title: title.clone(),
+            input: tool_call.get("rawInput").cloned(),
+            options: mapped_options.clone(),
+            selected: None,
+            requires_response: true,
+        });
+        let decision = receiver
+            .await
+            .map_err(|_| anyhow!("permission response channel closed"))?;
+        let selected = options
+            .iter()
+            .find(|option| {
+                option.get("optionId").and_then(Value::as_str) == Some(decision.option_id.as_str())
+            })
+            .ok_or_else(|| anyhow!("permission response selected an unknown option"))?;
+        selected.to_owned()
+    };
+    let selected_name = selected
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let option_id = selected
+        .get("optionId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("selected permission option is missing optionId"))?;
+    emit(RunEvent::Permission {
+        permission_id: if auto_allow {
+            None
+        } else {
+            Some(permission_id)
+        },
+        title,
+        input: tool_call.get("rawInput").cloned(),
+        options: mapped_options,
+        selected: Some(selected_name),
+        requires_response: false,
+    });
+    Ok(json!({"outcome": {"outcome": "selected", "optionId": option_id}}))
+}
+
+fn select_permission_option(options: &[Value], auto_allow: bool) -> Option<&Value> {
+    if auto_allow {
+        for desired in ["allow_once", "allow_always"] {
+            if let Some(option) = options
+                .iter()
+                .find(|option| option.get("kind").and_then(Value::as_str) == Some(desired))
+            {
+                return Some(option);
+            }
+        }
+    }
+    options.iter().find(|option| {
+        option
+            .get("kind")
+            .and_then(Value::as_str)
+            .is_some_and(|kind| kind.starts_with("allow"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_permission_option;
+    use serde_json::json;
+
+    #[test]
+    fn auto_allow_prefers_allow_once_before_allow_always() {
+        let options = vec![
+            json!({"kind": "allow_always", "optionId": "always"}),
+            json!({"kind": "allow_once", "optionId": "once"}),
+        ];
+
+        let selected = select_permission_option(&options, true).expect("permission option");
+
+        assert_eq!(
+            selected.get("optionId").and_then(|value| value.as_str()),
+            Some("once")
+        );
+    }
+
+    #[test]
+    fn manual_mode_still_selects_first_allow_option_as_fallback() {
+        let options = vec![
+            json!({"kind": "reject_once", "optionId": "reject"}),
+            json!({"kind": "allow_always", "optionId": "always"}),
+        ];
+
+        let selected = select_permission_option(&options, false).expect("permission option");
+
+        assert_eq!(
+            selected.get("optionId").and_then(|value| value.as_str()),
+            Some("always")
+        );
+    }
+}

--- a/src-tauri/src/adapters/acp/terminal.rs
+++ b/src-tauri/src/adapters/acp/terminal.rs
@@ -1,0 +1,257 @@
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Value, json};
+use std::{collections::HashMap, path::PathBuf, process::Stdio, sync::Arc};
+use tokio::{
+    io::AsyncReadExt,
+    process::{Child, Command},
+    sync::Mutex,
+};
+use uuid::Uuid;
+
+use crate::{
+    adapters::acp::util::{display_command, string_param},
+    domain::events::RunEvent,
+};
+
+struct TerminalState {
+    child: Arc<Mutex<Child>>,
+    output: Arc<Mutex<Vec<u8>>>,
+    output_limit: usize,
+    reader_task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+}
+
+pub struct TerminalHandler {
+    terminals: Mutex<HashMap<String, TerminalState>>,
+}
+
+impl TerminalHandler {
+    pub fn new() -> Self {
+        Self {
+            terminals: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub async fn create<F>(
+        &self,
+        params: Value,
+        workspace: PathBuf,
+        resolve_inside_workspace: impl Fn(&str) -> Result<PathBuf>,
+        emit: F,
+    ) -> Result<Value>
+    where
+        F: Fn(RunEvent),
+    {
+        let command = string_param(&params, "command")?;
+        let args = params
+            .get("args")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let working_dir = if let Some(cwd) = params.get("cwd").and_then(Value::as_str) {
+            resolve_inside_workspace(cwd)?
+        } else {
+            workspace
+        };
+        let mut cmd = Command::new(command);
+        cmd.args(&args)
+            .current_dir(&working_dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(env_items) = params.get("env").and_then(Value::as_array) {
+            for item in env_items {
+                if let (Some(name), Some(value)) = (
+                    item.get("name").and_then(Value::as_str),
+                    item.get("value").and_then(Value::as_str),
+                ) {
+                    cmd.env(name, value);
+                }
+            }
+        }
+
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("spawning terminal command {command}"))?;
+        let terminal_id = Uuid::new_v4().to_string();
+        let output_limit = params
+            .get("outputByteLimit")
+            .and_then(Value::as_u64)
+            .unwrap_or(256_000) as usize;
+
+        emit(RunEvent::Terminal {
+            operation: "create".into(),
+            terminal_id: Some(terminal_id.clone()),
+            message: format!(
+                "{} (cwd={})",
+                display_command(command, &args),
+                working_dir.display()
+            ),
+        });
+
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let mut stdout = child.stdout.take();
+        let mut stderr = child.stderr.take();
+        let reader_output = Arc::clone(&output);
+        let reader_task = tokio::spawn(async move {
+            let out_task = async {
+                if let Some(stdout) = stdout.as_mut() {
+                    capture_output(stdout, Arc::clone(&reader_output), output_limit).await;
+                }
+            };
+            let err_task = async {
+                if let Some(stderr) = stderr.as_mut() {
+                    capture_output(stderr, Arc::clone(&reader_output), output_limit).await;
+                }
+            };
+            tokio::join!(out_task, err_task);
+        });
+
+        self.terminals.lock().await.insert(
+            terminal_id.clone(),
+            TerminalState {
+                child: Arc::new(Mutex::new(child)),
+                output,
+                output_limit,
+                reader_task: Arc::new(Mutex::new(Some(reader_task))),
+            },
+        );
+        Ok(json!({"terminalId": terminal_id}))
+    }
+
+    pub async fn output(&self, params: Value) -> Result<Value> {
+        let terminal_id = string_param(&params, "terminalId")?;
+        let terminals = self.terminals.lock().await;
+        let state = terminals
+            .get(terminal_id)
+            .ok_or_else(|| anyhow!("unknown terminal id: {terminal_id}"))?;
+        let output = terminal_text(state).await;
+        let truncated = state.output.lock().await.len() >= state.output_limit;
+        let exit_status = terminal_exit_status(state).await?;
+        Ok(json!({"output": output, "truncated": truncated, "exitStatus": exit_status}))
+    }
+
+    pub async fn wait_for_exit<F>(&self, params: Value, emit: F) -> Result<Value>
+    where
+        F: Fn(RunEvent),
+    {
+        let terminal_id = string_param(&params, "terminalId")?;
+        let (child, reader_task) = {
+            let terminals = self.terminals.lock().await;
+            let state = terminals
+                .get(terminal_id)
+                .ok_or_else(|| anyhow!("unknown terminal id: {terminal_id}"))?;
+            (Arc::clone(&state.child), Arc::clone(&state.reader_task))
+        };
+        let status = child.lock().await.wait().await?;
+        if let Some(reader_task) = reader_task.lock().await.take() {
+            let _ = reader_task.await;
+        }
+        emit(RunEvent::Terminal {
+            operation: "exit".into(),
+            terminal_id: Some(terminal_id.to_string()),
+            message: format!("{:?}", status.code()),
+        });
+        Ok(exit_status_json(
+            status.code(),
+            unix_signal_from_status(&status),
+        ))
+    }
+
+    pub async fn kill<F>(&self, params: Value, emit: F) -> Result<Value>
+    where
+        F: Fn(RunEvent),
+    {
+        let terminal_id = string_param(&params, "terminalId")?;
+        let terminals = self.terminals.lock().await;
+        let state = terminals
+            .get(terminal_id)
+            .ok_or_else(|| anyhow!("unknown terminal id: {terminal_id}"))?;
+        let child = state.child.lock().await;
+        if let Some(pid) = child.id() {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
+        }
+        emit(RunEvent::Terminal {
+            operation: "kill".into(),
+            terminal_id: Some(terminal_id.to_string()),
+            message: "SIGTERM sent".into(),
+        });
+        Ok(json!({}))
+    }
+
+    pub async fn release(&self, params: Value) -> Result<Value> {
+        let terminal_id = string_param(&params, "terminalId")?;
+        if let Some(state) = self.terminals.lock().await.remove(terminal_id) {
+            if let Some(reader_task) = state.reader_task.lock().await.take() {
+                reader_task.abort();
+            }
+        }
+        Ok(json!({}))
+    }
+}
+
+async fn capture_output<R>(reader: &mut R, output: Arc<Mutex<Vec<u8>>>, limit: usize)
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut buf = [0_u8; 4096];
+    loop {
+        let Ok(read) = reader.read(&mut buf).await else {
+            return;
+        };
+        if read == 0 {
+            return;
+        }
+        let mut output = output.lock().await;
+        output.extend_from_slice(&buf[..read]);
+        if output.len() > limit {
+            let excess = output.len() - limit;
+            output.drain(..excess);
+        }
+    }
+}
+
+async fn terminal_text(state: &TerminalState) -> String {
+    String::from_utf8_lossy(&state.output.lock().await).into_owned()
+}
+
+async fn terminal_exit_status(state: &TerminalState) -> Result<Value> {
+    let mut child = state.child.lock().await;
+    if let Some(status) = child.try_wait()? {
+        Ok(exit_status_json(
+            status.code(),
+            unix_signal_from_status(&status),
+        ))
+    } else {
+        Ok(Value::Null)
+    }
+}
+
+fn exit_status_json(code: Option<i32>, signal: Option<i32>) -> Value {
+    if let Some(code) = code {
+        json!({"exitCode": code})
+    } else if let Some(signal) = signal {
+        json!({"signal": signal.to_string()})
+    } else {
+        Value::Null
+    }
+}
+
+#[cfg(unix)]
+fn unix_signal_from_status(status: &std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn unix_signal_from_status(_status: &std::process::ExitStatus) -> Option<i32> {
+    None
+}


### PR DESCRIPTION
## Summary
- extract ACP permission request flow into permission_flow.rs
- extract terminal state and terminal request handlers into terminal.rs
- keep AcpClient as the dispatcher/facade for ACP requests and notifications

Closes #21

## Tests
- cargo test