### PR TITLE
Add workspace git status commands

### DIFF
--- a/src-tauri/src/adapters/git.rs
+++ b/src-tauri/src/adapters/git.rs
@@ -6,7 +6,9 @@ use std::{
 
 use crate::{
     adapters::acp::util::{expand_tilde, normalize_path},
+    domain::git::{WorkspaceDiffSummary, WorkspaceGitFileStatus, WorkspaceGitStatus},
     domain::workspace::GitOrigin,
+    ports::git_repository::GitRepositoryPort,
 };
 
 #[derive(Clone, Debug)]
@@ -39,6 +41,21 @@ impl GitRepository {
             branch,
             head_sha,
         })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LocalGitRepository;
+
+impl GitRepositoryPort for LocalGitRepository {
+    fn status(&self, workdir: &Path) -> Result<WorkspaceGitStatus> {
+        git_status(workdir)
+    }
+
+    fn diff_summary(&self, workdir: &Path) -> Result<WorkspaceDiffSummary> {
+        let status = git_status(workdir)?;
+        let diff_stat = run_git_args(Path::new(&status.root), &["diff", "--stat", "HEAD", "--"])?;
+        Ok(WorkspaceDiffSummary { status, diff_stat })
     }
 }
 
@@ -81,7 +98,83 @@ pub fn parse_github_origin(raw_url: &str) -> Result<GitOrigin> {
     })
 }
 
+fn git_status(workdir: &Path) -> Result<WorkspaceGitStatus> {
+    let root = run_git_args(workdir, &["rev-parse", "--show-toplevel"])?;
+    let root = normalize_path(Path::new(root.trim()))?;
+    let branch = run_git_args(&root, &["branch", "--show-current"])
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let head_sha = run_git_args(&root, &["rev-parse", "HEAD"])
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let porcelain = run_git_args(
+        &root,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+    )?;
+    let files = parse_porcelain_status(&porcelain);
+
+    Ok(WorkspaceGitStatus {
+        root: root.to_string_lossy().to_string(),
+        branch,
+        head_sha,
+        is_dirty: !files.is_empty(),
+        files,
+    })
+}
+
+fn parse_porcelain_status(output: &str) -> Vec<WorkspaceGitFileStatus> {
+    output
+        .lines()
+        .filter_map(|line| {
+            if line.len() < 4 {
+                return None;
+            }
+            let status_code: String = line.chars().take(2).collect();
+            let path = line.get(3..)?.trim().to_string();
+            if path.is_empty() {
+                return None;
+            }
+            Some(WorkspaceGitFileStatus {
+                status_label: status_label(&status_code).to_string(),
+                status_code,
+                path,
+            })
+        })
+        .collect()
+}
+
+fn status_label(status_code: &str) -> &'static str {
+    if status_code == "??" {
+        return "untracked";
+    }
+    if status_code.contains('A') {
+        return "added";
+    }
+    if status_code.contains('D') {
+        return "deleted";
+    }
+    if status_code.contains('R') {
+        return "renamed";
+    }
+    if status_code.contains('C') {
+        return "copied";
+    }
+    if status_code.contains('U') {
+        return "conflicted";
+    }
+    if status_code.contains('M') {
+        return "modified";
+    }
+    "changed"
+}
+
 fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
