### PR TITLE
Add workspace git status commands

### DIFF
--- a/src-tauri/src/adapters/git.rs
+++ b/src-tauri/src/adapters/git.rs
@@ -6,7 +6,11 @@ use std::{
 
 use crate::{
     adapters::acp::util::{expand_tilde, normalize_path},
-    domain::workspace::GitOrigin,
+    domain::{
+        workspace::{GitOrigin, WorkspaceCheckout},
+        workspace_git::{WorkspaceDiffSummary, WorkspaceGitFileStatus, WorkspaceGitStatus},
+    },
+    ports::workspace_git::WorkspaceGitInspector,
 };
 
 #[derive(Clone, Debug)]
@@ -38,6 +42,52 @@ impl GitRepository {
             origin,
             branch,
             head_sha,
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct GitWorkspaceInspector;
+
+impl WorkspaceGitInspector for GitWorkspaceInspector {
+    async fn status(
+        &self,
+        workspace_id: String,
+        checkout: WorkspaceCheckout,
+    ) -> Result<WorkspaceGitStatus> {
+        let repo = GitRepository::from_path(&checkout.path.to_string_lossy())?;
+        let files = status_files(&repo.root)?;
+        Ok(WorkspaceGitStatus {
+            workspace_id,
+            checkout_id: checkout.id,
+            path: repo.root.to_string_lossy().to_string(),
+            branch: repo.branch,
+            head_sha: repo.head_sha,
+            is_clean: files.is_empty(),
+            files,
+        })
+    }
+
+    async fn diff_summary(
+        &self,
+        workspace_id: String,
+        checkout: WorkspaceCheckout,
+    ) -> Result<WorkspaceDiffSummary> {
+        let repo = GitRepository::from_path(&checkout.path.to_string_lossy())?;
+        let files = status_files(&repo.root)?;
+        Ok(WorkspaceDiffSummary {
+            workspace_id,
+            checkout_id: checkout.id,
+            path: repo.root.to_string_lossy().to_string(),
+            branch: repo.branch,
+            head_sha: repo.head_sha,
+            staged_stat: run_git_optional(&repo.root, ["diff", "--cached", "--stat"])?,
+            unstaged_stat: run_git_optional(&repo.root, ["diff", "--stat"])?,
+            untracked_files: files
+                .into_iter()
+                .filter(|file| file.index_status == "?" && file.worktree_status == "?")
+                .map(|file| file.path)
+                .collect(),
         })
     }
 }
@@ -90,9 +140,44 @@ fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
     Ok(String::from_utf8(output.stdout)?)
 }
 
+fn run_git_optional<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
+    Ok(run_git(cwd, args)
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default())
+}
+
+fn status_files(root: &Path) -> Result<Vec<WorkspaceGitFileStatus>> {
+    let raw = run_git(root, ["status", "--porcelain=v1"])?;
+    Ok(raw
+        .lines()
+        .filter_map(parse_status_line)
+        .collect::<Vec<_>>())
+}
+
+fn parse_status_line(line: &str) -> Option<WorkspaceGitFileStatus> {
+    if line.len() < 4 {
+        return None;
+    }
+    let mut chars = line.chars();
+    let index_status = chars.next()?.to_string();
+    let worktree_status = chars.next()?.to_string();
+    let path = line.get(3..)?.trim();
+    let path = path
+        .rsplit_once(" -> ")
+        .map(|(_, renamed)| renamed)
+        .unwrap_or(path)
+        .trim_matches('"')
+        .to_string();
+    Some(WorkspaceGitFileStatus {
+        path,
+        index_status,
+        worktree_status,
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_github_origin;
+    use super::{parse_github_origin, parse_status_line};
 
     #[test]
     fn parses_github_ssh_origin() {
@@ -110,5 +195,21 @@ mod tests {
     fn rejects_non_github_origin() {
         let err = parse_github_origin("https://gitlab.com/org/repo.git").unwrap_err();
         assert!(err.to_string().contains("only GitHub"));
+    }
+
+    #[test]
+    fn parses_porcelain_status_line() {
+        let file = parse_status_line(" M src/main.rs").unwrap();
+        assert_eq!(file.index_status, " ");
+        assert_eq!(file.worktree_status, "M");
+        assert_eq!(file.path, "src/main.rs");
+    }
+
+    #[test]
+    fn parses_porcelain_rename_line() {
+        let file = parse_status_line("R  old.rs -> new.rs").unwrap();
+        assert_eq!(file.index_status, "R");
+        assert_eq!(file.worktree_status, " ");
+        assert_eq!(file.path, "new.rs");
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -6,14 +6,14 @@ use crate::{
     adapters::{
         acp::runner::AcpAgentRunner, acp_session_store_sqlite::SqliteAcpSessionStore,
         agent_catalog::ConfigurableAgentCatalog, fs::LocalGoalFileReader,
-        session_registry::AppState, storage_state::StorageState,
+        git::GitWorkspaceInspector, session_registry::AppState, storage_state::StorageState,
         tauri::event_sink::TauriRunEventSink,
     },
     application::{
         cancel_agent_run::CancelAgentRunUseCase, list_agents::ListAgentsUseCase,
         load_goal_file::LoadGoalFileUseCase, resolve_workdir::ResolveWorkdirUseCase,
         respond_permission::RespondPermissionUseCase, send_prompt::SendPromptUseCase,
-        start_agent_run::StartAgentRunUseCase,
+        start_agent_run::StartAgentRunUseCase, workspace_git::WorkspaceGitUseCase,
     },
     domain::{
         acp_session::AcpSessionLookup,
@@ -23,6 +23,7 @@ use crate::{
             CreateSavedPromptInput, SavedPrompt, SavedPromptId, UpdateSavedPromptPatch,
         },
         workspace::{RegisteredWorkspace, Workspace, WorkspaceCheckout},
+        workspace_git::{WorkspaceDiffSummary, WorkspaceGitStatus},
     },
     ports::{
         acp_session_store::AcpSessionStore, saved_prompt_store::SavedPromptStore,
@@ -235,6 +236,30 @@ pub async fn resolve_workspace_workdir(
         )
         .await
         .map(|path| path.map(|value| value.to_string_lossy().to_string()))
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn get_workspace_git_status(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+    checkout_id: Option<String>,
+) -> Result<WorkspaceGitStatus, String> {
+    WorkspaceGitUseCase::new(storage.workspace_store(), GitWorkspaceInspector)
+        .status(&workspace_id, checkout_id.as_deref())
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn summarize_workspace_diff(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+    checkout_id: Option<String>,
+) -> Result<WorkspaceDiffSummary, String> {
+    WorkspaceGitUseCase::new(storage.workspace_store(), GitWorkspaceInspector)
+        .diff_summary(&workspace_id, checkout_id.as_deref())
+        .await
         .map_err(|err| err.to_string())
 }
 

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -6,3 +6,4 @@ pub mod resolve_workdir;
 pub mod respond_permission;
 pub mod send_prompt;
 pub mod start_agent_run;
+pub mod workspace_git;

--- a/src-tauri/src/application/workspace_git.rs
+++ b/src-tauri/src/application/workspace_git.rs
@@ -1,0 +1,71 @@
+use anyhow::{Result, anyhow, bail};
+
+use crate::{
+    domain::workspace::{WorkspaceCheckout, WorkspaceId},
+    domain::workspace_git::{WorkspaceDiffSummary, WorkspaceGitStatus},
+    ports::{workspace_git::WorkspaceGitInspector, workspace_store::WorkspaceStore},
+};
+
+#[derive(Clone)]
+pub struct WorkspaceGitUseCase<S, G>
+where
+    S: WorkspaceStore,
+    G: WorkspaceGitInspector,
+{
+    store: S,
+    git: G,
+}
+
+impl<S, G> WorkspaceGitUseCase<S, G>
+where
+    S: WorkspaceStore,
+    G: WorkspaceGitInspector,
+{
+    pub fn new(store: S, git: G) -> Self {
+        Self { store, git }
+    }
+
+    pub async fn status(
+        &self,
+        workspace_id: &WorkspaceId,
+        checkout_id: Option<&str>,
+    ) -> Result<WorkspaceGitStatus> {
+        let checkout = self.resolve_checkout(workspace_id, checkout_id).await?;
+        self.git.status(workspace_id.clone(), checkout).await
+    }
+
+    pub async fn diff_summary(
+        &self,
+        workspace_id: &WorkspaceId,
+        checkout_id: Option<&str>,
+    ) -> Result<WorkspaceDiffSummary> {
+        let checkout = self.resolve_checkout(workspace_id, checkout_id).await?;
+        self.git.diff_summary(workspace_id.clone(), checkout).await
+    }
+
+    async fn resolve_checkout(
+        &self,
+        workspace_id: &WorkspaceId,
+        checkout_id: Option<&str>,
+    ) -> Result<WorkspaceCheckout> {
+        let workspace = self
+            .store
+            .get_workspace(workspace_id)
+            .await?
+            .ok_or_else(|| anyhow!("workspace not found: {workspace_id}"))?;
+        let checkout_id = checkout_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or(workspace.default_checkout_id.as_deref())
+            .ok_or_else(|| anyhow!("workspace has no checkout: {workspace_id}"))?;
+        let checkout = self
+            .store
+            .get_checkout(checkout_id)
+            .await?
+            .ok_or_else(|| anyhow!("checkout not found: {checkout_id}"))?;
+        if checkout.workspace_id != *workspace_id {
+            bail!("checkout {checkout_id} does not belong to workspace {workspace_id}");
+        }
+        Ok(checkout)
+    }
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -4,3 +4,4 @@ pub mod events;
 pub mod run;
 pub mod saved_prompt;
 pub mod workspace;
+pub mod workspace_git;

--- a/src-tauri/src/domain/workspace_git.rs
+++ b/src-tauri/src/domain/workspace_git.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceGitFileStatus {
+    pub path: String,
+    pub index_status: String,
+    pub worktree_status: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceGitStatus {
+    pub workspace_id: String,
+    pub checkout_id: String,
+    pub path: String,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+    pub is_clean: bool,
+    pub files: Vec<WorkspaceGitFileStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceDiffSummary {
+    pub workspace_id: String,
+    pub checkout_id: String,
+    pub path: String,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+    pub staged_stat: String,
+    pub unstaged_stat: String,
+    pub untracked_files: Vec<String>,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,11 +7,11 @@ use adapters::{
     session_registry::AppState,
     storage_state::StorageState,
     tauri::commands::{
-        cancel_agent_run, create_saved_prompt, delete_saved_prompt, list_agents,
-        list_saved_prompts, list_workspace_checkouts, list_workspaces, load_goal_file,
+        cancel_agent_run, create_saved_prompt, delete_saved_prompt, get_workspace_git_status,
+        list_agents, list_saved_prompts, list_workspace_checkouts, list_workspaces, load_goal_file,
         record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
         remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
-        start_agent_run, update_saved_prompt,
+        start_agent_run, summarize_workspace_diff, update_saved_prompt,
     },
 };
 use tauri::Manager;
@@ -39,6 +39,8 @@ pub fn run() {
             list_workspace_checkouts,
             refresh_workspace_checkout,
             resolve_workspace_workdir,
+            get_workspace_git_status,
+            summarize_workspace_diff,
             list_saved_prompts,
             create_saved_prompt,
             update_saved_prompt,

--- a/src-tauri/src/ports/mod.rs
+++ b/src-tauri/src/ports/mod.rs
@@ -7,4 +7,5 @@ pub mod saved_prompt_store;
 pub mod session_handle;
 pub mod session_launcher;
 pub mod session_registry;
+pub mod workspace_git;
 pub mod workspace_store;

--- a/src-tauri/src/ports/workspace_git.rs
+++ b/src-tauri/src/ports/workspace_git.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use std::future::Future;
+
+use crate::domain::{
+    workspace::WorkspaceCheckout,
+    workspace_git::{WorkspaceDiffSummary, WorkspaceGitStatus},
+};
+
+pub trait WorkspaceGitInspector: Clone + Send + Sync + 'static {
+    fn status(
+        &self,
+        workspace_id: String,
+        checkout: WorkspaceCheckout,
+    ) -> impl Future<Output = Result<WorkspaceGitStatus>> + Send;
+
+    fn diff_summary(
+        &self,
+        workspace_id: String,
+        checkout: WorkspaceCheckout,
+    ) -> impl Future<Output = Result<WorkspaceDiffSummary>> + Send;
+}

--- a/src/entities/workspace/index.ts
+++ b/src/entities/workspace/index.ts
@@ -1,1 +1,9 @@
-export type { GitOrigin, RegisteredWorkspace, Workspace, WorkspaceCheckout } from "./model";
+export type {
+  GitOrigin,
+  RegisteredWorkspace,
+  Workspace,
+  WorkspaceCheckout,
+  WorkspaceDiffSummary,
+  WorkspaceGitFileStatus,
+  WorkspaceGitStatus,
+} from "./model";

--- a/src/entities/workspace/model.ts
+++ b/src/entities/workspace/model.ts
@@ -29,3 +29,30 @@ export type RegisteredWorkspace = {
   workspace: Workspace;
   checkout: WorkspaceCheckout;
 };
+
+export type WorkspaceGitFileStatus = {
+  path: string;
+  indexStatus: string;
+  worktreeStatus: string;
+};
+
+export type WorkspaceGitStatus = {
+  workspaceId: string;
+  checkoutId: string;
+  path: string;
+  branch?: string | null;
+  headSha?: string | null;
+  isClean: boolean;
+  files: WorkspaceGitFileStatus[];
+};
+
+export type WorkspaceDiffSummary = {
+  workspaceId: string;
+  checkoutId: string;
+  path: string;
+  branch?: string | null;
+  headSha?: string | null;
+  stagedStat: string;
+  unstagedStat: string;
+  untrackedFiles: string[];
+};

--- a/src/features/agent-run/api.test.ts
+++ b/src/features/agent-run/api.test.ts
@@ -8,9 +8,11 @@ vi.mock("../../shared/api", () => ({
 import { invokeCommand, listenEvent } from "../../shared/api";
 import {
   cancelAgentRun,
+  getWorkspaceGitStatus,
   listenRunEvents,
   sendPromptToRun,
   startAgentRun,
+  summarizeWorkspaceDiff,
 } from "./api";
 import { setupTauriListeners } from "../../test/tauri";
 
@@ -60,5 +62,21 @@ describe("agent-run api", () => {
 
     dispose();
     expect(events.count("agent-run-event")).toBe(0);
+  });
+
+  it("workspace git helpers pass workspace and checkout ids", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await getWorkspaceGitStatus({ workspaceId: "ws-1", checkoutId: "co-1" });
+    await summarizeWorkspaceDiff({ workspaceId: "ws-1", checkoutId: "co-1" });
+
+    expect(mockedInvoke).toHaveBeenNthCalledWith(1, "get_workspace_git_status", {
+      workspaceId: "ws-1",
+      checkoutId: "co-1",
+    });
+    expect(mockedInvoke).toHaveBeenNthCalledWith(2, "summarize_workspace_diff", {
+      workspaceId: "ws-1",
+      checkoutId: "co-1",
+    });
   });
 });

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -1,7 +1,13 @@
 import type { AgentDescriptor } from "../../entities/agent";
 import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message";
 import type { CreateSavedPromptInput, SavedPrompt, UpdateSavedPromptPatch } from "../../entities/saved-prompt";
-import type { RegisteredWorkspace, Workspace, WorkspaceCheckout } from "../../entities/workspace";
+import type {
+  RegisteredWorkspace,
+  Workspace,
+  WorkspaceCheckout,
+  WorkspaceDiffSummary,
+  WorkspaceGitStatus,
+} from "../../entities/workspace";
 import { invokeCommand, listenEvent } from "../../shared/api";
 
 export function listAgents() {
@@ -46,6 +52,14 @@ export function resolveWorkspaceWorkdir(args: {
   cwd?: string | null;
 }) {
   return invokeCommand<string | null>("resolve_workspace_workdir", args);
+}
+
+export function getWorkspaceGitStatus(args: { workspaceId: string; checkoutId?: string | null }) {
+  return invokeCommand<WorkspaceGitStatus>("get_workspace_git_status", args);
+}
+
+export function summarizeWorkspaceDiff(args: { workspaceId: string; checkoutId?: string | null }) {
+  return invokeCommand<WorkspaceDiffSummary>("summarize_workspace_diff", args);
 }
 
 export function listSavedPrompts(workspaceId?: string | null) {

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -17,6 +17,7 @@ export {
 export { useAgentRun } from "./useAgentRun";
 export { type FollowUpQueueItem } from "./model";
 export {
+  getWorkspaceGitStatus,
   listWorkspaceCheckouts,
   listWorkspaces,
   createSavedPrompt,
@@ -26,5 +27,6 @@ export {
   refreshWorkspaceCheckout,
   registerWorkspaceFromPath,
   resolveWorkspaceWorkdir,
+  summarizeWorkspaceDiff,
   updateSavedPrompt,
 } from "./api";


### PR DESCRIPTION
## Summary
- Add workspace-scoped git status and diff-summary domain models
- Add a WorkspaceGitInspector port and use case that resolves workspace checkouts before inspection
- Implement read-only git status and diff summary via the git adapter
- Expose Tauri commands and frontend API wrappers for status/diff summary

Refs #42

## Tests
- cargo test
- npm test
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries

## Follow-up
- Build the PR creation/review UI on top of these read-only workspace git primitives.