### PR TITLE
Add ACP session resume option

### DIFF
--- a/src/entities/message/index.ts
+++ b/src/entities/message/index.ts
@@ -6,6 +6,7 @@ export type {
   LifecycleStatus,
   PermissionOption,
   PlanEntry,
+  ResumePolicy,
   RunEvent,
   RunEventEnvelope,
   TimelineItem,

--- a/src/entities/message/model.ts
+++ b/src/entities/message/model.ts
@@ -1,3 +1,5 @@
+export type ResumePolicy = "fresh" | "resumeIfAvailable" | "resumeRequired";
+
 export type AgentRunRequest = {
   runId?: string;
   goal: string;
@@ -9,7 +11,7 @@ export type AgentRunRequest = {
   stdioBufferLimitMb?: number;
   autoAllow?: boolean;
   resumeSessionId?: string;
-  resumePolicy?: "fresh" | "resumeIfAvailable" | "resumeRequired";
+  resumePolicy?: ResumePolicy;
 };
 
 export type AgentRun = {

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -1,5 +1,11 @@
 import { create } from "zustand";
-import { toTimelineItem, type EventGroup, type RunEvent, type TimelineItem } from "../../entities/message";
+import {
+  toTimelineItem,
+  type EventGroup,
+  type ResumePolicy,
+  type RunEvent,
+  type TimelineItem,
+} from "../../entities/message";
 import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
@@ -17,6 +23,7 @@ export type AgentRunDraft = {
   customCommand: string;
   stdioBufferLimitMb: number;
   autoAllow: boolean;
+  resumePolicy: ResumePolicy;
   idleTimeoutSec: number;
 };
 
@@ -64,6 +71,7 @@ export type TabState = {
   customCommand: string;
   stdioBufferLimitMb: number;
   autoAllow: boolean;
+  resumePolicy: ResumePolicy;
   idleTimeoutSec: number;
   idleRemainingSec: number | null;
   activeRunId: string | null;
@@ -130,6 +138,7 @@ export function createTabState(preset: Partial<TabState> = {}, index = 0): TabSt
     customCommand: preset.customCommand ?? "",
     stdioBufferLimitMb: preset.stdioBufferLimitMb ?? 50,
     autoAllow: preset.autoAllow ?? true,
+    resumePolicy: preset.resumePolicy ?? "fresh",
     idleTimeoutSec: preset.idleTimeoutSec ?? 60,
     idleRemainingSec: preset.idleRemainingSec ?? null,
     activeRunId: preset.activeRunId ?? null,
@@ -153,6 +162,7 @@ function tabToDraft(tab: TabState): AgentRunDraft {
     customCommand: tab.customCommand,
     stdioBufferLimitMb: tab.stdioBufferLimitMb,
     autoAllow: tab.autoAllow,
+    resumePolicy: tab.resumePolicy,
     idleTimeoutSec: tab.idleTimeoutSec,
   };
 }
@@ -447,6 +457,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
           customCommand: patch.customCommand ?? next.draft.customCommand,
           stdioBufferLimitMb: patch.stdioBufferLimitMb ?? next.draft.stdioBufferLimitMb,
           autoAllow: patch.autoAllow ?? next.draft.autoAllow,
+          resumePolicy: patch.resumePolicy ?? next.draft.resumePolicy,
           idleTimeoutSec: patch.idleTimeoutSec ?? next.draft.idleTimeoutSec,
         };
         return next;
@@ -879,6 +890,7 @@ function workspaceViewToTabState(
     customCommand: view.draft.customCommand,
     stdioBufferLimitMb: view.draft.stdioBufferLimitMb,
     autoAllow: view.draft.autoAllow,
+    resumePolicy: view.draft.resumePolicy,
     idleTimeoutSec: view.draft.idleTimeoutSec,
     idleRemainingSec: run?.idleRemainingSec ?? fallback?.idleRemainingSec ?? null,
     activeRunId: view.activeRunId,

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -5,7 +5,7 @@ import {
   listAgents,
   startAgentRun,
 } from "./api";
-import type { AgentRunRequest, EventGroup, TimelineItem } from "../../entities/message";
+import type { AgentRunRequest, EventGroup, ResumePolicy, TimelineItem } from "../../entities/message";
 import type { SavedPromptRunMode } from "../../entities/saved-prompt";
 import {
   selectTab,
@@ -89,6 +89,7 @@ export function useAgentRun(tabId: string) {
       agentCommand: current.customCommand.trim() || undefined,
       stdioBufferLimitMb: Math.min(512, Math.max(1, current.stdioBufferLimitMb || 50)),
       autoAllow: current.autoAllow,
+      resumePolicy: current.resumePolicy === "fresh" ? undefined : current.resumePolicy,
     };
 
     try {
@@ -163,6 +164,7 @@ export function useAgentRun(tabId: string) {
     [patch],
   );
   const setAutoAllow = useCallback((value: boolean) => patch({ autoAllow: value }), [patch]);
+  const setResumePolicy = useCallback((value: ResumePolicy) => patch({ resumePolicy: value }), [patch]);
   const setIdleTimeoutSec = useCallback(
     (value: number) => patch({ idleTimeoutSec: value }),
     [patch],
@@ -195,6 +197,8 @@ export function useAgentRun(tabId: string) {
     setStdioBufferLimitMb,
     autoAllow: tab?.autoAllow ?? true,
     setAutoAllow,
+    resumePolicy: tab?.resumePolicy ?? "fresh",
+    setResumePolicy,
     idleTimeoutSec: tab?.idleTimeoutSec ?? 0,
     setIdleTimeoutSec,
     idleRemainingSec: tab?.idleRemainingSec ?? null,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -54,6 +54,8 @@ export function AgentWorkbenchPage() {
             onStdioBufferLimitChange={state.setStdioBufferLimitMb}
             autoAllow={state.autoAllow}
             onAutoAllowChange={state.setAutoAllow}
+            resumePolicy={state.resumePolicy}
+            onResumePolicyChange={state.setResumePolicy}
             idleTimeoutSec={state.idleTimeoutSec}
             onIdleTimeoutChange={state.setIdleTimeoutSec}
             idleRemainingSec={state.idleRemainingSec}

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -1,5 +1,6 @@
 import { Octagon, Play, ShieldCheck } from "lucide-react";
 import type { AgentDescriptor } from "../../entities/agent";
+import type { ResumePolicy } from "../../entities/message";
 import { cn } from "../../shared/lib";
 import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect } from "../../shared/ui";
 
@@ -16,6 +17,8 @@ type RunPanelProps = {
   onStdioBufferLimitChange: (value: number) => void;
   autoAllow: boolean;
   onAutoAllowChange: (value: boolean) => void;
+  resumePolicy: ResumePolicy;
+  onResumePolicyChange: (value: ResumePolicy) => void;
   idleTimeoutSec: number;
   onIdleTimeoutChange: (value: number) => void;
   idleRemainingSec: number | null;
@@ -38,6 +41,8 @@ export function RunPanel({
   onStdioBufferLimitChange,
   autoAllow,
   onAutoAllowChange,
+  resumePolicy,
+  onResumePolicyChange,
   idleTimeoutSec,
   onIdleTimeoutChange,
   idleRemainingSec,
@@ -119,6 +124,19 @@ export function RunPanel({
           />
           <ShieldCheck size={16} className="shrink-0 text-muted-foreground" />
           <span>Auto-select allow permission</span>
+        </label>
+
+        <label className="grid gap-2">
+          <span className="text-sm font-medium">ACP session</span>
+          <NativeSelect
+            value={resumePolicy}
+            onChange={(event) => onResumePolicyChange(event.target.value as ResumePolicy)}
+            disabled={isRunning}
+          >
+            <option value="fresh">Start new session</option>
+            <option value="resumeIfAvailable">Resume latest if available</option>
+            <option value="resumeRequired">Require latest session</option>
+          </NativeSelect>
         </label>
 
         <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">


### PR DESCRIPTION
## Summary
- Add a run-panel ACP session selector for fresh, resume-if-available, and resume-required modes
- Persist the selected resume policy in workspace run drafts
- Send non-fresh resume policies through startAgentRun so the backend can hydrate persisted sessions

Closes #39

## Tests
- npm test
- npm run build