### PR TITLE
Add workspace task worktree provisioning

### DIFF
--- a/docs/worktree-isolation.md
+++ b/docs/worktree-isolation.md
@@ -1,0 +1,26 @@
+# Workspace Task Worktree Isolation
+
+Workspace task work should run from an isolated git worktree instead of the original checkout.
+
+The backend command `provision_workspace_task_worktree` provisions a sibling worktree for a workspace checkout:
+
+- The branch name is `worktree/<task-slug>`.
+- The directory name is `<checkout-directory>-<task-slug>`.
+- The original checkout remains untouched, including any dirty files already present there.
+- The created worktree is saved as a workspace checkout with `kind: "worktree"` so the UI can show the active path in session context.
+
+For example, task slug `Issue #63: Worktree Isolation` from checkout `/repo/acp-agent-workbench` creates:
+
+```text
+branch: worktree/issue-63-worktree-isolation
+path:   /repo/acp-agent-workbench-issue-63-worktree-isolation
+```
+
+After the task is merged or abandoned, remove the isolated checkout from git and delete the task branch:
+
+```sh
+git worktree remove /repo/acp-agent-workbench-issue-63-worktree-isolation
+git branch -d worktree/issue-63-worktree-isolation
+```
+
+Use `git branch -D` only for an abandoned branch whose unmerged commits are intentionally being discarded.

--- a/src-tauri/src/adapters/git.rs
+++ b/src-tauri/src/adapters/git.rs
@@ -127,6 +127,20 @@ impl GitRepositoryPort for LocalGitRepository {
             branch: branch.to_string(),
         })
     }
