### PR TITLE
Route workbench reads through workspace run selectors

### DIFF
--- a/src/features/agent-run/model.test.ts
+++ b/src/features/agent-run/model.test.ts
@@ -102,4 +102,27 @@ describe("workspace-scoped run state", () => {
     expect(run.completedAt).toEqual(expect.any(Number));
     expect(run.items.map((item) => item.body)).toEqual(["first reply", "done"]);
   });
+
+  it("keeps failed startup errors on the run before clearing the active run", () => {
+    const tabId = useWorkbenchStore.getState().activeTabId;
+    const store = useWorkbenchStore.getState();
+    store.beginRun(tabId, "run-1");
+    store.patchTab(tabId, { error: "failed to start" });
+    store.endRun(tabId);
+    store.patchTab(tabId, { activeRunId: null });
+
+    const state = useWorkbenchStore.getState();
+    const [run] = selectWorkspaceViewRuns(state, tabId);
+    const view = selectWorkspaceView(state, tabId);
+
+    expect(view?.activeRunId).toBeNull();
+    expect(view?.viewError).toBe("failed to start");
+    expect(run).toMatchObject({
+      id: "run-1",
+      sessionActive: false,
+      awaitingResponse: false,
+      runError: "failed to start",
+    });
+    expect(run.completedAt).toEqual(expect.any(Number));
+  });
 });

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -213,6 +213,26 @@ function replaceWorkspaceView(
   return views.map((view) => (view.id === viewId ? updater(view) : view));
 }
 
+function patchRunForTab(
+  state: WorkbenchState,
+  tabId: string,
+  patch: Partial<TabState>,
+): Record<string, AgentRunState> {
+  const tab = state.tabs.find((entry) => entry.id === tabId);
+  if (!tab?.activeRunId || patch.activeRunId === null) return state.runsById;
+  const run = state.runsById[tab.activeRunId];
+  if (!run) return state.runsById;
+  const next: AgentRunState = { ...run };
+  if (patch.sessionActive !== undefined) next.sessionActive = patch.sessionActive;
+  if (patch.awaitingResponse !== undefined) next.awaitingResponse = patch.awaitingResponse;
+  if (patch.idleRemainingSec !== undefined) next.idleRemainingSec = patch.idleRemainingSec;
+  if (patch.permissionPending !== undefined) next.permissionPending = patch.permissionPending;
+  if (patch.followUpQueue !== undefined) next.followUpQueue = patch.followUpQueue;
+  if (patch.items !== undefined) next.items = patch.items;
+  if (patch.error !== undefined) next.runError = patch.error;
+  return { ...state.runsById, [run.id]: next };
+}
+
 function mergeStreamedText(items: TimelineItem[], item: TimelineItem): TimelineItem[] {
   const previous = items[items.length - 1];
   const canMerge =
@@ -431,6 +451,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
         };
         return next;
       }),
+      runsById: patchRunForTab(state, tabId, patch),
     })),
 
   setTabWorkspace: (tabId, workspaceId, checkoutId) =>
@@ -793,10 +814,6 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
   },
 }));
 
