### PR TITLE
Add workbench window bootstrap commands

### DIFF
--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use uuid::Uuid;
 
 use crate::{
     adapters::{
@@ -23,6 +24,7 @@ use crate::{
         saved_prompt::{
             CreateSavedPromptInput, SavedPrompt, SavedPromptId, UpdateSavedPromptPatch,
         },
+        workbench_window::{WorkbenchWindowBootstrap, WorkbenchWindowInfo},
         workspace::{RegisteredWorkspace, Workspace, WorkspaceCheckout},
     },
     ports::{
@@ -41,6 +43,52 @@ pub fn load_goal_file(path: String) -> Result<String, String> {
     LoadGoalFileUseCase::new(LocalGoalFileReader)
         .execute(&path)
         .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub fn get_window_bootstrap(window: WebviewWindow) -> WorkbenchWindowBootstrap {
+    WorkbenchWindowBootstrap::new(window.label())
+}
+
+#[tauri::command]
+pub fn list_workbench_windows(app: AppHandle) -> Vec<WorkbenchWindowInfo> {
+    let mut windows: Vec<_> = app
+        .webview_windows()
+        .into_values()
+        .map(|window| {
+            let title = window
+                .title()
+                .unwrap_or_else(|_| window.label().to_string());
+            WorkbenchWindowInfo::new(window.label(), title)
+        })
+        .collect();
+    windows.sort_by(|a, b| a.label.cmp(&b.label));
+    windows
+}
+
+#[tauri::command]
+pub fn open_workbench_window(app: AppHandle) -> Result<WorkbenchWindowInfo, String> {
+    let label = next_workbench_window_label(&app);
+    let title = "ACP Agent Workbench".to_string();
+
+    let window =
+        WebviewWindowBuilder::new(&app, label.clone(), WebviewUrl::App("index.html".into()))
+            .title(&title)
+            .build()
+            .map_err(|err| err.to_string())?;
+    window.set_focus().map_err(|err| err.to_string())?;
+
+    Ok(WorkbenchWindowInfo::new(label, title))
+}
+
+fn next_workbench_window_label(app: &AppHandle) -> String {
+    loop {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let label = format!("workbench-{suffix}");
+        if app.get_webview_window(&label).is_none() {
+            return label;
+        }
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -4,4 +4,5 @@ pub mod events;
 pub mod git;
 pub mod run;
 pub mod saved_prompt;
+pub mod workbench_window;
 pub mod workspace;

--- a/src-tauri/src/domain/workbench_window.rs
+++ b/src-tauri/src/domain/workbench_window.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+pub const MAIN_WORKBENCH_WINDOW_LABEL: &str = "main";
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkbenchWindowInfo {
+    pub label: String,
+    pub is_main: bool,
+    pub title: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkbenchWindowBootstrap {
+    pub label: String,
+    pub is_main: bool,
+}
+
+impl WorkbenchWindowInfo {
+    pub fn new(label: impl Into<String>, title: impl Into<String>) -> Self {
+        let label = label.into();
+        Self {
+            is_main: label == MAIN_WORKBENCH_WINDOW_LABEL,
+            label,
+            title: title.into(),
+        }
+    }
+}
+
+impl WorkbenchWindowBootstrap {
+    pub fn new(label: impl Into<String>) -> Self {
+        let label = label.into();
+        Self {
+            is_main: label == MAIN_WORKBENCH_WINDOW_LABEL,
+            label,
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,8 @@ use adapters::{
     storage_state::StorageState,
     tauri::commands::{
         cancel_agent_run, create_saved_prompt, delete_saved_prompt, get_workspace_git_status,
-        list_agents, list_saved_prompts, list_workspace_checkouts, list_workspaces, load_goal_file,
+        get_window_bootstrap, list_agents, list_saved_prompts, list_workbench_windows,
+        list_workspace_checkouts, list_workspaces, load_goal_file, open_workbench_window,
         record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
         remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
         start_agent_run, summarize_workspace_diff, update_saved_prompt,
@@ -29,6 +30,9 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             list_agents,
             load_goal_file,
+            get_window_bootstrap,
+            list_workbench_windows,
+            open_workbench_window,
             start_agent_run,
             send_prompt_to_run,
             cancel_agent_run,

--- a/src/entities/workbench-window/index.ts
+++ b/src/entities/workbench-window/index.ts
@@ -1,0 +1,1 @@
+export type { WorkbenchWindowBootstrap, WorkbenchWindowInfo } from "./model";

--- a/src/entities/workbench-window/model.ts
+++ b/src/entities/workbench-window/model.ts
@@ -1,0 +1,10 @@
+export type WorkbenchWindowInfo = {
+  label: string;
+  isMain: boolean;
+  title: string;
+};
+
+export type WorkbenchWindowBootstrap = {
+  label: string;
+  isMain: boolean;
+};

--- a/src/features/workbench-window/api.test.ts
+++ b/src/features/workbench-window/api.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shared/api", () => ({
+  invokeCommand: vi.fn(),
+}));
+
+import { invokeCommand } from "../../shared/api";
+import { getWindowBootstrap, listWorkbenchWindows, openWorkbenchWindow } from "./api";
+
+const mockedInvoke = vi.mocked(invokeCommand);
+
+describe("workbench-window api", () => {
+  it("forwards window bootstrap and registry commands", async () => {
+    mockedInvoke
+      .mockResolvedValueOnce({ label: "main", isMain: true })
+      .mockResolvedValueOnce([{ label: "main", isMain: true, title: "ACP Agent Workbench" }])
+      .mockResolvedValueOnce({ label: "workbench-1", isMain: false, title: "ACP Agent Workbench" });
+
+    await expect(getWindowBootstrap()).resolves.toEqual({ label: "main", isMain: true });
+    await expect(listWorkbenchWindows()).resolves.toHaveLength(1);
+    await expect(openWorkbenchWindow()).resolves.toMatchObject({ label: "workbench-1" });
+
+    expect(mockedInvoke).toHaveBeenNthCalledWith(1, "get_window_bootstrap");
+    expect(mockedInvoke).toHaveBeenNthCalledWith(2, "list_workbench_windows");
+    expect(mockedInvoke).toHaveBeenNthCalledWith(3, "open_workbench_window");
+  });
+});

--- a/src/features/workbench-window/api.ts
+++ b/src/features/workbench-window/api.ts
@@ -1,0 +1,14 @@
+import type { WorkbenchWindowBootstrap, WorkbenchWindowInfo } from "../../entities/workbench-window";
+import { invokeCommand } from "../../shared/api";
+
+export function getWindowBootstrap() {
+  return invokeCommand<WorkbenchWindowBootstrap>("get_window_bootstrap");
+}
+
+export function listWorkbenchWindows() {
+  return invokeCommand<WorkbenchWindowInfo[]>("list_workbench_windows");
+}
+
+export function openWorkbenchWindow() {
+  return invokeCommand<WorkbenchWindowInfo>("open_workbench_window");
+}

--- a/src/features/workbench-window/index.ts
+++ b/src/features/workbench-window/index.ts
@@ -1,0 +1,1 @@
+export { getWindowBootstrap, listWorkbenchWindows, openWorkbenchWindow } from "./api";


### PR DESCRIPTION
## Summary
- add serializable workbench window bootstrap and window info types
- expose Tauri commands to get the current window bootstrap, list workbench windows, and open a new workbench window
- add frontend typed API wrappers and coverage for the window commands

Part of #8

## Validation
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test
- git diff --check