+
+    fn create_worktree(
+        &self,
+        source_workdir: &Path,
+        branch_name: &str,
+        worktree_path: &Path,
+    ) -> Result<WorkspaceGitStatus> {
+        let path_arg = worktree_path.to_string_lossy().to_string();
+        run_git_args(
+            source_workdir,
+            &["worktree", "add", "-b", branch_name, &path_arg, "HEAD"],
+        )?;
+        git_status(worktree_path)
+    }
 }
 
 pub fn parse_github_origin(raw_url: &str) -> Result<GitOrigin> {

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -15,6 +15,7 @@ use crate::{
         load_goal_file::LoadGoalFileUseCase, resolve_workdir::ResolveWorkdirUseCase,
         respond_permission::RespondPermissionUseCase, send_prompt::SendPromptUseCase,
         start_agent_run::StartAgentRunUseCase, workspace_git::WorkspaceGitUseCase,
+        workspace_worktree::WorkspaceTaskWorktreeUseCase,
     },
     domain::{
         acp_session::AcpSessionLookup,
@@ -344,6 +345,19 @@ pub async fn create_github_pull_request(
 ) -> Result<GitHubPullRequestSummary, String> {
     WorkspaceGitUseCase::new(storage.workspace_store(), LocalGitRepository)
         .create_pull_request(GhCliPullRequestClient, request)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn provision_workspace_task_worktree(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+    checkout_id: Option<String>,
+    task_slug: Option<String>,
+) -> Result<WorkspaceCheckout, String> {
+    WorkspaceTaskWorktreeUseCase::new(storage.workspace_store(), LocalGitRepository)
+        .provision(&workspace_id, checkout_id.as_deref(), task_slug.as_deref())
         .await
         .map_err(|err| err.to_string())
 }

--- a/src-tauri/src/adapters/workspace_store.rs
+++ b/src-tauri/src/adapters/workspace_store.rs
@@ -180,6 +180,16 @@ impl WorkspaceStore for LocalWorkspaceStore {
         self.write_file_unlocked(&file)
     }
 
+    async fn save_checkout(&self, checkout: WorkspaceCheckout) -> Result<WorkspaceCheckout> {
+        let _guard = self.lock.lock().await;
+        let mut file = self.read_file_unlocked()?;
+        upsert_by_id(&mut file.checkouts, checkout.clone(), |entry| {
+            entry.id.clone()
+        });
+        self.write_file_unlocked(&file)?;
+        Ok(checkout)
+    }
+
     async fn refresh_checkout(
         &self,
         checkout_id: &CheckoutId,

--- a/src-tauri/src/adapters/workspace_store_sqlite.rs
+++ b/src-tauri/src/adapters/workspace_store_sqlite.rs
@@ -136,6 +136,13 @@ impl WorkspaceStore for SqliteWorkspaceStore {
         Ok(())
     }
 
+    async fn save_checkout(&self, checkout: WorkspaceCheckout) -> Result<WorkspaceCheckout> {
+        let mut tx = self.pool.begin().await?;
+        upsert_checkout(&mut tx, &checkout).await?;
+        tx.commit().await?;
+        Ok(checkout)
+    }
+
     async fn refresh_checkout(
         &self,
         checkout_id: &CheckoutId,

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -7,3 +7,4 @@ pub mod respond_permission;
 pub mod send_prompt;
 pub mod start_agent_run;
 pub mod workspace_git;
+pub mod workspace_worktree;

--- a/src-tauri/src/application/workspace_git.rs
+++ b/src-tauri/src/application/workspace_git.rs
@@ -176,6 +176,10 @@ mod tests {
             Ok(None)
         }
 
+        async fn save_checkout(&self, _checkout: WorkspaceCheckout) -> Result<WorkspaceCheckout> {
+            panic!("confirmation should be checked before checkout save")
+        }
+
         async fn remove_workspace(&self, _workspace_id: &WorkspaceId) -> Result<()> {
             Ok(())
         }
@@ -223,6 +227,15 @@ mod tests {
             _set_upstream: bool,
         ) -> Result<WorkspacePushResult> {
             panic!("confirmation should be checked before push")
+        }
+
+        fn create_worktree(
+            &self,
+            _source_workdir: &Path,
+            _branch_name: &str,
+            _worktree_path: &Path,
+        ) -> Result<WorkspaceGitStatus> {
+            panic!("confirmation should be checked before worktree creation")
         }
     }
 

--- a/src-tauri/src/application/workspace_worktree.rs
+++ b/src-tauri/src/application/workspace_worktree.rs
@@ -1,0 +1,141 @@
+use anyhow::{Result, anyhow, bail};
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+use crate::{
+    domain::workspace::WorkspaceCheckout,
+    ports::{git_repository::GitRepositoryPort, workspace_store::WorkspaceStore},
+};
+
+#[derive(Clone)]
+pub struct WorkspaceTaskWorktreeUseCase<S, G>
+where
+    S: WorkspaceStore,
+    G: GitRepositoryPort,
+{
+    store: S,
+    git: G,
+}
+
+impl<S, G> WorkspaceTaskWorktreeUseCase<S, G>
+where
+    S: WorkspaceStore,
+    G: GitRepositoryPort,
+{
+    pub fn new(store: S, git: G) -> Self {
+        Self { store, git }
+    }
+
+    pub async fn provision(
+        &self,
+        workspace_id: &str,
+        checkout_id: Option<&str>,
+        task_slug: Option<&str>,
+    ) -> Result<WorkspaceCheckout> {
+        let workspace_id = workspace_id.trim();
+        if workspace_id.is_empty() {
+            bail!("workspace id is required");
+        }
+
+        let workspace = self
+            .store
+            .get_workspace(workspace_id)
+            .await?
+            .ok_or_else(|| anyhow!("workspace not found: {workspace_id}"))?;
+
+        let checkout_id = checkout_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or(workspace.default_checkout_id.as_deref())
+            .ok_or_else(|| anyhow!("workspace has no checkout: {workspace_id}"))?;
+
+        let checkout = self
+            .store
+            .get_checkout(checkout_id)
+            .await?
+            .ok_or_else(|| anyhow!("checkout not found: {checkout_id}"))?;
+
+        if checkout.workspace_id != workspace.id {
+            bail!("checkout {checkout_id} does not belong to workspace {workspace_id}");
+        }
+
+        let slug = task_worktree_slug(task_slug);
+        let branch = format!("worktree/{slug}");
+        let path = derive_worktree_path(&checkout.path, &slug)?;
+        let status = self.git.create_worktree(&checkout.path, &branch, &path)?;
+        let worktree = WorkspaceCheckout::new_worktree(
+            workspace.id,
+            &workspace.origin.canonical_url,
+            PathBuf::from(status.root),
+            status.branch,
+            status.head_sha,
+        );
+
+        self.store.save_checkout(worktree).await
+    }
+}
+
+fn derive_worktree_path(checkout_path: &Path, slug: &str) -> Result<PathBuf> {
+    let parent = checkout_path
+        .parent()
+        .ok_or_else(|| anyhow!("checkout path has no parent: {}", checkout_path.display()))?;
+    let checkout_name = checkout_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            anyhow!(
+                "checkout path has no directory name: {}",
+                checkout_path.display()
+            )
+        })?;
+    Ok(parent.join(format!("{checkout_name}-{slug}")))
+}
+
+fn task_worktree_slug(value: Option<&str>) -> String {
+    let slug = sanitize_worktree_slug(value.unwrap_or_default());
+    if slug.is_empty() {
+        let id = Uuid::new_v4().simple().to_string();
+        format!("task-{}", &id[..8])
+    } else {
+        slug
+    }
+}
+
+fn sanitize_worktree_slug(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+
+    for ch in value.trim().chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash && !slug.is_empty() {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    slug.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{derive_worktree_path, sanitize_worktree_slug};
+    use std::path::Path;
+
+    #[test]
+    fn sanitizes_task_identifier_for_branch_and_path() {
+        assert_eq!(
+            sanitize_worktree_slug("Issue #63: Worktree Isolation"),
+            "issue-63-worktree-isolation"
+        );
+        assert_eq!(sanitize_worktree_slug("  ///  "), "");
+    }
+
+    #[test]
+    fn derives_sibling_worktree_path_from_checkout_name() {
+        let path =
+            derive_worktree_path(Path::new("/repo/acp-agent-workbench"), "issue-63").unwrap();
+        assert_eq!(path, Path::new("/repo/acp-agent-workbench-issue-63"));
+    }
+}

--- a/src-tauri/src/domain/workspace.rs
+++ b/src-tauri/src/domain/workspace.rs
@@ -88,6 +88,24 @@ impl WorkspaceCheckout {
             is_default,
         }
     }
+
+    pub fn new_worktree(
+        workspace_id: WorkspaceId,
+        canonical_origin: &str,
+        path: PathBuf,
+        branch: Option<String>,
+        head_sha: Option<String>,
+    ) -> Self {
+        Self {
+            id: checkout_id(canonical_origin, &path),
+            workspace_id,
+            path,
+            kind: CheckoutKind::Worktree,
+            branch,
+            head_sha,
+            is_default: false,
+        }
+    }
 }
 
 pub fn workspace_id(canonical_origin: &str) -> WorkspaceId {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,12 +8,13 @@ use adapters::{
     storage_state::StorageState,
     tauri::commands::{
         cancel_agent_run, create_github_pull_request, create_saved_prompt, create_workspace_commit,
-        delete_saved_prompt, get_workspace_git_status, get_window_bootstrap, list_agents,
+        delete_saved_prompt, get_window_bootstrap, get_workspace_git_status, list_agents,
         list_saved_prompts, list_workbench_windows, list_workspace_checkouts, list_workspaces,
-        load_goal_file, open_workbench_window, push_workspace_branch,
-        record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
-        remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
-        start_agent_run, summarize_workspace_diff, update_saved_prompt,
+        load_goal_file, open_workbench_window, provision_workspace_task_worktree,
+        push_workspace_branch, record_saved_prompt_used, refresh_workspace_checkout,
+        register_workspace_from_path, remove_workspace, resolve_workspace_workdir,
+        respond_agent_permission, send_prompt_to_run, start_agent_run, summarize_workspace_diff,
+        update_saved_prompt,
     },
 };
 use tauri::Manager;
@@ -49,6 +50,7 @@ pub fn run() {
             create_workspace_commit,
             push_workspace_branch,
             create_github_pull_request,
+            provision_workspace_task_worktree,
             list_saved_prompts,
             create_saved_prompt,
             update_saved_prompt,

--- a/src-tauri/src/ports/git_repository.rs
+++ b/src-tauri/src/ports/git_repository.rs
@@ -24,4 +24,11 @@ pub trait GitRepositoryPort: Clone + Send + Sync + 'static {
         branch: &str,
         set_upstream: bool,
     ) -> Result<WorkspacePushResult>;
+
+    fn create_worktree(
+        &self,
+        source_workdir: &Path,
+        branch_name: &str,
+        worktree_path: &Path,
+    ) -> Result<WorkspaceGitStatus>;
 }

--- a/src-tauri/src/ports/workspace_store.rs
+++ b/src-tauri/src/ports/workspace_store.rs
@@ -23,6 +23,11 @@ pub trait WorkspaceStore: Clone + Send + Sync + 'static {
         workspace_id: &WorkspaceId,
     ) -> impl Future<Output = Result<()>> + Send;
 
