### PR TITLE
Add workspace task worktree provisioning

### DIFF
--- a/docs/worktree-isolation.md
+++ b/docs/worktree-isolation.md
@@ -2,25 +2,27 @@
 
 Workspace task work should run from an isolated git worktree instead of the original checkout.
 
-The backend command `provision_workspace_task_worktree` provisions a sibling worktree for a workspace checkout:
+Workspace-scoped agent runs call `provision_workspace_task_worktree` before starting the ACP session.
+The command provisions a sibling worktree for the selected workspace checkout and returns the new checkout.
 
-- The branch name is `worktree/<task-slug>`.
-- The directory name is `<checkout-directory>-<task-slug>`.
+- The branch name is `worktree/<task-slug>-<short-id>`.
+- The directory name is `<checkout-directory>-<task-slug>-<short-id>`.
 - The original checkout remains untouched, including any dirty files already present there.
-- The created worktree is saved as a workspace checkout with `kind: "worktree"` so the UI can show the active path in session context.
+- The created worktree is saved as a workspace checkout with `kind: "worktree"`.
+- The active tab switches to the worktree checkout and clears the custom `cwd`, so the ACP session starts from the isolated worktree root.
 
-For example, task slug `Issue #63: Worktree Isolation` from checkout `/repo/acp-agent-workbench` creates:
+For example, task slug `Issue #63: Worktree Isolation` from checkout `/repo/acp-agent-workbench` creates a path like:
 
 ```text
-branch: worktree/issue-63-worktree-isolation
-path:   /repo/acp-agent-workbench-issue-63-worktree-isolation
+branch: worktree/issue-63-worktree-isolation-a1b2c3d4
+path:   /repo/acp-agent-workbench-issue-63-worktree-isolation-a1b2c3d4
 ```
 
 After the task is merged or abandoned, remove the isolated checkout from git and delete the task branch:
 
 ```sh
-git worktree remove /repo/acp-agent-workbench-issue-63-worktree-isolation
-git branch -d worktree/issue-63-worktree-isolation
+git worktree remove /repo/acp-agent-workbench-issue-63-worktree-isolation-a1b2c3d4
+git branch -d worktree/issue-63-worktree-isolation-a1b2c3d4
 ```
 
 Use `git branch -D` only for an abandoned branch whose unmerged commits are intentionally being discarded.

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -339,17 +339,6 @@ pub async fn push_workspace_branch(
 }
 
 #[tauri::command]
-pub async fn create_github_pull_request(
-    storage: State<'_, StorageState>,
-    request: GitHubPullRequestCreateRequest,
-) -> Result<GitHubPullRequestSummary, String> {
-    WorkspaceGitUseCase::new(storage.workspace_store(), LocalGitRepository)
-        .create_pull_request(GhCliPullRequestClient, request)
-        .await
-        .map_err(|err| err.to_string())
-}
-
-#[tauri::command]
 pub async fn provision_workspace_task_worktree(
     storage: State<'_, StorageState>,
     workspace_id: String,
@@ -358,6 +347,17 @@ pub async fn provision_workspace_task_worktree(
 ) -> Result<WorkspaceCheckout, String> {
     WorkspaceTaskWorktreeUseCase::new(storage.workspace_store(), LocalGitRepository)
         .provision(&workspace_id, checkout_id.as_deref(), task_slug.as_deref())
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn create_github_pull_request(
+    storage: State<'_, StorageState>,
+    request: GitHubPullRequestCreateRequest,
+) -> Result<GitHubPullRequestSummary, String> {
+    WorkspaceGitUseCase::new(storage.workspace_store(), LocalGitRepository)
+        .create_pull_request(GhCliPullRequestClient, request)
         .await
         .map_err(|err| err.to_string())
 }

--- a/src-tauri/src/application/workspace_worktree.rs
+++ b/src-tauri/src/application/workspace_worktree.rs
@@ -92,12 +92,15 @@ fn derive_worktree_path(checkout_path: &Path, slug: &str) -> Result<PathBuf> {
 }
 
 fn task_worktree_slug(value: Option<&str>) -> String {
-    let slug = sanitize_worktree_slug(value.unwrap_or_default());
+    let mut slug = sanitize_worktree_slug(value.unwrap_or_default());
+    let id = Uuid::new_v4().simple().to_string();
     if slug.is_empty() {
-        let id = Uuid::new_v4().simple().to_string();
         format!("task-{}", &id[..8])
     } else {
-        slug
+        const MAX_SLUG_PREFIX_LEN: usize = 48;
+        slug.truncate(MAX_SLUG_PREFIX_LEN);
+        slug = slug.trim_matches('-').to_string();
+        format!("{slug}-{}", &id[..8])
     }
 }
 

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -2,7 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import {
   cancelAgentRun,
+  listWorkspaceCheckouts,
   listAgents,
+  provisionWorkspaceTaskWorktree,
   startAgentRun,
 } from "./api";
 import type {
@@ -74,7 +76,7 @@ export function useAgentRun(tabId: string) {
     ).length;
     if (
       sameWorkdirRuns > 0 &&
-      current.workspaceId &&
+      !current.workspaceId &&
       !window.confirm(
         `There ${sameWorkdirRuns === 1 ? "is" : "are"} ${sameWorkdirRuns} active run${
           sameWorkdirRuns === 1 ? "" : "s"
@@ -86,13 +88,16 @@ export function useAgentRun(tabId: string) {
     const runId = crypto.randomUUID();
     useWorkbenchStore.getState().beginRun(tabId, runId);
 
+    let checkoutId = current.checkoutId ?? undefined;
+    let cwd = current.cwd.trim() || undefined;
+
     const request: AgentRunRequest = {
       runId,
       goal: trimmedGoal,
       agentId: current.selectedAgentId,
       workspaceId: current.workspaceId ?? undefined,
-      checkoutId: current.checkoutId ?? undefined,
-      cwd: current.cwd.trim() || undefined,
+      checkoutId,
+      cwd,
       agentCommand: current.customCommand.trim() || undefined,
       stdioBufferLimitMb: Math.min(512, Math.max(1, current.stdioBufferLimitMb || 50)),
       autoAllow: current.autoAllow,
@@ -101,6 +106,23 @@ export function useAgentRun(tabId: string) {
     };
 
     try {
+      if (current.workspaceId) {
+        const worktree = await provisionWorkspaceTaskWorktree({
+          workspaceId: current.workspaceId,
+          checkoutId,
+          taskSlug: trimmedGoal,
+        });
+        checkoutId = worktree.id;
+        cwd = undefined;
+        request.checkoutId = checkoutId;
+        request.cwd = cwd;
+
+        const store = useWorkbenchStore.getState();
+        store.setTabWorkspace(tabId, current.workspaceId, checkoutId);
+        store.patchTab(tabId, { cwd: "" });
+        const checkouts = await listWorkspaceCheckouts(current.workspaceId);
+        store.setWorkspaceCheckouts(current.workspaceId, checkouts);
+      }
       await startAgentRun(request);
     } catch (err) {
       const error = String(err);


### PR DESCRIPTION
## Summary
- add a workspace task worktree provisioning use case and Tauri command
- create sibling git worktrees with task-derived branch/path names and register them as workspace checkouts
- automatically provision and switch workspace-scoped runs onto the isolated worktree before starting ACP
- expose the frontend API wrapper and document worktree lifecycle cleanup

Part of #63

## Validation
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check