### PR TITLE
Add Ralph loop run settings

### DIFF
--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -315,6 +315,7 @@ mod tests {
             run_id: Some("run-1".into()),
             resume_session_id: None,
             resume_policy: None,
+            ralph_loop: None,
         }
     }
 

--- a/src-tauri/src/domain/run.rs
+++ b/src-tauri/src/domain/run.rs
@@ -12,6 +12,17 @@ pub enum ResumePolicy {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RalphLoopRequest {
+    pub enabled: bool,
+    pub max_iterations: usize,
+    pub prompt_template: String,
+    pub stop_on_error: bool,
+    pub stop_on_permission: bool,
+    pub delay_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AgentRunRequest {
     pub goal: String,
     pub agent_id: String,
@@ -24,6 +35,7 @@ pub struct AgentRunRequest {
     pub run_id: Option<String>,
     pub resume_session_id: Option<String>,
     pub resume_policy: Option<ResumePolicy>,
+    pub ralph_loop: Option<RalphLoopRequest>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/entities/message/index.ts
+++ b/src/entities/message/index.ts
@@ -6,6 +6,7 @@ export type {
   LifecycleStatus,
   PermissionOption,
   PlanEntry,
+  RalphLoopSettings,
   ResumePolicy,
   RunEvent,
   RunEventEnvelope,

--- a/src/entities/message/model.ts
+++ b/src/entities/message/model.ts
@@ -1,5 +1,14 @@
 export type ResumePolicy = "fresh" | "resumeIfAvailable" | "resumeRequired";
 
+export type RalphLoopSettings = {
+  enabled: boolean;
+  maxIterations: number;
+  promptTemplate: string;
+  stopOnError: boolean;
+  stopOnPermission: boolean;
+  delayMs: number;
+};
+
 export type AgentRunRequest = {
   runId?: string;
   goal: string;
@@ -12,6 +21,7 @@ export type AgentRunRequest = {
   autoAllow?: boolean;
   resumeSessionId?: string;
   resumePolicy?: ResumePolicy;
+  ralphLoop?: RalphLoopSettings;
 };
 
 export type AgentRun = {

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import {
   toTimelineItem,
   type EventGroup,
+  type RalphLoopSettings,
   type ResumePolicy,
   type RunEvent,
   type TimelineItem,
@@ -9,6 +10,14 @@ import {
 import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
+export const defaultRalphLoopSettings: RalphLoopSettings = {
+  enabled: false,
+  maxIterations: 3,
+  promptTemplate: "Continue from the previous result. If the task is complete, say so clearly.",
+  stopOnError: true,
+  stopOnPermission: true,
+  delayMs: 0,
+};
 
 export type FollowUpQueueItem = {
   id: string;
@@ -24,6 +33,7 @@ export type AgentRunDraft = {
   stdioBufferLimitMb: number;
   autoAllow: boolean;
   resumePolicy: ResumePolicy;
+  ralphLoop: RalphLoopSettings;
   idleTimeoutSec: number;
 };
 
@@ -72,6 +82,7 @@ export type TabState = {
   stdioBufferLimitMb: number;
   autoAllow: boolean;
   resumePolicy: ResumePolicy;
+  ralphLoop: RalphLoopSettings;
   idleTimeoutSec: number;
   idleRemainingSec: number | null;
   activeRunId: string | null;
@@ -139,6 +150,7 @@ export function createTabState(preset: Partial<TabState> = {}, index = 0): TabSt
     stdioBufferLimitMb: preset.stdioBufferLimitMb ?? 50,
     autoAllow: preset.autoAllow ?? true,
     resumePolicy: preset.resumePolicy ?? "fresh",
+    ralphLoop: preset.ralphLoop ?? { ...defaultRalphLoopSettings },
     idleTimeoutSec: preset.idleTimeoutSec ?? 60,
     idleRemainingSec: preset.idleRemainingSec ?? null,
     activeRunId: preset.activeRunId ?? null,
@@ -163,6 +175,7 @@ function tabToDraft(tab: TabState): AgentRunDraft {
     stdioBufferLimitMb: tab.stdioBufferLimitMb,
     autoAllow: tab.autoAllow,
     resumePolicy: tab.resumePolicy,
+    ralphLoop: tab.ralphLoop,
     idleTimeoutSec: tab.idleTimeoutSec,
   };
 }
@@ -458,6 +471,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
           stdioBufferLimitMb: patch.stdioBufferLimitMb ?? next.draft.stdioBufferLimitMb,
           autoAllow: patch.autoAllow ?? next.draft.autoAllow,
           resumePolicy: patch.resumePolicy ?? next.draft.resumePolicy,
+          ralphLoop: patch.ralphLoop ?? next.draft.ralphLoop,
           idleTimeoutSec: patch.idleTimeoutSec ?? next.draft.idleTimeoutSec,
         };
         return next;
@@ -891,6 +905,7 @@ function workspaceViewToTabState(
     stdioBufferLimitMb: view.draft.stdioBufferLimitMb,
     autoAllow: view.draft.autoAllow,
     resumePolicy: view.draft.resumePolicy,
+    ralphLoop: view.draft.ralphLoop,
     idleTimeoutSec: view.draft.idleTimeoutSec,
     idleRemainingSec: run?.idleRemainingSec ?? fallback?.idleRemainingSec ?? null,
     activeRunId: view.activeRunId,

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -5,9 +5,16 @@ import {
   listAgents,
   startAgentRun,
 } from "./api";
-import type { AgentRunRequest, EventGroup, ResumePolicy, TimelineItem } from "../../entities/message";
+import type {
+  AgentRunRequest,
+  EventGroup,
+  RalphLoopSettings,
+  ResumePolicy,
+  TimelineItem,
+} from "../../entities/message";
 import type { SavedPromptRunMode } from "../../entities/saved-prompt";
 import {
+  defaultRalphLoopSettings,
   selectTab,
   selectTabList,
   useWorkbenchStore,
@@ -90,6 +97,7 @@ export function useAgentRun(tabId: string) {
       stdioBufferLimitMb: Math.min(512, Math.max(1, current.stdioBufferLimitMb || 50)),
       autoAllow: current.autoAllow,
       resumePolicy: current.resumePolicy === "fresh" ? undefined : current.resumePolicy,
+      ralphLoop: current.ralphLoop.enabled ? current.ralphLoop : undefined,
     };
 
     try {
@@ -165,6 +173,10 @@ export function useAgentRun(tabId: string) {
   );
   const setAutoAllow = useCallback((value: boolean) => patch({ autoAllow: value }), [patch]);
   const setResumePolicy = useCallback((value: ResumePolicy) => patch({ resumePolicy: value }), [patch]);
+  const setRalphLoop = useCallback(
+    (value: RalphLoopSettings) => patch({ ralphLoop: value }),
+    [patch],
+  );
   const setIdleTimeoutSec = useCallback(
     (value: number) => patch({ idleTimeoutSec: value }),
     [patch],
@@ -199,6 +211,8 @@ export function useAgentRun(tabId: string) {
     setAutoAllow,
     resumePolicy: tab?.resumePolicy ?? "fresh",
     setResumePolicy,
+    ralphLoop: tab?.ralphLoop ?? defaultRalphLoopSettings,
+    setRalphLoop,
     idleTimeoutSec: tab?.idleTimeoutSec ?? 0,
     setIdleTimeoutSec,
     idleRemainingSec: tab?.idleRemainingSec ?? null,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -56,6 +56,8 @@ export function AgentWorkbenchPage() {
             onAutoAllowChange={state.setAutoAllow}
             resumePolicy={state.resumePolicy}
             onResumePolicyChange={state.setResumePolicy}
+            ralphLoop={state.ralphLoop}
+            onRalphLoopChange={state.setRalphLoop}
             idleTimeoutSec={state.idleTimeoutSec}
             onIdleTimeoutChange={state.setIdleTimeoutSec}
             idleRemainingSec={state.idleRemainingSec}

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -1,6 +1,6 @@
 import { Octagon, Play, ShieldCheck } from "lucide-react";
 import type { AgentDescriptor } from "../../entities/agent";
-import type { ResumePolicy } from "../../entities/message";
+import type { RalphLoopSettings, ResumePolicy } from "../../entities/message";
 import { cn } from "../../shared/lib";
 import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect } from "../../shared/ui";
 
@@ -19,6 +19,8 @@ type RunPanelProps = {
   onAutoAllowChange: (value: boolean) => void;
   resumePolicy: ResumePolicy;
   onResumePolicyChange: (value: ResumePolicy) => void;
+  ralphLoop: RalphLoopSettings;
+  onRalphLoopChange: (value: RalphLoopSettings) => void;
   idleTimeoutSec: number;
   onIdleTimeoutChange: (value: number) => void;
   idleRemainingSec: number | null;
@@ -43,6 +45,8 @@ export function RunPanel({
   onAutoAllowChange,
   resumePolicy,
   onResumePolicyChange,
+  ralphLoop,
+  onRalphLoopChange,
   idleTimeoutSec,
   onIdleTimeoutChange,
   idleRemainingSec,
@@ -138,6 +142,81 @@ export function RunPanel({
             <option value="resumeRequired">Require latest session</option>
           </NativeSelect>
         </label>
+
+        <div className="grid gap-3 rounded-lg border border-border bg-muted/25 p-3">
+          <label className="flex items-center gap-2 text-sm font-medium">
+            <input
+              type="checkbox"
+              className="h-4 w-4 accent-primary"
+              checked={ralphLoop.enabled}
+              disabled={isRunning}
+              onChange={(event) => onRalphLoopChange({ ...ralphLoop, enabled: event.target.checked })}
+            />
+            <span>Ralph loop</span>
+          </label>
+          <label className="grid gap-2">
+            <span className="text-xs font-medium text-muted-foreground">Max iterations</span>
+            <Input
+              type="number"
+              min={1}
+              max={50}
+              value={ralphLoop.maxIterations}
+              disabled={isRunning || !ralphLoop.enabled}
+              onChange={(event) =>
+                onRalphLoopChange({
+                  ...ralphLoop,
+                  maxIterations: Math.max(1, Math.min(50, Number(event.target.value) || 1)),
+                })
+              }
+            />
+          </label>
+          <label className="grid gap-2">
+            <span className="text-xs font-medium text-muted-foreground">Loop prompt</span>
+            <Input
+              value={ralphLoop.promptTemplate}
+              disabled={isRunning || !ralphLoop.enabled}
+              onChange={(event) => onRalphLoopChange({ ...ralphLoop, promptTemplate: event.target.value })}
+            />
+          </label>
+          <label className="grid gap-2">
+            <span className="text-xs font-medium text-muted-foreground">Delay (ms)</span>
+            <Input
+              type="number"
+              min={0}
+              max={60000}
+              value={ralphLoop.delayMs}
+              disabled={isRunning || !ralphLoop.enabled}
+              onChange={(event) =>
+                onRalphLoopChange({
+                  ...ralphLoop,
+                  delayMs: Math.max(0, Math.min(60000, Number(event.target.value) || 0)),
+                })
+              }
+            />
+          </label>
+          <div className="grid gap-2">
+            <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                checked={ralphLoop.stopOnError}
+                disabled={isRunning || !ralphLoop.enabled}
+                onChange={(event) => onRalphLoopChange({ ...ralphLoop, stopOnError: event.target.checked })}
+              />
+              <span>Stop on error</span>
+            </label>
+            <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                checked={ralphLoop.stopOnPermission}
+                disabled={isRunning || !ralphLoop.enabled}
+                onChange={(event) => onRalphLoopChange({ ...ralphLoop, stopOnPermission: event.target.checked })}
+              />
+              <span>Stop on permission request</span>
+            </label>
+          </div>
+        </div>
 
         <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
           <Button type="button" variant="primary" icon={<Play size={17} />} disabled={isRunning} onClick={onRun}>


### PR DESCRIPTION
## Summary
- Add RalphLoopSettings/RalphLoopRequest to frontend and Rust run request models
- Persist Ralph loop settings in workspace run drafts
- Add execution-panel controls for enabling Ralph loop, iteration count, prompt, delay, and stop conditions

Refs #41

## Tests
- cargo test
- npm test
- npm run build

## Follow-up
- Implement the runtime/controller that consumes these settings and sends repeated prompts.