### PR TITLE
Enforce backend architecture boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check frontend FSD boundaries
         run: npm run check:fsd
 
+      - name: Check backend architecture boundaries
+        run: npm run check:backend-boundaries
+
       - name: Build frontend
         run: npm run build
 

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -74,6 +74,14 @@ flowchart LR
 - **application**은 유스케이스 오케스트레이션을 소유한다. `SessionRegistry`, `SessionHandle`, `RunEventSink` 같은 포트를 통해 일한다. 테스트에서는 fake port로 대체 가능.
 - **adapters**는 포트를 구현하면서 Tauri, ACP JSON-RPC, subprocess, 파일시스템, 권한 결정 등 외부 프로토콜을 격리한다.
 
+이 방향은 CI에서 `npm run check:backend-boundaries`로 검사한다. 검사는 `src-tauri/src/{domain,ports,application}`의 Rust `use crate::...` 경로를 확인하며 다음 역방향 의존을 실패 처리한다.
+
+- `domain` → `ports`, `application`, `adapters`
+- `ports` → `application`, `adapters`
+- `application` → `adapters`
+
+검사 스크립트는 `scripts/check-backend-boundaries.mjs`에 있으며, 파서 자체의 기본 동작은 `npm run check:backend-boundaries:self-test`로 확인할 수 있다.
+
 ## 주요 포트
 
 | 포트 | 책임 |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "check:backend-boundaries": "node scripts/check-backend-boundaries.mjs",
+    "check:backend-boundaries:self-test": "node scripts/check-backend-boundaries.mjs --self-test",
     "check:fsd": "node scripts/check-fsd-boundaries.mjs",
     "check:fsd:self-test": "node scripts/check-fsd-boundaries.mjs --self-test",
     "preview": "vite preview",

