### PR TITLE
Move ACP resume target state into run hook

### DIFF
--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import {
+  clearAcpSession,
   cancelAgentRun,
+  listAcpSessions,
   listWorkspaceCheckouts,
   listAgents,
   provisionWorkspaceTaskWorktree,
@@ -50,6 +52,29 @@ export function useAgentRun(tabId: string) {
     () => agents.find((agent) => agent.id === tab?.selectedAgentId),
     [agents, tab?.selectedAgentId],
   );
+  const acpSessionQuery = useMemo(
+    () => ({
+      workspaceId: tab?.workspaceId ?? null,
+      checkoutId: tab?.checkoutId ?? null,
+      workdir: tab?.cwd?.trim() || null,
+      agentId: tab?.selectedAgentId ?? null,
+      agentCommand: (tab?.customCommand.trim() || selectedAgent?.command) ?? null,
+      limit: 1,
+    }),
+    [
+      selectedAgent?.command,
+      tab?.checkoutId,
+      tab?.customCommand,
+      tab?.cwd,
+      tab?.selectedAgentId,
+      tab?.workspaceId,
+    ],
+  );
+  const acpSessionsQuery = useQuery({
+    queryKey: ["acp-sessions", acpSessionQuery],
+    queryFn: () => listAcpSessions(acpSessionQuery),
+    enabled: Boolean(acpSessionQuery.agentId),
+  });
 
   const items = tab?.items ?? EMPTY_ITEMS;
   const filter: EventGroup | "all" = tab?.filter ?? "all";
@@ -124,6 +149,7 @@ export function useAgentRun(tabId: string) {
         store.setWorkspaceCheckouts(current.workspaceId, checkouts);
       }
       await startAgentRun(request);
+      void acpSessionsQuery.refetch();
     } catch (err) {
       const error = String(err);
       const store = useWorkbenchStore.getState();
@@ -131,7 +157,7 @@ export function useAgentRun(tabId: string) {
       store.endRun(tabId);
       store.patchTab(tabId, { activeRunId: null });
     }
-  }, [tabId, patch]);
+  }, [acpSessionsQuery, tabId, patch]);
 
   const cancel = useCallback(async () => {
     const current = selectTab(useWorkbenchStore.getState(), tabId);
@@ -212,6 +238,17 @@ export function useAgentRun(tabId: string) {
     [patch],
   );
   const setError = useCallback((value: string | null) => patch({ error: value }), [patch]);
+  const clearLatestAcpSession = useCallback(async () => {
+    const latest = acpSessionsQuery.data?.[0];
+    if (!latest) return;
+    try {
+      await clearAcpSession(latest.runId);
+      await acpSessionsQuery.refetch();
+      patch({ error: null });
+    } catch (err) {
+      patch({ error: String(err) });
+    }
+  }, [acpSessionsQuery, patch]);
 
   return {
     agents,
@@ -233,6 +270,9 @@ export function useAgentRun(tabId: string) {
     setAutoAllow,
     resumePolicy: tab?.resumePolicy ?? "fresh",
     setResumePolicy,
+    latestAcpSession: acpSessionsQuery.data?.[0] ?? null,
+    acpSessionLoading: acpSessionsQuery.isFetching,
+    clearLatestAcpSession,
     ralphLoop: tab?.ralphLoop ?? defaultRalphLoopSettings,
     setRalphLoop,
     idleTimeoutSec: tab?.idleTimeoutSec ?? 0,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -48,8 +48,6 @@ export function AgentWorkbenchPage() {
             selectedAgentId={state.selectedAgentId}
             onSelectAgent={state.setSelectedAgentId}
             selectedAgent={state.selectedAgent}
-            workspaceId={state.workspaceId}
-            checkoutId={state.checkoutId}
             cwd={state.cwd}
             onCwdChange={state.setCwd}
             customCommand={state.customCommand}
@@ -60,6 +58,9 @@ export function AgentWorkbenchPage() {
             onAutoAllowChange={state.setAutoAllow}
             resumePolicy={state.resumePolicy}
             onResumePolicyChange={state.setResumePolicy}
+            latestAcpSession={state.latestAcpSession}
+            acpSessionLoading={state.acpSessionLoading}
+            onClearLatestAcpSession={state.clearLatestAcpSession}
             ralphLoop={state.ralphLoop}
             onRalphLoopChange={state.setRalphLoop}
             idleTimeoutSec={state.idleTimeoutSec}

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -1,9 +1,7 @@
 import { Octagon, Play, ShieldCheck, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AcpSessionRecord } from "../../entities/acp-session";
 import type { AgentDescriptor } from "../../entities/agent";
 import type { RalphLoopSettings, ResumePolicy } from "../../entities/message";
-import { clearAcpSession, listAcpSessions } from "../../features/agent-run";
 import { cn } from "../../shared/lib";
 import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect } from "../../shared/ui";
 
@@ -12,8 +10,6 @@ type RunPanelProps = {
   selectedAgentId: string;
   onSelectAgent: (id: string) => void;
   selectedAgent?: AgentDescriptor;
-  workspaceId: string | null;
-  checkoutId: string | null;
   cwd: string;
   onCwdChange: (value: string) => void;
   customCommand: string;
@@ -24,6 +20,9 @@ type RunPanelProps = {
   onAutoAllowChange: (value: boolean) => void;
   resumePolicy: ResumePolicy;
   onResumePolicyChange: (value: ResumePolicy) => void;
+  latestAcpSession: AcpSessionRecord | null;
+  acpSessionLoading: boolean;
+  onClearLatestAcpSession: () => void;
   ralphLoop: RalphLoopSettings;
   onRalphLoopChange: (value: RalphLoopSettings) => void;
   idleTimeoutSec: number;
@@ -40,8 +39,6 @@ export function RunPanel({
   selectedAgentId,
   onSelectAgent,
   selectedAgent,
-  workspaceId,
-  checkoutId,
   cwd,
   onCwdChange,
   customCommand,
@@ -52,6 +49,9 @@ export function RunPanel({
   onAutoAllowChange,
   resumePolicy,
   onResumePolicyChange,
+  latestAcpSession,
+  acpSessionLoading,
+  onClearLatestAcpSession,
   ralphLoop,
   onRalphLoopChange,
   idleTimeoutSec,
@@ -62,61 +62,6 @@ export function RunPanel({
   onRun,
   onCancel,
 }: RunPanelProps) {
-  const [sessions, setSessions] = useState<AcpSessionRecord[]>([]);
-  const [sessionsLoading, setSessionsLoading] = useState(false);
-  const [sessionsError, setSessionsError] = useState<string | null>(null);
-  const [clearingSession, setClearingSession] = useState(false);
-
-  const agentCommand = customCommand.trim() || selectedAgent?.command || null;
-  const latestSession = sessions[0] ?? null;
-  const sessionUpdatedAt = useMemo(
-    () => (latestSession ? new Date(latestSession.updatedAt).toLocaleString() : null),
-    [latestSession],
-  );
-
-  const refreshSessions = useCallback(async () => {
-    if (resumePolicy === "fresh" || !selectedAgentId) {
-      setSessions([]);
-      setSessionsError(null);
-      return;
-    }
-    setSessionsLoading(true);
-    setSessionsError(null);
-    try {
-      const next = await listAcpSessions({
-        workspaceId,
-        checkoutId,
-        agentId: selectedAgentId,
-        agentCommand,
-        limit: 1,
-      });
-      setSessions(next);
-    } catch (err) {
-      setSessionsError(String(err));
-      setSessions([]);
-    } finally {
-      setSessionsLoading(false);
-    }
-  }, [agentCommand, checkoutId, resumePolicy, selectedAgentId, workspaceId]);
-
-  useEffect(() => {
-    void refreshSessions();
-  }, [refreshSessions]);
-
-  const clearLatestSession = useCallback(async () => {
-    if (!latestSession || clearingSession) return;
-    setClearingSession(true);
-    setSessionsError(null);
-    try {
-      await clearAcpSession(latestSession.runId);
-      await refreshSessions();
-    } catch (err) {
-      setSessionsError(String(err));
-    } finally {
-      setClearingSession(false);
-    }
-  }, [clearingSession, latestSession, refreshSessions]);
-
   return (
     <Card as="section" aria-labelledby="run-heading">
       <CardHeader>
@@ -206,30 +151,35 @@ export function RunPanel({
         </label>
 
         {resumePolicy !== "fresh" ? (
-          <div className="grid gap-2 rounded-lg border border-border bg-muted/25 p-3 text-sm">
-            {sessionsLoading ? (
-              <p className="text-muted-foreground">Checking persisted sessions...</p>
-            ) : latestSession ? (
-              <div className="grid gap-2">
-                <div className="grid gap-1">
-                  <p className="font-medium text-foreground">Latest session {latestSession.sessionId.slice(0, 8)}</p>
-                  <p className="truncate text-xs text-muted-foreground">{latestSession.task}</p>
-                  <p className="text-xs text-muted-foreground">{sessionUpdatedAt}</p>
-                </div>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  icon={<Trash2 size={15} />}
-                  disabled={isRunning || clearingSession}
-                  onClick={clearLatestSession}
-                >
-                  Clear latest session
-                </Button>
+          <div className="grid gap-2 rounded-md border border-border bg-muted/20 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Resume target
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                icon={<Trash2 size={14} />}
+                disabled={isRunning || !latestAcpSession}
+                onClick={onClearLatestAcpSession}
+              >
+                Clear
+              </Button>
+            </div>
+            {latestAcpSession ? (
+              <div className="grid gap-1 text-xs text-muted-foreground">
+                <code className="truncate font-mono text-foreground">
+                  {latestAcpSession.sessionId.slice(0, 12)}
+                </code>
+                <span className="truncate">{latestAcpSession.task}</span>
+                <span>{formatSessionTime(latestAcpSession.updatedAt)}</span>
               </div>
             ) : (
-              <p className="text-muted-foreground">No matching persisted session</p>
+              <span className="text-xs text-muted-foreground">
+                {acpSessionLoading ? "Checking sessions..." : "No stored session"}
+              </span>
             )}
-            {sessionsError ? <p className="text-xs font-medium text-destructive">{sessionsError}</p> : null}
           </div>
         ) : null}
 
@@ -332,4 +282,12 @@ export function RunPanel({
       </CardContent>
     </Card>
   );
+}
+
+function formatSessionTime(value: string) {
+  const timestamp = Number(value);
+  if (Number.isFinite(timestamp) && timestamp > 0) {
+    return new Date(timestamp * 1000).toLocaleString();
+  }
+  return value;
 }


### PR DESCRIPTION
## Summary
- move persisted ACP session lookup and clear handling out of the RunPanel widget and into useAgentRun
- keep the run panel focused on rendering the injected resume target state
- refresh the displayed resume target after a run starts or a stored session is cleared

Follow-up to #66 after #73.

## Validation
- npm test -- --run
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- cargo test
- git diff --check