### PR TITLE
Match ACP resume sessions by agent command

### DIFF
--- a/src-tauri/src/adapters/acp/runner.rs
+++ b/src-tauri/src/adapters/acp/runner.rs
@@ -196,7 +196,12 @@ where
             &run_id,
             lifecycle(LifecycleStatus::SessionCreated, session_id.clone()),
         );
-        let session_record = AcpSessionRecord::from_request(&run_id, &session_id, request);
+        let session_record = AcpSessionRecord::from_request_with_agent_command(
+            &run_id,
+            &session_id,
+            request,
+            Some(&agent_command),
+        );
         self.session_store
             .record_session(session_record.clone())
             .await?;

--- a/src-tauri/src/adapters/acp_session_store_sqlite.rs
+++ b/src-tauri/src/adapters/acp_session_store_sqlite.rs
@@ -47,6 +47,7 @@ impl AcpSessionStore for SqliteAcpSessionStore {
                   AND workspace_id IS ?
                   AND checkout_id IS ?
                   AND workdir IS ?
+                  AND agent_command IS ?
                 ORDER BY updated_at DESC
                 LIMIT 1
                 "#,
@@ -55,6 +56,7 @@ impl AcpSessionStore for SqliteAcpSessionStore {
             .bind(&lookup.workspace_id)
             .bind(&lookup.checkout_id)
             .bind(&lookup.workdir)
+            .bind(&lookup.agent_command)
             .fetch_optional(&self.pool)
             .await?;
             row.map(session_from_row).transpose()
@@ -189,6 +191,7 @@ mod tests {
                 checkout_id: Some("co-1".into()),
                 workdir: Some("/tmp/work".into()),
                 agent_id: "agent".into(),
+                agent_command: Some("agent --stdio".into()),
             })
             .await
             .unwrap()
@@ -196,5 +199,28 @@ mod tests {
 
         assert_eq!(found.run_id, "run-1");
         assert_eq!(found.session_id, "session-2");
+    }
+
+    #[tokio::test]
+    async fn latest_session_requires_matching_agent_command() {
+        let store = temp_store().await;
+        insert_workspace_fixture(&store).await;
+        store
+            .record_session(record("run-1", "session-default"))
+            .await
+            .unwrap();
+
+        let found = store
+            .latest_session(AcpSessionLookup {
+                workspace_id: Some("ws-1".into()),
+                checkout_id: Some("co-1".into()),
+                workdir: Some("/tmp/work".into()),
+                agent_id: "agent".into(),
+                agent_command: Some("custom-agent --stdio".into()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(found, None);
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -18,7 +18,7 @@ use crate::{
         workspace_worktree::WorkspaceTaskWorktreeUseCase,
     },
     domain::{
-        acp_session::AcpSessionLookup,
+        acp_session::{AcpSessionLookup, normalize_agent_command},
         agent::AgentDescriptor,
         git::{
             GitHubPullRequestCreateRequest, GitHubPullRequestSummary, WorkspaceCommitRequest,
@@ -33,8 +33,8 @@ use crate::{
         workspace::{RegisteredWorkspace, Workspace, WorkspaceCheckout},
     },
     ports::{
-        acp_session_store::AcpSessionStore, saved_prompt_store::SavedPromptStore,
-        workspace_store::WorkspaceStore,
+        acp_session_store::AcpSessionStore, agent_catalog::AgentCatalog,
+        saved_prompt_store::SavedPromptStore, workspace_store::WorkspaceStore,
     },
 };
 
@@ -154,9 +154,10 @@ async fn hydrate_resume_session(
         return Ok(());
     }
 
-    let latest = session_store
-        .latest_session(AcpSessionLookup::from_request(request))
-        .await?;
+    let agent_command = resolve_agent_command(&ConfigurableAgentCatalog::from_env(), request)?;
+    let mut lookup = AcpSessionLookup::from_request(request);
+    lookup.agent_command = Some(agent_command);
+    let latest = session_store.latest_session(lookup).await?;
     if let Some(record) = latest {
         request.resume_session_id = Some(record.session_id);
         return Ok(());
@@ -166,6 +167,23 @@ async fn hydrate_resume_session(
         anyhow::bail!("resume session not found for requested workspace context");
     }
     Ok(())
+}
+
+fn resolve_agent_command<C: AgentCatalog>(
+    catalog: &C,
+    request: &AgentRunRequest,
+) -> anyhow::Result<String> {
+    if let Some(command) = request.agent_command.as_deref() {
+        if let Some(command) = normalize_agent_command(command)? {
+            return Ok(command);
+        }
+    }
+
+    let command = catalog
+        .command_for_agent(&request.agent_id)
+        .ok_or_else(|| anyhow::anyhow!("unknown agent: {}", request.agent_id))?;
+    normalize_agent_command(&command)?
+        .ok_or_else(|| anyhow::anyhow!("agent command cannot be empty"))
 }
 
 fn has_resume_session_id(request: &AgentRunRequest) -> bool {
@@ -421,4 +439,45 @@ pub async fn record_saved_prompt_used(
         .record_saved_prompt_used(&id)
         .await
         .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_agent_command;
+    use crate::{adapters::agent_catalog::StaticAgentCatalog, domain::run::AgentRunRequest};
+
+    fn request(agent_command: Option<&str>) -> AgentRunRequest {
+        AgentRunRequest {
+            goal: "task".into(),
+            agent_id: "codex".into(),
+            workspace_id: Some("ws-1".into()),
+            checkout_id: Some("co-1".into()),
+            cwd: Some("/tmp/work".into()),
+            agent_command: agent_command.map(str::to_string),
+            stdio_buffer_limit_mb: None,
+            auto_allow: None,
+            run_id: None,
+            resume_session_id: None,
+            resume_policy: None,
+            ralph_loop: None,
+        }
+    }
+
+    #[test]
+    fn resolves_catalog_command_for_resume_lookup() {
+        let command = resolve_agent_command(&StaticAgentCatalog, &request(None)).unwrap();
+
+        assert_eq!(command, "npx -y @zed-industries/codex-acp");
+    }
+
+    #[test]
+    fn normalizes_explicit_command_for_resume_lookup() {
+        let command = resolve_agent_command(
+            &StaticAgentCatalog,
+            &request(Some(" npx   -y   @zed-industries/codex-acp ")),
+        )
+        .unwrap();
+
+        assert_eq!(command, "npx -y @zed-industries/codex-acp");
+    }
 }

--- a/src-tauri/src/domain/acp_session.rs
+++ b/src-tauri/src/domain/acp_session.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::domain::{run::AgentRunRequest, workspace::timestamp};
@@ -23,10 +24,16 @@ pub struct AcpSessionLookup {
     pub checkout_id: Option<String>,
     pub workdir: Option<String>,
     pub agent_id: String,
+    pub agent_command: Option<String>,
 }
 
 impl AcpSessionRecord {
-    pub fn from_request(run_id: &str, session_id: &str, request: &AgentRunRequest) -> Self {
+    pub fn from_request_with_agent_command(
+        run_id: &str,
+        session_id: &str,
+        request: &AgentRunRequest,
+        agent_command: Option<&str>,
+    ) -> Self {
         let now = timestamp();
         Self {
             run_id: run_id.to_string(),
@@ -35,7 +42,7 @@ impl AcpSessionRecord {
             checkout_id: request.checkout_id.clone(),
             workdir: request.cwd.clone(),
             agent_id: request.agent_id.clone(),
-            agent_command: request.agent_command.clone(),
+            agent_command: normalize_agent_command_lossy(agent_command),
             task: request.goal.clone(),
             created_at: now.clone(),
             updated_at: now,
@@ -50,6 +57,51 @@ impl AcpSessionLookup {
             checkout_id: request.checkout_id.clone(),
             workdir: request.cwd.clone(),
             agent_id: request.agent_id.clone(),
+            agent_command: normalize_agent_command_lossy(request.agent_command.as_deref()),
         }
+    }
+}
+
+pub fn normalize_agent_command(command: &str) -> Result<Option<String>> {
+    let command = command.trim();
+    if command.is_empty() {
+        return Ok(None);
+    }
+
+    let argv = shell_words::split(command).context("agent command cannot be parsed")?;
+    if argv.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(shell_words::join(argv)))
+}
+
+fn normalize_agent_command_lossy(command: Option<&str>) -> Option<String> {
+    command.and_then(|value| {
+        normalize_agent_command(value)
+            .ok()
+            .flatten()
+            .or_else(|| Some(value.trim().to_string()).filter(|value| !value.is_empty()))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_agent_command;
+
+    #[test]
+    fn normalizes_equivalent_agent_commands() {
+        assert_eq!(
+            normalize_agent_command(" npx   -y   @zed-industries/codex-acp ")
+                .unwrap()
+                .as_deref(),
+            Some("npx -y @zed-industries/codex-acp")
+        );
+        assert_eq!(
+            normalize_agent_command("agent '--flag=value with spaces'")
+                .unwrap()
+                .as_deref(),
+            Some("agent '--flag=value with spaces'")
+        );
+        assert_eq!(normalize_agent_command("  ").unwrap(), None);
     }
 }


### PR DESCRIPTION
## Summary
- store normalized resolved ACP agent commands on session records
- include normalized agent command in resume lookup keys
- add tests for command normalization and mismatch-safe session lookup

Closes #67

## Validation
- cargo test
- npm test -- --run
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- git diff --check