--- a/scripts/check-backend-boundaries.mjs
+++ b/scripts/check-backend-boundaries.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const backendSrcRoot = path.join(root, "src-tauri", "src");
+const runSelfTest = process.argv.includes("--self-test");
+const rustExtension = ".rs";
+
+const layers = new Set(["domain", "ports", "application", "adapters"]);
+const forbiddenImports = {
+  domain: new Set(["ports", "application", "adapters"]),
+  ports: new Set(["application", "adapters"]),
+  application: new Set(["adapters"]),
+  adapters: new Set(),
+};
+
+const violations = [];
+
+if (runSelfTest) {
+  runBoundarySelfTest();
+} else {
+  for (const file of walk(backendSrcRoot)) {
+    const fromLayer = getLayer(file);
+    if (!fromLayer) continue;
+
+    const relativeFile = toPosix(path.relative(root, file));
+    const source = fs.readFileSync(file, "utf8");
+    const importLayers = collectUseImportLayers(source);
+    for (const importedLayer of importLayers) {
+      if (!forbiddenImports[fromLayer].has(importedLayer)) continue;
+      violations.push({
+        file: relativeFile,
+        message: `${fromLayer} cannot import from crate::${importedLayer}. Allowed direction is adapters -> application -> ports -> domain.`,
+      });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Backend boundary check failed:\n");
+  for (const violation of violations) {
+    console.error(`- ${violation.file}`);
+    console.error(`  ${violation.message}`);
+  }
+  process.exit(1);
+}
+
+console.log("Backend boundary check passed.");
+
+function runBoundarySelfTest() {
+  const cases = [
+    {
+      name: "domain cannot import ports",
+      fromLayer: "domain",
+      source: "use crate::ports::session_registry::SessionRegistry;",
+      expected: ["ports"],
+    },
+    {
+      name: "ports can import domain",
+      fromLayer: "ports",
+      source: "use crate::domain::events::RunEvent;",
+      expected: [],
+    },
+    {
+      name: "application cannot import grouped adapters",
+      fromLayer: "application",
+      source: "use crate::{adapters::session_registry::AppState, ports::event_sink::RunEventSink};",
+      expected: ["adapters"],
+    },
+    {
+      name: "adapters can import application and ports",
+      fromLayer: "adapters",
+      source: "use crate::{application::start_agent_run::StartAgentRunUseCase, ports::{event_sink::RunEventSink, session_registry::SessionRegistry}};",
+      expected: [],
+    },
+    {
+      name: "line and block comments are ignored",
+      fromLayer: "ports",
+      source: `
+        // use crate::adapters::fs::LocalGoalFileReader;
+        /*
+          use crate::application::list_agents::ListAgentsUseCase;
+        */
+        use crate::domain::agent::AgentDescriptor;
+      `,
+      expected: [],
+    },
+    {
+      name: "restricted visibility use statements are checked",
+      fromLayer: "application",
+      source: "pub(crate) use crate::adapters::session_registry::AppState;",
+      expected: ["adapters"],
+    },
+  ];
+
+  for (const testCase of cases) {
+    const before = violations.length;
+    const actual = collectUseImportLayers(testCase.source)
+      .filter((importedLayer) => forbiddenImports[testCase.fromLayer].has(importedLayer))
+      .sort();
+    const expected = testCase.expected.toSorted();
+
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(
+        `Self-test failed for "${testCase.name}": expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}.`,
+      );
+    }
+    violations.splice(before);
+  }
+
+  console.log("Backend boundary self-test passed.");
+}
+
+function* walk(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else if (path.extname(entry.name) === rustExtension) {
+      yield fullPath;
+    }
+  }
+}
+
+function getLayer(file) {
+  const relative = toPosix(path.relative(backendSrcRoot, file));
+  const [layer] = relative.split("/");
+  return layers.has(layer) ? layer : undefined;
+}
+
+function collectUseImportLayers(source) {
+  const cleanedSource = stripRustComments(source);
+  const importedLayers = new Set();
+  const useStatements = /\b(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([\s\S]*?);/g;
+
+  for (const match of cleanedSource.matchAll(useStatements)) {
+    const useTree = match[1];
+    collectDirectCrateImports(useTree, importedLayers);
+    collectGroupedCrateImports(useTree, importedLayers);
+  }
+
+  return [...importedLayers];
+}
+
+function collectDirectCrateImports(useTree, importedLayers) {
+  const directCrateImport = /crate\s*::\s*(domain|ports|application|adapters)\b/g;
+  for (const match of useTree.matchAll(directCrateImport)) {
+    importedLayers.add(match[1]);
+  }
+}
+
+function collectGroupedCrateImports(useTree, importedLayers) {
+  const groupedRoot = /crate\s*::\s*\{([\s\S]*)\}/g;
+  for (const match of useTree.matchAll(groupedRoot)) {
+    const groupBody = match[1];
+    const rootLayerImport = /(?:^|[,{])\s*(domain|ports|application|adapters)\b/g;
+    for (const layerMatch of groupBody.matchAll(rootLayerImport)) {
+      importedLayers.add(layerMatch[1]);
+    }
+  }
+}
+
+function stripRustComments(source) {
+  let output = "";
+  let i = 0;
+  let blockDepth = 0;
+  let inLineComment = false;
+
+  while (i < source.length) {
+    const current = source[i];
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (current === "\n") {
+        inLineComment = false;
+        output += current;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (blockDepth > 0) {
+      if (current === "/" && next === "*") {
+        blockDepth += 1;
+        i += 2;
+      } else if (current === "*" && next === "/") {
+        blockDepth -= 1;
+        i += 2;
+      } else {
+        if (current === "\n") output += current;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      inLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      blockDepth = 1;
+      i += 2;
+      continue;
+    }
+
+    output += current;
+    i += 1;
+  }
+
+  return output;
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}

--- a/src-tauri/src/application/resolve_workdir.rs
+++ b/src-tauri/src/application/resolve_workdir.rs
@@ -1,10 +1,10 @@
 use anyhow::{Result, anyhow, bail};
-use std::path::{Path, PathBuf};
-
-use crate::{
-    adapters::acp::util::{expand_tilde, normalize_path},
-    ports::workspace_store::WorkspaceStore,
+use std::{
+    env,
+    path::{Path, PathBuf},
 };
+
+use crate::ports::workspace_store::WorkspaceStore;
 
 #[derive(Clone)]
 pub struct ResolveWorkdirUseCase<S>
@@ -75,5 +75,36 @@ where
             );
         }
         Ok(Some(resolved))
+    }
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Some(home) = env::var_os("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn normalize_path(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        Ok(path.canonicalize()?)
+    } else if let Some(parent) = path.parent() {
+        let parent = if parent.as_os_str().is_empty() {
+            env::current_dir()?
+        } else if parent.exists() {
+            parent.canonicalize()?
+        } else {
+            normalize_path(parent)?
+        };
+        Ok(parent.join(path.file_name().unwrap_or_default()))
+    } else {
+        Ok(env::current_dir()?.join(path))
     }
 }


### PR DESCRIPTION
## Summary
- add a lightweight backend boundary checker for Rust crate layer imports
- wire the checker into npm scripts and CI
- document the backend boundary enforcement in the architecture guide
- remove an existing application -> adapters import from resolve_workdir

Closes #22

## Validation
- npm run check:backend-boundaries:self-test
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test
- git diff --check