### PR TITLE
Persist ACP session metadata

### DIFF
--- a/src-tauri/src/adapters/acp/runner.rs
+++ b/src-tauri/src/adapters/acp/runner.rs
@@ -15,10 +15,12 @@ use crate::{
         util::{RpcError, display_command, expand_tilde, normalize_path, rpc_to_anyhow},
     },
     domain::{
+        acp_session::AcpSessionRecord,
         events::{LifecycleStatus, RunEvent},
         run::{AgentRunRequest, ResumePolicy},
     },
     ports::{
+        acp_session_store::AcpSessionStore,
         agent_catalog::AgentCatalog,
         event_sink::RunEventSink,
         permission::PermissionDecisionPort,
@@ -39,6 +41,7 @@ where
 {
     catalog: C,
     permissions: P,
+    session_store: Arc<dyn AcpSessionStore>,
 }
 
 impl<C, P> AcpAgentRunner<C, P>
@@ -46,10 +49,11 @@ where
     C: AgentCatalog,
     P: PermissionDecisionPort,
 {
-    pub fn new(catalog: C, permissions: P) -> Self {
+    pub fn new(catalog: C, permissions: P, session_store: Arc<dyn AcpSessionStore>) -> Self {
         Self {
             catalog,
             permissions,
+            session_store,
         }
     }
 
@@ -192,6 +196,10 @@ where
             &run_id,
             lifecycle(LifecycleStatus::SessionCreated, session_id.clone()),
         );
+        let session_record = AcpSessionRecord::from_request(&run_id, &session_id, request);
+        self.session_store
+            .record_session(session_record.clone())
+            .await?;
 
         let session = Arc::new(AcpSession {
             run_id,
@@ -199,6 +207,8 @@ where
             workspace,
             peer,
             resume_policy,
+            session_record,
+            session_store: self.session_store.clone(),
             in_flight: Mutex::new(()),
         });
 
@@ -367,6 +377,8 @@ pub struct AcpSession {
     session_id: Mutex<String>,
     workspace: PathBuf,
     resume_policy: ResumePolicy,
+    session_record: AcpSessionRecord,
+    session_store: Arc<dyn AcpSessionStore>,
     in_flight: Mutex<()>,
 }
 
@@ -429,6 +441,9 @@ impl SessionHandle for AcpSession {
                         &self.run_id,
                         lifecycle(LifecycleStatus::SessionCreated, new_id.clone()),
                     );
+                    let mut record = self.session_record.clone();
+                    record.session_id.clone_from(&new_id);
+                    self.session_store.record_session(record).await?;
                     *self.session_id.lock().await = new_id;
                     continue;
                 }

--- a/src-tauri/src/adapters/acp_session_store_sqlite.rs
+++ b/src-tauri/src/adapters/acp_session_store_sqlite.rs
@@ -1,0 +1,200 @@
+use anyhow::Result;
+use sqlx::{Row, SqlitePool};
+use std::{future::Future, pin::Pin};
+
+use crate::{
+    domain::{
+        acp_session::{AcpSessionLookup, AcpSessionRecord},
+        workspace::timestamp,
+    },
+    ports::acp_session_store::AcpSessionStore,
+};
+
+#[derive(Clone)]
+pub struct SqliteAcpSessionStore {
+    pool: SqlitePool,
+}
+
+impl SqliteAcpSessionStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+impl AcpSessionStore for SqliteAcpSessionStore {
+    fn record_session<'a>(
+        &'a self,
+        mut record: AcpSessionRecord,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            let now = timestamp();
+            record.updated_at = now;
+            upsert_session(&self.pool, &record).await
+        })
+    }
+
+    fn latest_session<'a>(
+        &'a self,
+        lookup: AcpSessionLookup,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<AcpSessionRecord>>> + Send + 'a>> {
+        Box::pin(async move {
+            let row = sqlx::query(
+                r#"
+                SELECT run_id, session_id, workspace_id, checkout_id, workdir,
+                       agent_id, agent_command, task, created_at, updated_at
+                FROM acp_sessions
+                WHERE agent_id = ?
+                  AND workspace_id IS ?
+                  AND checkout_id IS ?
+                  AND workdir IS ?
+                ORDER BY updated_at DESC
+                LIMIT 1
+                "#,
+            )
+            .bind(&lookup.agent_id)
+            .bind(&lookup.workspace_id)
+            .bind(&lookup.checkout_id)
+            .bind(&lookup.workdir)
+            .fetch_optional(&self.pool)
+            .await?;
+            row.map(session_from_row).transpose()
+        })
+    }
+}
+
+async fn upsert_session(pool: &SqlitePool, record: &AcpSessionRecord) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO acp_sessions (
+            run_id, session_id, workspace_id, checkout_id, workdir,
+            agent_id, agent_command, task, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET
+            session_id = excluded.session_id,
+            workspace_id = excluded.workspace_id,
+            checkout_id = excluded.checkout_id,
+            workdir = excluded.workdir,
+            agent_id = excluded.agent_id,
+            agent_command = excluded.agent_command,
+            task = excluded.task,
+            updated_at = excluded.updated_at
+        "#,
+    )
+    .bind(&record.run_id)
+    .bind(&record.session_id)
+    .bind(&record.workspace_id)
+    .bind(&record.checkout_id)
+    .bind(&record.workdir)
+    .bind(&record.agent_id)
+    .bind(&record.agent_command)
+    .bind(&record.task)
+    .bind(&record.created_at)
+    .bind(&record.updated_at)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn session_from_row(row: sqlx::sqlite::SqliteRow) -> Result<AcpSessionRecord> {
+    Ok(AcpSessionRecord {
+        run_id: row.try_get("run_id")?,
+        session_id: row.try_get("session_id")?,
+        workspace_id: row.try_get("workspace_id")?,
+        checkout_id: row.try_get("checkout_id")?,
+        workdir: row.try_get("workdir")?,
+        agent_id: row.try_get("agent_id")?,
+        agent_command: row.try_get("agent_command")?,
+        task: row.try_get("task")?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SqliteAcpSessionStore;
+    use crate::{
+        adapters::sqlite::open_database,
+        domain::{
+            acp_session::{AcpSessionLookup, AcpSessionRecord},
+            workspace::timestamp,
+        },
+        ports::acp_session_store::AcpSessionStore,
+    };
+
+    async fn temp_store() -> SqliteAcpSessionStore {
+        let dir = std::env::temp_dir().join(format!("acp-sessions-{}", uuid::Uuid::new_v4()));
+        let pool = open_database(&dir).await.unwrap();
+        SqliteAcpSessionStore::new(pool)
+    }
+
+    async fn insert_workspace_fixture(store: &SqliteAcpSessionStore) {
+        sqlx::query(
+            r#"
+            INSERT INTO workspaces (
+                id, name, raw_origin_url, canonical_origin_url, host, owner, repo, created_at, updated_at
+            )
+            VALUES ('ws-1', 'repo', 'git@github.com:owner/repo.git', 'github.com/owner/repo', 'github.com', 'owner', 'repo', '1', '1')
+            "#,
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO workspace_checkouts (
+                id, workspace_id, path, kind, is_default, created_at, updated_at
+            )
+            VALUES ('co-1', 'ws-1', '/tmp/work', 'clone', 1, '1', '1')
+            "#,
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    }
+
+    fn record(run_id: &str, session_id: &str) -> AcpSessionRecord {
+        let now = timestamp();
+        AcpSessionRecord {
+            run_id: run_id.into(),
+            session_id: session_id.into(),
+            workspace_id: Some("ws-1".into()),
+            checkout_id: Some("co-1".into()),
+            workdir: Some("/tmp/work".into()),
+            agent_id: "agent".into(),
+            agent_command: Some("agent --stdio".into()),
+            task: "task".into(),
+            created_at: now.clone(),
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn records_and_replaces_session_for_run() {
+        let store = temp_store().await;
+        insert_workspace_fixture(&store).await;
+        store
+            .record_session(record("run-1", "session-1"))
+            .await
+            .unwrap();
+        store
+            .record_session(record("run-1", "session-2"))
+            .await
+            .unwrap();
+
+        let found = store
+            .latest_session(AcpSessionLookup {
+                workspace_id: Some("ws-1".into()),
+                checkout_id: Some("co-1".into()),
+                workdir: Some("/tmp/work".into()),
+                agent_id: "agent".into(),
+            })
+            .await
+            .unwrap()
+            .expect("session should exist");
+
+        assert_eq!(found.run_id, "run-1");
+        assert_eq!(found.session_id, "session-2");
+    }
+}

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp;
+pub mod acp_session_store_sqlite;
 pub mod agent_catalog;
 pub mod fs;
 pub mod git;

--- a/src-tauri/src/adapters/sqlite.rs
+++ b/src-tauri/src/adapters/sqlite.rs
@@ -7,6 +7,7 @@ use std::{path::Path, time::Duration};
 
 const WORKSPACE_SCHEMA_VERSION: i64 = 1;
 const SAVED_PROMPTS_SCHEMA_VERSION: i64 = 2;
+const ACP_SESSIONS_SCHEMA_VERSION: i64 = 3;
 
 pub async fn open_database(app_data_dir: &Path) -> Result<SqlitePool> {
     tokio::fs::create_dir_all(app_data_dir).await?;
@@ -61,6 +62,9 @@ async fn migrate_database(pool: &SqlitePool) -> Result<()> {
     }
     if !migration_applied(pool, SAVED_PROMPTS_SCHEMA_VERSION).await? {
         migrate_saved_prompts_schema(pool).await?;
+    }
+    if !migration_applied(pool, ACP_SESSIONS_SCHEMA_VERSION).await? {
+        migrate_acp_sessions_schema(pool).await?;
     }
     Ok(())
 }
@@ -160,6 +164,42 @@ async fn migrate_saved_prompts_schema(pool: &SqlitePool) -> Result<()> {
     .await?;
     sqlx::query("INSERT INTO schema_migrations (version) VALUES (?)")
         .bind(SAVED_PROMPTS_SCHEMA_VERSION)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn migrate_acp_sessions_schema(pool: &SqlitePool) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS acp_sessions (
+            run_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            workspace_id TEXT REFERENCES workspaces(id) ON DELETE SET NULL,
+            checkout_id TEXT REFERENCES workspace_checkouts(id) ON DELETE SET NULL,
+            workdir TEXT,
+            agent_id TEXT NOT NULL,
+            agent_command TEXT,
+            task TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_acp_sessions_lookup
+        ON acp_sessions(workspace_id, checkout_id, workdir, agent_id, updated_at DESC)
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("INSERT INTO schema_migrations (version) VALUES (?)")
+        .bind(ACP_SESSIONS_SCHEMA_VERSION)
         .execute(&mut *tx)
         .await?;
     tx.commit().await?;

--- a/src-tauri/src/adapters/storage_state.rs
+++ b/src-tauri/src/adapters/storage_state.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 use std::path::PathBuf;
 
 use crate::adapters::{
+    acp_session_store_sqlite::SqliteAcpSessionStore,
     saved_prompt_store_sqlite::SqliteSavedPromptStore, sqlite::open_database,
     workspace_store_migration::migrate_json_workspace_store,
     workspace_store_sqlite::SqliteWorkspaceStore,
@@ -37,5 +38,9 @@ impl StorageState {
 
     pub fn saved_prompt_store(&self) -> SqliteSavedPromptStore {
         SqliteSavedPromptStore::new(self.pool())
+    }
+
+    pub fn acp_session_store(&self) -> SqliteAcpSessionStore {
+        SqliteAcpSessionStore::new(self.pool())
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use tauri::{AppHandle, State};
 
 use crate::{
     adapters::{
-        acp::runner::AcpAgentRunner, agent_catalog::ConfigurableAgentCatalog,
-        fs::LocalGoalFileReader, session_registry::AppState, storage_state::StorageState,
+        acp::runner::AcpAgentRunner, acp_session_store_sqlite::SqliteAcpSessionStore,
+        agent_catalog::ConfigurableAgentCatalog, fs::LocalGoalFileReader,
+        session_registry::AppState, storage_state::StorageState,
         tauri::event_sink::TauriRunEventSink,
     },
     application::{
@@ -13,14 +16,18 @@ use crate::{
         start_agent_run::StartAgentRunUseCase,
     },
     domain::{
+        acp_session::AcpSessionLookup,
         agent::AgentDescriptor,
-        run::{AgentRun, AgentRunRequest},
+        run::{AgentRun, AgentRunRequest, ResumePolicy},
         saved_prompt::{
             CreateSavedPromptInput, SavedPrompt, SavedPromptId, UpdateSavedPromptPatch,
         },
         workspace::{RegisteredWorkspace, Workspace, WorkspaceCheckout},
     },
-    ports::{saved_prompt_store::SavedPromptStore, workspace_store::WorkspaceStore},
+    ports::{
+        acp_session_store::AcpSessionStore, saved_prompt_store::SavedPromptStore,
+        workspace_store::WorkspaceStore,
+    },
 };
 
 #[tauri::command]
@@ -43,7 +50,7 @@ pub async fn start_agent_run(
     mut request: AgentRunRequest,
 ) -> Result<AgentRun, String> {
     let workspace_store = storage.workspace_store();
-    let resolved_cwd = ResolveWorkdirUseCase::new(workspace_store)
+    let resolved_cwd = ResolveWorkdirUseCase::new(workspace_store.clone())
         .execute(
             request.workspace_id.as_deref(),
             request.checkout_id.as_deref(),
@@ -54,16 +61,65 @@ pub async fn start_agent_run(
     if let Some(cwd) = resolved_cwd {
         request.cwd = Some(cwd.to_string_lossy().to_string());
     }
+    if request.checkout_id.as_deref().is_none_or(str::is_empty) {
+        if let Some(workspace_id) = request.workspace_id.as_deref() {
+            let workspace = workspace_store
+                .get_workspace(workspace_id)
+                .await
+                .map_err(|err| err.to_string())?;
+            request.checkout_id = workspace.and_then(|value| value.default_checkout_id);
+        }
+    }
+
+    let session_store = storage.acp_session_store();
+    hydrate_resume_session(&mut request, &session_store)
+        .await
+        .map_err(|err| err.to_string())?;
 
     let sink = TauriRunEventSink::new(app);
     let permissions = state.permissions();
     let registry = state.inner().clone();
-    let runner = AcpAgentRunner::new(ConfigurableAgentCatalog::from_env(), permissions);
+    let runner = AcpAgentRunner::new(
+        ConfigurableAgentCatalog::from_env(),
+        permissions,
+        Arc::new(session_store),
+    );
 
     StartAgentRunUseCase::new(registry)
         .execute(runner, sink, request)
         .await
         .map_err(String::from)
+}
+
+async fn hydrate_resume_session(
+    request: &mut AgentRunRequest,
+    session_store: &SqliteAcpSessionStore,
+) -> anyhow::Result<()> {
+    let resume_policy = request.resume_policy.unwrap_or_default();
+    if resume_policy == ResumePolicy::Fresh || has_resume_session_id(request) {
+        return Ok(());
+    }
+
+    let latest = session_store
+        .latest_session(AcpSessionLookup::from_request(request))
+        .await?;
+    if let Some(record) = latest {
+        request.resume_session_id = Some(record.session_id);
+        return Ok(());
+    }
+
+    if resume_policy == ResumePolicy::ResumeRequired {
+        anyhow::bail!("resume session not found for requested workspace context");
+    }
+    Ok(())
+}
+
+fn has_resume_session_id(request: &AgentRunRequest) -> bool {
+    request
+        .resume_session_id
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/acp_session.rs
+++ b/src-tauri/src/domain/acp_session.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{run::AgentRunRequest, workspace::timestamp};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpSessionRecord {
+    pub run_id: String,
+    pub session_id: String,
+    pub workspace_id: Option<String>,
+    pub checkout_id: Option<String>,
+    pub workdir: Option<String>,
+    pub agent_id: String,
+    pub agent_command: Option<String>,
+    pub task: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AcpSessionLookup {
+    pub workspace_id: Option<String>,
+    pub checkout_id: Option<String>,
+    pub workdir: Option<String>,
+    pub agent_id: String,
+}
+
+impl AcpSessionRecord {
+    pub fn from_request(run_id: &str, session_id: &str, request: &AgentRunRequest) -> Self {
+        let now = timestamp();
+        Self {
+            run_id: run_id.to_string(),
+            session_id: session_id.to_string(),
+            workspace_id: request.workspace_id.clone(),
+            checkout_id: request.checkout_id.clone(),
+            workdir: request.cwd.clone(),
+            agent_id: request.agent_id.clone(),
+            agent_command: request.agent_command.clone(),
+            task: request.goal.clone(),
+            created_at: now.clone(),
+            updated_at: now,
+        }
+    }
+}
+
+impl AcpSessionLookup {
+    pub fn from_request(request: &AgentRunRequest) -> Self {
+        Self {
+            workspace_id: request.workspace_id.clone(),
+            checkout_id: request.checkout_id.clone(),
+            workdir: request.cwd.clone(),
+            agent_id: request.agent_id.clone(),
+        }
+    }
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod acp_session;
 pub mod agent;
 pub mod events;
 pub mod run;

--- a/src-tauri/src/ports/acp_session_store.rs
+++ b/src-tauri/src/ports/acp_session_store.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use std::{future::Future, pin::Pin};
+
+use crate::domain::acp_session::{AcpSessionLookup, AcpSessionRecord};
+
+pub trait AcpSessionStore: Send + Sync + 'static {
+    fn record_session<'a>(
+        &'a self,
+        record: AcpSessionRecord,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    fn latest_session<'a>(
+        &'a self,
+        lookup: AcpSessionLookup,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<AcpSessionRecord>>> + Send + 'a>>;
+}

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -1,3 +1,4 @@
+pub mod acp_session_store;
 pub mod agent_catalog;
 pub mod event_sink;
 pub mod goal_file;


### PR DESCRIPTION
## Summary
- Add SQLite-backed ACP session metadata storage on the existing WAL database
- Record ACP session ids when sessions are created or replaced
- Hydrate resume requests from the latest persisted session for the workspace/checkouter/workdir/agent context
- Fail ResumeRequired when no persisted session exists for the requested context

Stacked on #54. Refs #39

## Tests
- cargo test
- npm run build