+    fn save_checkout(
+        &self,
+        checkout: WorkspaceCheckout,
+    ) -> impl Future<Output = Result<WorkspaceCheckout>> + Send;
+
     fn refresh_checkout(
         &self,
         checkout_id: &CheckoutId,

--- a/src/features/agent-run/api.test.ts
+++ b/src/features/agent-run/api.test.ts
@@ -13,6 +13,7 @@ import {
   getWorkspaceGitStatus,
   listenRunEvents,
   pushWorkspaceBranch,
+  provisionWorkspaceTaskWorktree,
   sendPromptToRun,
   startAgentRun,
   summarizeWorkspaceDiff,
@@ -124,6 +125,31 @@ describe("agent-run api", () => {
     });
     expect(mockedInvoke).toHaveBeenNthCalledWith(3, "create_github_pull_request", {
       request: pullRequestRequest,
+    });
+  });
+
+  it("provisionWorkspaceTaskWorktree forwards workspace task isolation args", async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      id: "checkout-worktree",
+      workspaceId: "workspace-1",
+      path: "/repo/acp-agent-workbench-issue-63",
+      branch: "worktree/issue-63",
+      headSha: "abc123",
+      kind: "worktree",
+      isDefault: false,
+    });
+
+    const checkout = await provisionWorkspaceTaskWorktree({
+      workspaceId: "workspace-1",
+      checkoutId: "checkout-main",
+      taskSlug: "Issue #63",
+    });
+
+    expect(checkout.kind).toBe("worktree");
+    expect(mockedInvoke).toHaveBeenCalledWith("provision_workspace_task_worktree", {
+      workspaceId: "workspace-1",
+      checkoutId: "checkout-main",
+      taskSlug: "Issue #63",
     });
   });
 });

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -80,6 +80,14 @@ export function createGitHubPullRequest(request: GitHubPullRequestCreateRequest)
   return invokeCommand<GitHubPullRequestSummary>("create_github_pull_request", { request });
 }
 
+export function provisionWorkspaceTaskWorktree(args: {
+  workspaceId: string;
+  checkoutId?: string | null;
+  taskSlug?: string | null;
+}) {
+  return invokeCommand<WorkspaceCheckout>("provision_workspace_task_worktree", args);
+}
+
 export function listSavedPrompts(workspaceId?: string | null) {
   return invokeCommand<SavedPrompt[]>("list_saved_prompts", { workspaceId });
 }

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -27,6 +27,7 @@ export {
   listSavedPrompts,
   pushWorkspaceBranch,
   recordSavedPromptUsed,
+  provisionWorkspaceTaskWorktree,
   refreshWorkspaceCheckout,
   registerWorkspaceFromPath,
   resolveWorkspaceWorkdir,


### PR DESCRIPTION
## Summary
- add workspace task worktree provisioning command and persistence support
- create sibling git worktrees with task-derived branch/path slugs and unique short ids
- switch workspace-scoped agent runs to the provisioned worktree checkout before starting ACP
- document lifecycle and cleanup rules for isolated task worktrees

Closes #63

## Validation
- npm test -- --run
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- cargo test
- git diff --check