+    run_git_args(cwd, &args)
+}
+
+fn run_git_args(cwd: &Path, args: &[&str]) -> Result<String> {
     let output = Command::new("git").args(args).current_dir(cwd).output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -92,7 +185,7 @@ fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_github_origin;
+    use super::{parse_github_origin, parse_porcelain_status};
 
     #[test]
     fn parses_github_ssh_origin() {
@@ -110,5 +203,20 @@ mod tests {
     fn rejects_non_github_origin() {
         let err = parse_github_origin("https://gitlab.com/org/repo.git").unwrap_err();
         assert!(err.to_string().contains("only GitHub"));
+    }
+
+    #[test]
+    fn parses_porcelain_status_lines() {
+        let files = parse_porcelain_status(
+            " M src/main.rs\nA  README.md\n?? scratch.txt\nR  old.rs -> new.rs\n",
+        );
+
+        assert_eq!(files.len(), 4);
+        assert_eq!(files[0].path, "src/main.rs");
+        assert_eq!(files[0].status_code, " M");
+        assert_eq!(files[0].status_label, "modified");
+        assert_eq!(files[1].status_label, "added");
+        assert_eq!(files[2].status_label, "untracked");
+        assert_eq!(files[3].status_label, "renamed");
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -5,7 +5,7 @@ use tauri::{AppHandle, State};
 use crate::{
     adapters::{
         acp::runner::AcpAgentRunner, acp_session_store_sqlite::SqliteAcpSessionStore,
-        agent_catalog::ConfigurableAgentCatalog, fs::LocalGoalFileReader,
+        agent_catalog::ConfigurableAgentCatalog, fs::LocalGoalFileReader, git::LocalGitRepository,
         session_registry::AppState, storage_state::StorageState,
         tauri::event_sink::TauriRunEventSink,
     },
@@ -13,11 +13,12 @@ use crate::{
         cancel_agent_run::CancelAgentRunUseCase, list_agents::ListAgentsUseCase,
         load_goal_file::LoadGoalFileUseCase, resolve_workdir::ResolveWorkdirUseCase,
         respond_permission::RespondPermissionUseCase, send_prompt::SendPromptUseCase,
-        start_agent_run::StartAgentRunUseCase,
+        start_agent_run::StartAgentRunUseCase, workspace_git::WorkspaceGitUseCase,
     },
     domain::{
         acp_session::AcpSessionLookup,
         agent::AgentDescriptor,
+        git::{WorkspaceDiffSummary, WorkspaceGitStatus},
         run::{AgentRun, AgentRunRequest, ResumePolicy},
         saved_prompt::{
             CreateSavedPromptInput, SavedPrompt, SavedPromptId, UpdateSavedPromptPatch,
@@ -235,6 +236,30 @@ pub async fn resolve_workspace_workdir(
         )
         .await
         .map(|path| path.map(|value| value.to_string_lossy().to_string()))
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn get_workspace_git_status(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+    checkout_id: Option<String>,
+) -> Result<WorkspaceGitStatus, String> {
+    WorkspaceGitUseCase::new(storage.workspace_store(), LocalGitRepository)
+        .status(&workspace_id, checkout_id.as_deref())
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn summarize_workspace_diff(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+    checkout_id: Option<String>,
+) -> Result<WorkspaceDiffSummary, String> {
+    WorkspaceGitUseCase::new(storage.workspace_store(), LocalGitRepository)
+        .diff_summary(&workspace_id, checkout_id.as_deref())
+        .await
         .map_err(|err| err.to_string())
 }
 

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -6,3 +6,4 @@ pub mod resolve_workdir;
 pub mod respond_permission;
 pub mod send_prompt;
 pub mod start_agent_run;
+pub mod workspace_git;

--- a/src-tauri/src/application/workspace_git.rs
+++ b/src-tauri/src/application/workspace_git.rs
@@ -1,0 +1,82 @@
+use anyhow::{Result, anyhow, bail};
+
+use crate::{
+    domain::{
+        git::{WorkspaceDiffSummary, WorkspaceGitStatus},
+        workspace::WorkspaceCheckout,
+    },
+    ports::{git_repository::GitRepositoryPort, workspace_store::WorkspaceStore},
+};
+
+#[derive(Clone)]
+pub struct WorkspaceGitUseCase<S, G>
+where
+    S: WorkspaceStore,
+    G: GitRepositoryPort,
+{
+    store: S,
+    git: G,
+}
+
+impl<S, G> WorkspaceGitUseCase<S, G>
+where
+    S: WorkspaceStore,
+    G: GitRepositoryPort,
+{
+    pub fn new(store: S, git: G) -> Self {
+        Self { store, git }
+    }
+
+    pub async fn status(
+        &self,
+        workspace_id: &str,
+        checkout_id: Option<&str>,
+    ) -> Result<WorkspaceGitStatus> {
+        let checkout = self.resolve_checkout(workspace_id, checkout_id).await?;
+        self.git.status(&checkout.path)
+    }
+
+    pub async fn diff_summary(
+        &self,
+        workspace_id: &str,
+        checkout_id: Option<&str>,
+    ) -> Result<WorkspaceDiffSummary> {
+        let checkout = self.resolve_checkout(workspace_id, checkout_id).await?;
+        self.git.diff_summary(&checkout.path)
+    }
+
+    async fn resolve_checkout(
+        &self,
+        workspace_id: &str,
+        checkout_id: Option<&str>,
+    ) -> Result<WorkspaceCheckout> {
+        let workspace_id = workspace_id.trim();
+        if workspace_id.is_empty() {
+            bail!("workspace id is required");
+        }
+
+        let workspace = self
+            .store
+            .get_workspace(workspace_id)
+            .await?
+            .ok_or_else(|| anyhow!("workspace not found: {workspace_id}"))?;
+
+        let checkout_id = checkout_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or(workspace.default_checkout_id.as_deref())
+            .ok_or_else(|| anyhow!("workspace has no checkout: {workspace_id}"))?;
+
+        let checkout = self
+            .store
+            .get_checkout(checkout_id)
+            .await?
+            .ok_or_else(|| anyhow!("checkout not found: {checkout_id}"))?;
+
+        if checkout.workspace_id != workspace.id {
+            bail!("checkout {checkout_id} does not belong to workspace {workspace_id}");
+        }
+
+        Ok(checkout)
+    }
+}

--- a/src-tauri/src/domain/git.rs
+++ b/src-tauri/src/domain/git.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceGitStatus {
+    pub root: String,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+    pub is_dirty: bool,
+    pub files: Vec<WorkspaceGitFileStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceGitFileStatus {
+    pub path: String,
+    pub status_code: String,
+    pub status_label: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceDiffSummary {
+    pub status: WorkspaceGitStatus,
+    pub diff_stat: String,
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,6 +1,7 @@
 pub mod acp_session;
 pub mod agent;
 pub mod events;
+pub mod git;
 pub mod run;
 pub mod saved_prompt;
 pub mod workspace;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,11 +7,11 @@ use adapters::{
     session_registry::AppState,
     storage_state::StorageState,
     tauri::commands::{
-        cancel_agent_run, create_saved_prompt, delete_saved_prompt, list_agents,
-        list_saved_prompts, list_workspace_checkouts, list_workspaces, load_goal_file,
+        cancel_agent_run, create_saved_prompt, delete_saved_prompt, get_workspace_git_status,
+        list_agents, list_saved_prompts, list_workspace_checkouts, list_workspaces, load_goal_file,
         record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
         remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
-        start_agent_run, update_saved_prompt,
+        start_agent_run, summarize_workspace_diff, update_saved_prompt,
     },
 };
 use tauri::Manager;
@@ -39,6 +39,8 @@ pub fn run() {
             list_workspace_checkouts,
             refresh_workspace_checkout,
             resolve_workspace_workdir,
+            get_workspace_git_status,
+            summarize_workspace_diff,
             list_saved_prompts,
             create_saved_prompt,
             update_saved_prompt,

--- a/src-tauri/src/ports/git_repository.rs
+++ b/src-tauri/src/ports/git_repository.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::domain::git::{WorkspaceDiffSummary, WorkspaceGitStatus};
+
+pub trait GitRepositoryPort: Clone + Send + Sync + 'static {
+    fn status(&self, workdir: &Path) -> Result<WorkspaceGitStatus>;
+
+    fn diff_summary(&self, workdir: &Path) -> Result<WorkspaceDiffSummary>;
+}

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -1,6 +1,7 @@
 pub mod acp_session_store;
 pub mod agent_catalog;
 pub mod event_sink;
+pub mod git_repository;
 pub mod goal_file;
 pub mod permission;
 pub mod saved_prompt_store;

--- a/src/entities/workspace/index.ts
+++ b/src/entities/workspace/index.ts
@@ -1,1 +1,9 @@
-export type { GitOrigin, RegisteredWorkspace, Workspace, WorkspaceCheckout } from "./model";
+export type {
+  GitOrigin,
+  RegisteredWorkspace,
+  Workspace,
+  WorkspaceCheckout,
+  WorkspaceDiffSummary,
+  WorkspaceGitFileStatus,
+  WorkspaceGitStatus,
+} from "./model";

--- a/src/entities/workspace/model.ts
+++ b/src/entities/workspace/model.ts
@@ -29,3 +29,22 @@ export type RegisteredWorkspace = {
   workspace: Workspace;
   checkout: WorkspaceCheckout;
 };
+
+export type WorkspaceGitFileStatus = {
+  path: string;
+  statusCode: string;
+  statusLabel: string;
+};
+
+export type WorkspaceGitStatus = {
+  root: string;
+  branch?: string | null;
+  headSha?: string | null;
+  isDirty: boolean;
+  files: WorkspaceGitFileStatus[];
+};
+
+export type WorkspaceDiffSummary = {
+  status: WorkspaceGitStatus;
+  diffStat: string;
+};

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -1,7 +1,13 @@
 import type { AgentDescriptor } from "../../entities/agent";
 import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message";
 import type { CreateSavedPromptInput, SavedPrompt, UpdateSavedPromptPatch } from "../../entities/saved-prompt";
-import type { RegisteredWorkspace, Workspace, WorkspaceCheckout } from "../../entities/workspace";
+import type {
+  RegisteredWorkspace,
+  Workspace,
+  WorkspaceCheckout,
+  WorkspaceDiffSummary,
+  WorkspaceGitStatus,
+} from "../../entities/workspace";
 import { invokeCommand, listenEvent } from "../../shared/api";
 
 export function listAgents() {
@@ -46,6 +52,14 @@ export function resolveWorkspaceWorkdir(args: {
   cwd?: string | null;
 }) {
   return invokeCommand<string | null>("resolve_workspace_workdir", args);
+}
+
+export function getWorkspaceGitStatus(workspaceId: string, checkoutId?: string | null) {
+  return invokeCommand<WorkspaceGitStatus>("get_workspace_git_status", { workspaceId, checkoutId });
+}
+
+export function summarizeWorkspaceDiff(workspaceId: string, checkoutId?: string | null) {
+  return invokeCommand<WorkspaceDiffSummary>("summarize_workspace_diff", { workspaceId, checkoutId });
 }
 
 export function listSavedPrompts(workspaceId?: string | null) {


### PR DESCRIPTION
## Summary
- add domain and port types for workspace-scoped Git status and diff summaries
- implement a local Git adapter that reports branch, HEAD, dirty files, and diff stat for a workspace checkout
- expose Tauri commands and frontend API wrappers for `get_workspace_git_status` and `summarize_workspace_diff`

Part of #42

## Validation
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test
- git diff --check