### PR TITLE
Enforce backend architecture boundaries

### DIFF
--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -74,7 +74,13 @@ flowchart LR
 - **application**은 유스케이스 오케스트레이션을 소유한다. `SessionRegistry`, `SessionHandle`, `RunEventSink` 같은 포트를 통해 일한다. 테스트에서는 fake port로 대체 가능.
 - **adapters**는 포트를 구현하면서 Tauri, ACP JSON-RPC, subprocess, 파일시스템, 권한 결정 등 외부 프로토콜을 격리한다.
 
-이 방향은 CI에서 `npm run check:backend-boundaries`로 검사한다. 스크립트는 `src-tauri/src/domain`, `src-tauri/src/ports`, `src-tauri/src/application`의 Rust 소스에서 금지된 `crate::...` 레이어 참조를 찾고, 예를 들어 `application/`이 `crate::adapters`를 참조하면 실패한다. 스크립트 자체의 샘플 규칙 검증은 `npm run check:backend-boundaries:self-test`로 실행한다.
+이 방향은 CI에서 `npm run check:backend-boundaries`로 검사한다. 스크립트는 `src-tauri/src/{domain,ports,application}`의 Rust 소스에서 금지된 `crate::...` 레이어 참조를 찾고, 다음 역방향 의존을 실패 처리한다.
+
+- `domain` → `ports`, `application`, `adapters`
+- `ports` → `application`, `adapters`
+- `application` → `adapters`
+
+검사 스크립트는 `scripts/check-backend-boundaries.mjs`에 있으며, 파서 자체의 기본 동작은 `npm run check:backend-boundaries:self-test`로 확인할 수 있다.
 
 ## 주요 포트
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "check:fsd": "node scripts/check-fsd-boundaries.mjs",
-    "check:fsd:self-test": "node scripts/check-fsd-boundaries.mjs --self-test",
     "check:backend-boundaries": "node scripts/check-backend-boundaries.mjs",
     "check:backend-boundaries:self-test": "node scripts/check-backend-boundaries.mjs --self-test",
+    "check:fsd": "node scripts/check-fsd-boundaries.mjs",
+    "check:fsd:self-test": "node scripts/check-fsd-boundaries.mjs --self-test",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",

--- a/scripts/check-backend-boundaries.mjs
+++ b/scripts/check-backend-boundaries.mjs
@@ -69,6 +69,24 @@ function runBoundarySelfTest() {
       source: "let _ = crate::adapters::session_registry::AppState::default();",
       expected: 1,
     },
+    {
+      name: "restricted visibility use statements are checked",
+      layer: "application",
+      source: "pub(crate) use crate::adapters::session_registry::AppState;",
+      expected: 1,
+    },
+    {
+      name: "line and block comments are ignored",
+      layer: "ports",
+      source: `
+        // use crate::adapters::fs::LocalGoalFileReader;
+        /*
+          let _ = crate::application::list_agents::ListAgentsUseCase;
+        */
+        use crate::domain::agent::AgentDescriptor;
+      `,
+      expected: 0,
+    },
   ];
 
   for (const testCase of cases) {
@@ -87,9 +105,10 @@ function runBoundarySelfTest() {
 }
 
 function validateSource(file, layer, source) {
+  const sourceWithoutComments = stripRustComments(source);
   const forbiddenLayers = layerRules.get(layer) ?? new Set();
   for (const forbidden of forbiddenLayers) {
-    if (referencesCrateLayer(source, forbidden)) {
+    if (referencesCrateLayer(sourceWithoutComments, forbidden)) {
       violations.push({
         file,
         message: `${layer}/ cannot depend on crate::${forbidden}. Allowed direction is domain -> ports -> application -> adapters.`,
@@ -100,14 +119,14 @@ function validateSource(file, layer, source) {
 
 function referencesCrateLayer(source, layer) {
   return (
-    new RegExp(String.raw`\bcrate::${layer}\s*(?:::|\{)`).test(source) ||
+    new RegExp(String.raw`\bcrate::${layer}\s*(?:::|\{|\b)`).test(source) ||
     collectCrateUseBodies(source).some((body) => groupedUseReferencesLayer(body, layer))
   );
 }
 
 function collectCrateUseBodies(source) {
   const bodies = [];
-  const useCrate = /\buse\s+crate::([\s\S]*?);/g;
+  const useCrate = /\b(?:pub(?:\s*\([^)]*\))?\s+)?use\s+crate::([\s\S]*?);/g;
   for (const match of source.matchAll(useCrate)) {
     bodies.push(match[1]);
   }
@@ -117,7 +136,59 @@ function collectCrateUseBodies(source) {
 function groupedUseReferencesLayer(body, layer) {
   const trimmed = body.trim();
   if (!trimmed.startsWith("{")) return false;
-  return new RegExp(String.raw`(?:^|[,{]\s*)${layer}\s*(?:::|\{)`).test(trimmed);
+  return new RegExp(String.raw`(?:^|[,{]\s*)${layer}\s*(?:::|\{|\b)`).test(trimmed);
+}
+
+function stripRustComments(source) {
+  let output = "";
+  let i = 0;
+  let blockDepth = 0;
+  let inLineComment = false;
+
+  while (i < source.length) {
+    const current = source[i];
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (current === "\n") {
+        inLineComment = false;
+        output += current;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (blockDepth > 0) {
+      if (current === "/" && next === "*") {
+        blockDepth += 1;
+        i += 2;
+      } else if (current === "*" && next === "/") {
+        blockDepth -= 1;
+        i += 2;
+      } else {
+        if (current === "\n") output += current;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      inLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      blockDepth = 1;
+      i += 2;
+      continue;
+    }
+
+    output += current;
+    i += 1;
+  }
+
+  return output;
 }
 
 function* walk(directory) {


### PR DESCRIPTION
## Summary
- strengthen the backend boundary checker for Rust crate layer references
- preserve CI/script wiring from main while adding comment stripping and restricted visibility coverage
- document the backend boundary enforcement rules in the architecture guide

Closes #22

## Validation
- npm run check:backend-boundaries:self-test
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test
- git diff --check