### PR TITLE
Run Ralph loop prompts from runtime

### DIFF
--- a/src/features/agent-run/runtime.test.ts
+++ b/src/features/agent-run/runtime.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./api", () => ({
+  cancelAgentRun: vi.fn(),
+  listenRunEvents: vi.fn(),
+  sendPromptToRun: vi.fn(),
+}));
+
+import { sendPromptToRun } from "./api";
+import { defaultRalphLoopSettings, useWorkbenchStore } from "./model";
+import { drainRalphLoop, resetRalphLoopStateForTests } from "./runtime";
+
+const mockedSendPrompt = vi.mocked(sendPromptToRun);
+
+function startRunWithLoop(overrides: Partial<typeof defaultRalphLoopSettings> = {}) {
+  const tabId = useWorkbenchStore.getState().activeTabId;
+  useWorkbenchStore.getState().patchTab(tabId, {
+    ralphLoop: {
+      ...defaultRalphLoopSettings,
+      enabled: true,
+      ...overrides,
+    },
+  });
+  useWorkbenchStore.getState().beginRun(tabId, "run-1");
+  useWorkbenchStore.getState().dispatchRunEvent("run-1", {
+    type: "lifecycle",
+    status: "promptCompleted",
+    message: "stopReason=end_turn",
+  });
+  return tabId;
+}
+
+describe("Ralph loop runtime", () => {
+  beforeEach(() => {
+    useWorkbenchStore.setState(useWorkbenchStore.getInitialState(), true);
+    resetRalphLoopStateForTests();
+    mockedSendPrompt.mockReset();
+  });
+
+  it("does nothing when Ralph loop is disabled", async () => {
+    const tabId = useWorkbenchStore.getState().activeTabId;
+    useWorkbenchStore.getState().beginRun(tabId, "run-1");
+    useWorkbenchStore.getState().dispatchRunEvent("run-1", {
+      type: "lifecycle",
+      status: "promptCompleted",
+      message: "stopReason=end_turn",
+    });
+
+    await drainRalphLoop(tabId);
+
+    expect(mockedSendPrompt).not.toHaveBeenCalled();
+  });
+
+  it("sends loop prompts until max iterations is reached", async () => {
+    mockedSendPrompt.mockResolvedValue(undefined);
+    const tabId = startRunWithLoop({
+      maxIterations: 2,
+      promptTemplate: "continue",
+    });
+
+    await drainRalphLoop(tabId);
+    expect(mockedSendPrompt).toHaveBeenCalledTimes(1);
+    expect(mockedSendPrompt).toHaveBeenLastCalledWith("run-1", "continue");
+
+    useWorkbenchStore.getState().dispatchRunEvent("run-1", {
+      type: "lifecycle",
+      status: "promptCompleted",
+      message: "stopReason=end_turn",
+    });
+    await drainRalphLoop(tabId);
+    expect(mockedSendPrompt).toHaveBeenCalledTimes(2);
+
+    useWorkbenchStore.getState().dispatchRunEvent("run-1", {
+      type: "lifecycle",
+      status: "promptCompleted",
+      message: "stopReason=end_turn",
+    });
+    await drainRalphLoop(tabId);
+    expect(mockedSendPrompt).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops when permission is pending and stopOnPermission is enabled", async () => {
+    mockedSendPrompt.mockResolvedValue(undefined);
+    const tabId = startRunWithLoop({ stopOnPermission: true });
+    useWorkbenchStore.getState().patchTab(tabId, { permissionPending: true });
+
+    await drainRalphLoop(tabId);
+
+    expect(mockedSendPrompt).not.toHaveBeenCalled();
+  });
+
+  it("records an error when a loop prompt fails", async () => {
+    mockedSendPrompt.mockRejectedValue(new Error("send failed"));
+    const tabId = startRunWithLoop({ promptTemplate: "continue" });
+
+    await drainRalphLoop(tabId);
+
+    const tab = useWorkbenchStore.getState().tabs.find((entry) => entry.id === tabId);
+    expect(tab?.awaitingResponse).toBe(false);
+    expect(tab?.error).toBe("Error: send failed");
+  });
+
+  it("does not send when the run has been cancelled", async () => {
+    mockedSendPrompt.mockResolvedValue(undefined);
+    const tabId = startRunWithLoop({ promptTemplate: "continue" });
+    useWorkbenchStore.getState().endRun(tabId);
+
+    await drainRalphLoop(tabId);
+
+    expect(mockedSendPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/agent-run/runtime.ts
+++ b/src/features/agent-run/runtime.ts
@@ -3,6 +3,15 @@ import { selectTab, selectTabList, useWorkbenchStore } from "./model";
 
 let installed = false;
 let disposers: Array<() => void> = [];
+const ralphLoopStateByRunId = new Map<string, { sent: number; pending: boolean }>();
+
+function resetRalphLoopStateForTests() {
+  ralphLoopStateByRunId.clear();
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 async function drainTabQueue(tabId: string) {
   const store = useWorkbenchStore.getState();
@@ -39,6 +48,63 @@ async function drainTabQueue(tabId: string) {
   }
 }
 
+async function drainRalphLoop(tabId: string) {
+  const store = useWorkbenchStore.getState();
+  const tab = selectTab(store, tabId);
+  if (
+    !tab ||
+    !tab.sessionActive ||
+    !tab.activeRunId ||
+    tab.awaitingResponse ||
+    tab.closing ||
+    tab.followUpQueue.length > 0 ||
+    !tab.ralphLoop.enabled
+  ) {
+    return;
+  }
+  if (tab.permissionPending && tab.ralphLoop.stopOnPermission) return;
+  if (tab.error && tab.ralphLoop.stopOnError) return;
+
+  const runId = tab.activeRunId;
+  const loop = tab.ralphLoop;
+  const loopState = ralphLoopStateByRunId.get(runId) ?? { sent: 0, pending: false };
+  const maxIterations = Math.max(1, loop.maxIterations);
+  const prompt = loop.promptTemplate.trim();
+  if (loopState.pending || loopState.sent >= maxIterations || !prompt) return;
+
+  const iteration = loopState.sent + 1;
+  ralphLoopStateByRunId.set(runId, { ...loopState, pending: true });
+  store.dispatchRunEvent(runId, {
+    type: "diagnostic",
+    message: `Ralph loop iteration ${iteration}/${maxIterations} started`,
+  });
+  store.patchTab(tabId, { awaitingResponse: true });
+
+  if (loop.delayMs > 0) {
+    await sleep(loop.delayMs);
+    const latest = selectTab(useWorkbenchStore.getState(), tabId);
+    if (!latest?.sessionActive || latest.activeRunId !== runId || latest.closing) {
+      ralphLoopStateByRunId.set(runId, { ...loopState, pending: false });
+      return;
+    }
+  }
+
+  try {
+    await sendPromptToRun(runId, prompt);
+    ralphLoopStateByRunId.set(runId, { sent: iteration, pending: false });
+    void drainRalphLoop(tabId);
+  } catch (err) {
+    ralphLoopStateByRunId.set(runId, { ...loopState, pending: false });
+    const latest = selectTab(useWorkbenchStore.getState(), tabId);
+    if (latest?.activeRunId === runId) {
+      useWorkbenchStore.getState().patchTab(tabId, {
+        awaitingResponse: false,
+        error: String(err),
+      });
+    }
+  }
+}
+
 function startIdleTicker() {
   const interval = setInterval(() => {
     const store = useWorkbenchStore.getState();
@@ -50,6 +116,9 @@ function startIdleTicker() {
         tab.idleTimeoutSec > 0;
 
       if (!shouldCount) {
+        if (!tab.sessionActive && tab.activeRunId) {
+          ralphLoopStateByRunId.delete(tab.activeRunId);
+        }
         if (tab.idleRemainingSec !== null) {
           store.patchTab(tab.id, { idleRemainingSec: null });
         }
@@ -79,7 +148,11 @@ function subscribeForDrain() {
     const signature = tabs
       .map(
         (t) =>
-          `${t.id}:${t.sessionActive ? 1 : 0}:${t.awaitingResponse ? 1 : 0}:${t.followUpQueue.length}`,
+          `${t.id}:${t.activeRunId ?? ""}:${t.sessionActive ? 1 : 0}:${
+            t.awaitingResponse ? 1 : 0
+          }:${t.followUpQueue.length}:${t.permissionPending ? 1 : 0}:${
+            t.ralphLoop.enabled ? 1 : 0
+          }`,
       )
       .join("|");
     if (signature === previousSignature) return;
@@ -92,6 +165,14 @@ function subscribeForDrain() {
         tab.activeRunId
       ) {
         void drainTabQueue(tab.id);
+      } else if (
+        tab.sessionActive &&
+        !tab.awaitingResponse &&
+        tab.followUpQueue.length === 0 &&
+        tab.activeRunId &&
+        tab.ralphLoop.enabled
+      ) {
+        void drainRalphLoop(tab.id);
       }
     }
   });
@@ -119,4 +200,4 @@ export async function installAgentRuntime() {
   });
 }
 
-export { drainTabQueue };
+export { drainRalphLoop, drainTabQueue, resetRalphLoopStateForTests };


### PR DESCRIPTION
## Summary
- Add runtime Ralph loop draining for active ACP sessions
- Send configured loop prompts through the existing send_prompt_to_run path on the same run/session
- Respect max iterations, manual cancellation, pending permissions, manual follow-up queue priority, and send failures
- Emit diagnostic timeline entries for each Ralph loop iteration
- Add focused runtime tests for disabled loops, max iterations, permission stop, cancellation, and send failures

Refs #41

## Tests
- cargo test
- npm test
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries