### PR TITLE
Show ACP resume target in run panel

### DIFF
--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import {
+  clearAcpSession,
   cancelAgentRun,
+  listAcpSessions,
   listWorkspaceCheckouts,
   listAgents,
   provisionWorkspaceTaskWorktree,
@@ -50,6 +52,29 @@ export function useAgentRun(tabId: string) {
     () => agents.find((agent) => agent.id === tab?.selectedAgentId),
     [agents, tab?.selectedAgentId],
   );
+  const acpSessionQuery = useMemo(
+    () => ({
+      workspaceId: tab?.workspaceId ?? null,
+      checkoutId: tab?.checkoutId ?? null,
+      workdir: tab?.cwd?.trim() || null,
+      agentId: tab?.selectedAgentId ?? null,
+      agentCommand: (tab?.customCommand.trim() || selectedAgent?.command) ?? null,
+      limit: 1,
+    }),
+    [
+      selectedAgent?.command,
+      tab?.checkoutId,
+      tab?.customCommand,
+      tab?.cwd,
+      tab?.selectedAgentId,
+      tab?.workspaceId,
+    ],
+  );
+  const acpSessionsQuery = useQuery({
+    queryKey: ["acp-sessions", acpSessionQuery],
+    queryFn: () => listAcpSessions(acpSessionQuery),
+    enabled: Boolean(acpSessionQuery.agentId),
+  });
 
   const items = tab?.items ?? EMPTY_ITEMS;
   const filter: EventGroup | "all" = tab?.filter ?? "all";
@@ -124,6 +149,7 @@ export function useAgentRun(tabId: string) {
         store.setWorkspaceCheckouts(current.workspaceId, checkouts);
       }
       await startAgentRun(request);
+      void acpSessionsQuery.refetch();
     } catch (err) {
       const error = String(err);
       const store = useWorkbenchStore.getState();
@@ -131,7 +157,7 @@ export function useAgentRun(tabId: string) {
       store.endRun(tabId);
       store.patchTab(tabId, { activeRunId: null });
     }
-  }, [tabId, patch]);
+  }, [acpSessionsQuery, tabId, patch]);
 
   const cancel = useCallback(async () => {
     const current = selectTab(useWorkbenchStore.getState(), tabId);
@@ -212,6 +238,17 @@ export function useAgentRun(tabId: string) {
     [patch],
   );
   const setError = useCallback((value: string | null) => patch({ error: value }), [patch]);
+  const clearLatestAcpSession = useCallback(async () => {
+    const latest = acpSessionsQuery.data?.[0];
+    if (!latest) return;
+    try {
+      await clearAcpSession(latest.runId);
+      await acpSessionsQuery.refetch();
+      patch({ error: null });
+    } catch (err) {
+      patch({ error: String(err) });
+    }
+  }, [acpSessionsQuery, patch]);
 
   return {
     agents,
@@ -233,6 +270,9 @@ export function useAgentRun(tabId: string) {
     setAutoAllow,
     resumePolicy: tab?.resumePolicy ?? "fresh",
     setResumePolicy,
+    latestAcpSession: acpSessionsQuery.data?.[0] ?? null,
+    acpSessionLoading: acpSessionsQuery.isFetching,
+    clearLatestAcpSession,
     ralphLoop: tab?.ralphLoop ?? defaultRalphLoopSettings,
     setRalphLoop,
     idleTimeoutSec: tab?.idleTimeoutSec ?? 0,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -58,6 +58,9 @@ export function AgentWorkbenchPage() {
             onAutoAllowChange={state.setAutoAllow}
             resumePolicy={state.resumePolicy}
             onResumePolicyChange={state.setResumePolicy}
+            latestAcpSession={state.latestAcpSession}
+            acpSessionLoading={state.acpSessionLoading}
+            onClearLatestAcpSession={state.clearLatestAcpSession}
             ralphLoop={state.ralphLoop}
             onRalphLoopChange={state.setRalphLoop}
             idleTimeoutSec={state.idleTimeoutSec}

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -1,4 +1,5 @@
-import { Octagon, Play, ShieldCheck } from "lucide-react";
+import { Octagon, Play, ShieldCheck, Trash2 } from "lucide-react";
+import type { AcpSessionRecord } from "../../entities/acp-session";
 import type { AgentDescriptor } from "../../entities/agent";
 import type { RalphLoopSettings, ResumePolicy } from "../../entities/message";
 import { cn } from "../../shared/lib";
@@ -19,6 +20,9 @@ type RunPanelProps = {
   onAutoAllowChange: (value: boolean) => void;
   resumePolicy: ResumePolicy;
   onResumePolicyChange: (value: ResumePolicy) => void;
+  latestAcpSession: AcpSessionRecord | null;
+  acpSessionLoading: boolean;
+  onClearLatestAcpSession: () => void;
   ralphLoop: RalphLoopSettings;
   onRalphLoopChange: (value: RalphLoopSettings) => void;
   idleTimeoutSec: number;
@@ -45,6 +49,9 @@ export function RunPanel({
   onAutoAllowChange,
   resumePolicy,
   onResumePolicyChange,
+  latestAcpSession,
+  acpSessionLoading,
+  onClearLatestAcpSession,
   ralphLoop,
   onRalphLoopChange,
   idleTimeoutSec,
@@ -142,6 +149,37 @@ export function RunPanel({
             <option value="resumeRequired">Require latest session</option>
           </NativeSelect>
         </label>
+
+        <div className="grid gap-2 rounded-md border border-border bg-muted/20 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Resume target
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              icon={<Trash2 size={14} />}
+              disabled={isRunning || !latestAcpSession}
+              onClick={onClearLatestAcpSession}
+            >
+              Clear
+            </Button>
+          </div>
+          {latestAcpSession ? (
+            <div className="grid gap-1 text-xs text-muted-foreground">
+              <code className="truncate font-mono text-foreground">
+                {latestAcpSession.sessionId.slice(0, 12)}
+              </code>
+              <span className="truncate">{latestAcpSession.task}</span>
+              <span>{formatSessionTime(latestAcpSession.updatedAt)}</span>
+            </div>
+          ) : (
+            <span className="text-xs text-muted-foreground">
+              {acpSessionLoading ? "Checking sessions..." : "No stored session"}
+            </span>
+          )}
+        </div>
 
         <div className="grid gap-3 rounded-lg border border-border bg-muted/25 p-3">
           <label className="flex items-center gap-2 text-sm font-medium">
@@ -242,4 +280,12 @@ export function RunPanel({
       </CardContent>
     </Card>
   );
+}
+
+function formatSessionTime(value: string) {
+  const timestamp = Number(value);
+  if (Number.isFinite(timestamp) && timestamp > 0) {
+    return new Date(timestamp * 1000).toLocaleString();
+  }
+  return value;
 }


### PR DESCRIPTION
## Summary
- show the latest persisted ACP session that matches the current run context near the ACP session selector
- query using the selected agent command so the visible resume target matches backend resume lookup
- add a clear action for the latest stored session from the run panel

Part of #66

## Validation
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check