-export function selectTab(state: WorkbenchState, tabId: string): TabState | undefined {
-  return state.tabs.find((t) => t.id === tabId);
-}
-
 export function selectWorkspaceView(
   state: WorkbenchState,
   workspaceViewId: string,
@@ -825,6 +842,57 @@ export function selectWorkspaceViewRuns(
   workspaceViewId: string,
 ): AgentRunState[] {
   return Object.values(state.runsById).filter((run) => run.workspaceViewId === workspaceViewId);
+}
+
+export function selectTab(state: WorkbenchState, tabId: string): TabState | undefined {
+  const view = selectWorkspaceView(state, tabId);
+  if (!view) return state.tabs.find((tab) => tab.id === tabId);
+  const activeRun = view.activeRunId ? selectRun(state, view.activeRunId) : undefined;
+  const fallback = state.tabs.find((tab) => tab.id === tabId);
+  return workspaceViewToTabState(view, activeRun, fallback);
+}
+
+export function selectTabList(state: WorkbenchState): TabState[] {
+  if (state.workspaceViews.length === 0) return state.tabs;
+  return state.workspaceViews.map((view) =>
+    workspaceViewToTabState(
+      view,
+      view.activeRunId ? selectRun(state, view.activeRunId) : undefined,
+      state.tabs.find((tab) => tab.id === view.id),
+    ),
+  );
+}
+
+function workspaceViewToTabState(
+  view: WorkspaceViewState,
+  run: AgentRunState | undefined,
+  fallback?: TabState,
+): TabState {
+  return {
+    id: view.id,
+    title: view.title,
+    workspaceId: view.workspaceId,
+    checkoutId: view.checkoutId,
+    selectedAgentId: view.draft.selectedAgentId,
+    goal: view.draft.goal,
+    cwd: view.cwd,
+    customCommand: view.draft.customCommand,
+    stdioBufferLimitMb: view.draft.stdioBufferLimitMb,
+    autoAllow: view.draft.autoAllow,
+    idleTimeoutSec: view.draft.idleTimeoutSec,
+    idleRemainingSec: run?.idleRemainingSec ?? fallback?.idleRemainingSec ?? null,
+    activeRunId: view.activeRunId,
+    sessionActive: run?.sessionActive ?? fallback?.sessionActive ?? false,
+    awaitingResponse: run?.awaitingResponse ?? fallback?.awaitingResponse ?? false,
+    followUpDraft: view.followUpDraft,
+    followUpQueue: run?.followUpQueue ?? fallback?.followUpQueue ?? [],
+    items: run?.items ?? fallback?.items ?? [],
+    filter: view.filter,
+    error: run?.runError ?? view.viewError,
+    unreadCount: view.unreadCount,
+    permissionPending: run?.permissionPending ?? fallback?.permissionPending ?? false,
+    closing: view.closing,
+  };
 }
 
 function upsertItem<T>(items: T[], item: T, getId: (item: T) => string): T[] {

--- a/src/features/agent-run/runtime.ts
+++ b/src/features/agent-run/runtime.ts
@@ -1,12 +1,12 @@
 import { cancelAgentRun, listenRunEvents, sendPromptToRun } from "./api";
-import { useWorkbenchStore } from "./model";
+import { selectTab, selectTabList, useWorkbenchStore } from "./model";
 
 let installed = false;
 let disposers: Array<() => void> = [];
 
 async function drainTabQueue(tabId: string) {
   const store = useWorkbenchStore.getState();
-  const tab = store.tabs.find((t) => t.id === tabId);
+  const tab = selectTab(store, tabId);
   if (
     !tab ||
     !tab.sessionActive ||
@@ -29,7 +29,7 @@ async function drainTabQueue(tabId: string) {
   try {
     await sendPromptToRun(runId, next.text);
   } catch (err) {
-    const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+    const current = selectTab(useWorkbenchStore.getState(), tabId);
     if (current?.activeRunId === runId) {
       useWorkbenchStore.getState().patchTab(tabId, {
         awaitingResponse: false,
@@ -42,7 +42,7 @@ async function drainTabQueue(tabId: string) {
 function startIdleTicker() {
   const interval = setInterval(() => {
     const store = useWorkbenchStore.getState();
-    for (const tab of store.tabs) {
+    for (const tab of selectTabList(store)) {
       const shouldCount =
         tab.sessionActive &&
         !tab.awaitingResponse &&
@@ -75,7 +75,8 @@ function startIdleTicker() {
 function subscribeForDrain() {
   let previousSignature = "";
   return useWorkbenchStore.subscribe((state) => {
-    const signature = state.tabs
+    const tabs = selectTabList(state);
+    const signature = tabs
       .map(
         (t) =>
           `${t.id}:${t.sessionActive ? 1 : 0}:${t.awaitingResponse ? 1 : 0}:${t.followUpQueue.length}`,
@@ -83,7 +84,7 @@ function subscribeForDrain() {
       .join("|");
     if (signature === previousSignature) return;
     previousSignature = signature;
-    for (const tab of state.tabs) {
+    for (const tab of tabs) {
       if (
         tab.sessionActive &&
         !tab.awaitingResponse &&

--- a/src/features/agent-run/tabActions.ts
+++ b/src/features/agent-run/tabActions.ts
@@ -1,11 +1,11 @@
 import { cancelAgentRun } from "./api";
-import { useWorkbenchStore } from "./model";
+import { selectTab, useWorkbenchStore } from "./model";
 
 const CLOSE_FALLBACK_MS = 5000;
 
 export async function closeWorkbenchTab(tabId: string) {
   const store = useWorkbenchStore.getState();
-  const tab = store.tabs.find((t) => t.id === tabId);
+  const tab = selectTab(store, tabId);
   if (!tab) return;
 
   if (tab.closing && tab.error) {
@@ -25,7 +25,7 @@ export async function closeWorkbenchTab(tabId: string) {
       return;
     }
     setTimeout(() => {
-      const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+      const current = selectTab(useWorkbenchStore.getState(), tabId);
       if (current && current.closing && !current.error) {
         useWorkbenchStore.getState().patchTab(tabId, {
           error: "backend lifecycle 이벤트를 받지 못했습니다. 강제로 닫을 수 있습니다.",

--- a/src/features/agent-run/tabApi.ts
+++ b/src/features/agent-run/tabApi.ts
@@ -1,5 +1,5 @@
 import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
-import { useWorkbenchStore, type TabState } from "./model";
+import { selectTab, selectTabList, useWorkbenchStore, type TabState } from "./model";
 import { closeWorkbenchTab } from "./tabActions";
 
 export type WorkbenchTabListItem = Readonly<
@@ -22,11 +22,11 @@ export type WorkbenchTabListItem = Readonly<
 >;
 
 export function useActiveTabId() {
-  return useWorkbenchStore((state) => state.activeTabId);
+  return useWorkbenchStore((state) => state.activeWorkspaceViewId);
 }
 
 export function useTabList(): WorkbenchTabListItem[] {
-  return useWorkbenchStore((state) => state.tabs);
+  return useWorkbenchStore(selectTabList);
 }
 
 export function createWorkbenchTab() {
@@ -41,14 +41,14 @@ export { closeWorkbenchTab };
 
 export function useWorkspaceState(tabId: string) {
   return useWorkbenchStore((state) => {
-    const tab = state.tabs.find((entry) => entry.id === tabId);
+    const tab = selectTab(state, tabId);
     const selectedWorkspace = state.workspaces.find((entry) => entry.id === tab?.workspaceId);
     const checkouts = tab?.workspaceId
       ? (state.checkoutsByWorkspaceId[tab.workspaceId] ?? [])
       : [];
     const selectedCheckout = checkouts.find((entry) => entry.id === tab?.checkoutId);
     const activeSameWorkdirCount = tab
-      ? state.tabs.filter(
+      ? selectTabList(state).filter(
           (entry) =>
             entry.id !== tab.id &&
             entry.sessionActive &&

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -7,7 +7,13 @@ import {
 } from "./api";
 import type { AgentRunRequest, EventGroup, TimelineItem } from "../../entities/message";
 import type { SavedPromptRunMode } from "../../entities/saved-prompt";
-import { useWorkbenchStore, type TabState, type FollowUpQueueItem } from "./model";
+import {
+  selectTab,
+  selectTabList,
+  useWorkbenchStore,
+  type TabState,
+  type FollowUpQueueItem,
+} from "./model";
 
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
 const EMPTY_ITEMS: TimelineItem[] = [];
@@ -16,9 +22,7 @@ export function useAgentRun(tabId: string) {
   const agentsQuery = useQuery({ queryKey: ["agents"], queryFn: listAgents });
   const agents = agentsQuery.data ?? [];
 
-  const tab = useWorkbenchStore(
-    (state) => state.tabs.find((t) => t.id === tabId),
-  );
+  const tab = useWorkbenchStore((state) => selectTab(state, tabId));
 
   const patch = useCallback(
     (update: Partial<TabState>) => useWorkbenchStore.getState().patchTab(tabId, update),
@@ -46,16 +50,14 @@ export function useAgentRun(tabId: string) {
   );
 
   const run = useCallback(async () => {
-    const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+    const current = selectTab(useWorkbenchStore.getState(), tabId);
     if (!current) return;
     const trimmedGoal = current.goal.trim();
     if (!trimmedGoal) {
       patch({ error: "Goal is empty." });
       return;
     }
-    const sameWorkdirRuns = useWorkbenchStore
-      .getState()
-      .tabs.filter(
+    const sameWorkdirRuns = selectTabList(useWorkbenchStore.getState()).filter(
         (entry) =>
           entry.id !== current.id &&
           entry.sessionActive &&
@@ -99,7 +101,7 @@ export function useAgentRun(tabId: string) {
   }, [tabId, patch]);
 
   const cancel = useCallback(async () => {
-    const current = useWorkbenchStore.getState().tabs.find((t) => t.id === tabId);
+    const current = selectTab(useWorkbenchStore.getState(), tabId);
     if (!current?.activeRunId) return;
     try {
       await cancelAgentRun(current.activeRunId);
@@ -112,7 +114,7 @@ export function useAgentRun(tabId: string) {
 
   const send = useCallback(() => {
     const store = useWorkbenchStore.getState();
-    const current = store.tabs.find((t) => t.id === tabId);
+    const current = selectTab(store, tabId);
     if (!current?.sessionActive) return;
     const trimmed = current.followUpDraft.trim();
     if (!trimmed) return;
@@ -123,7 +125,7 @@ export function useAgentRun(tabId: string) {
   const applySavedPrompt = useCallback(
     (body: string, runMode: SavedPromptRunMode) => {
       const store = useWorkbenchStore.getState();
-      const current = store.tabs.find((t) => t.id === tabId);
+      const current = selectTab(store, tabId);
       const trimmed = body.trim();
       if (!current || !trimmed) return;
       if (!current.sessionActive) {

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -58,13 +58,13 @@ export function useAgentRun(tabId: string) {
       return;
     }
     const sameWorkdirRuns = selectTabList(useWorkbenchStore.getState()).filter(
-        (entry) =>
-          entry.id !== current.id &&
-          entry.sessionActive &&
-          entry.workspaceId === current.workspaceId &&
-          entry.checkoutId === current.checkoutId &&
-          entry.cwd === current.cwd,
-      ).length;
+      (entry) =>
+        entry.id !== current.id &&
+        entry.sessionActive &&
+        entry.workspaceId === current.workspaceId &&
+        entry.checkoutId === current.checkoutId &&
+        entry.cwd === current.cwd,
+    ).length;
     if (
       sameWorkdirRuns > 0 &&
       current.workspaceId &&
@@ -94,9 +94,11 @@ export function useAgentRun(tabId: string) {
     try {
       await startAgentRun(request);
     } catch (err) {
-      useWorkbenchStore.getState().patchTab(tabId, { activeRunId: null });
-      useWorkbenchStore.getState().endRun(tabId);
-      patch({ error: String(err) });
+      const error = String(err);
+      const store = useWorkbenchStore.getState();
+      store.patchTab(tabId, { error });
+      store.endRun(tabId);
+      store.patchTab(tabId, { activeRunId: null });
     }
   }, [tabId, patch]);
 


### PR DESCRIPTION
## Summary
- derive tab-facing state from WorkspaceViewState and AgentRunState selectors
- switch tab API, run hook, runtime queue drain, and tab close reads to selector-based workspace view state
- keep the compatibility tab write path in place for the current UI while making runsById the read source for active run state
- preserve failed startup errors in the run map before clearing the active run pointer

Refs #13

## Tests
- npm test -- --run
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- git diff --check origin/main...HEAD