### PR TITLE
Handle renamed workspace git paths

### DIFF
--- a/src-tauri/src/adapters/git.rs
+++ b/src-tauri/src/adapters/git.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow, bail};
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -84,9 +85,10 @@ impl GitRepositoryPort for LocalGitRepository {
         if clean_files.is_empty() {
             bail!("at least one file must be selected for commit");
         }
+        let add_files = dedupe_selected_paths(&clean_files);
 
-        let mut add_args = vec!["add", "--"];
-        add_args.extend(clean_files.iter().copied());
+        let mut add_args = vec!["add", "-A", "--"];
+        add_args.extend(add_files.iter().map(String::as_str));
         run_git_args(root, &add_args)?;
         run_git_args(root, &["commit", "-m", message])?;
         let commit_sha = run_git_args(root, &["rev-parse", "HEAD"])?
@@ -204,11 +206,17 @@ fn git_status(workdir: &Path) -> Result<WorkspaceGitStatus> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let porcelain = run_git_args(
+    let porcelain = run_git_bytes(
         &root,
-        &["status", "--porcelain=v1", "--untracked-files=all"],
+        &[
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--find-renames",
+        ],
     )?;
-    let files = parse_porcelain_status(&porcelain);
+    let files = parse_porcelain_status_z(&porcelain);
 
     Ok(WorkspaceGitStatus {
         root: root.to_string_lossy().to_string(),
@@ -219,25 +227,64 @@ fn git_status(workdir: &Path) -> Result<WorkspaceGitStatus> {
     })
 }
 
-fn parse_porcelain_status(output: &str) -> Vec<WorkspaceGitFileStatus> {
-    output
-        .lines()
-        .filter_map(|line| {
-            if line.len() < 4 {
-                return None;
-            }
-            let status_code: String = line.chars().take(2).collect();
-            let path = line.get(3..)?.trim().to_string();
-            if path.is_empty() {
-                return None;
-            }
-            Some(WorkspaceGitFileStatus {
-                status_label: status_label(&status_code).to_string(),
-                status_code,
-                path,
-            })
-        })
-        .collect()
+fn parse_porcelain_status_z(output: &[u8]) -> Vec<WorkspaceGitFileStatus> {
+    let mut files = Vec::new();
+    let mut entries = output
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty());
+
+    while let Some(entry) = entries.next() {
+        if entry.len() < 4 {
+            continue;
+        }
+        let status_code = String::from_utf8_lossy(&entry[..2]).into_owned();
+        let path = decode_status_path(&entry[3..]);
+        if path.is_empty() {
+            continue;
+        }
+        let is_rename_or_copy = status_code.contains('R') || status_code.contains('C');
+        let previous_path = if is_rename_or_copy {
+            entries
+                .next()
+                .map(decode_status_path)
+                .filter(|path| !path.is_empty())
+        } else {
+            None
+        };
+        files.push(WorkspaceGitFileStatus {
+            status_label: status_label(&status_code).to_string(),
+            status_code,
+            path,
+            previous_path,
+        });
+    }
+
+    files
+}
+
+fn decode_status_path(raw: &[u8]) -> String {
+    String::from_utf8_lossy(raw).into_owned()
+}
+
+fn dedupe_selected_paths(selected_files: &[&str]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+
+    for selected in selected_files {
+        let selected = selected.trim();
+        if selected.is_empty() {
+            continue;
+        }
+        push_unique_path(&mut paths, &mut seen, selected);
+    }
+
+    paths
+}
+
+fn push_unique_path(paths: &mut Vec<String>, seen: &mut HashSet<String>, path: &str) {
+    if seen.insert(path.to_string()) {
+        paths.push(path.to_string());
+    }
 }
 
 fn status_label(status_code: &str) -> &'static str {
@@ -270,12 +317,16 @@ fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String> {
 }
 
 fn run_git_args(cwd: &Path, args: &[&str]) -> Result<String> {
+    Ok(String::from_utf8(run_git_bytes(cwd, args)?)?)
+}
+
+fn run_git_bytes(cwd: &Path, args: &[&str]) -> Result<Vec<u8>> {
     let output = Command::new("git").args(args).current_dir(cwd).output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("git command failed: {}", stderr.trim());
     }
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(output.stdout)
 }
 
 fn run_git_dir_args(git_dir: &Path, args: &[&str]) -> Result<String> {
@@ -302,7 +353,9 @@ fn normalize_git_dir(workdir: &Path, raw: &str) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_github_origin, parse_porcelain_status};
+    use super::{LocalGitRepository, parse_github_origin, parse_porcelain_status_z};
+    use crate::ports::git_repository::GitRepositoryPort;
+    use std::{fs, path::Path, process::Command};
 
     #[test]
     fn parses_github_ssh_origin() {
@@ -323,9 +376,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_porcelain_status_lines() {
-        let files = parse_porcelain_status(
-            " M src/main.rs\nA  README.md\n?? scratch.txt\nR  old.rs -> new.rs\n",
+    fn parses_nul_delimited_porcelain_status_entries() {
+        let files = parse_porcelain_status_z(
+            b" M src/main.rs\0A  README.md\0?? scratch \"file\".txt\0R  new name.rs\0old name.rs\0",
         );
 
         assert_eq!(files.len(), 4);
@@ -334,6 +387,56 @@ mod tests {
         assert_eq!(files[0].status_label, "modified");
         assert_eq!(files[1].status_label, "added");
         assert_eq!(files[2].status_label, "untracked");
+        assert_eq!(files[2].path, "scratch \"file\".txt");
         assert_eq!(files[3].status_label, "renamed");
+        assert_eq!(files[3].path, "new name.rs");
+        assert_eq!(files[3].previous_path.as_deref(), Some("old name.rs"));
+    }
+
+    #[test]
+    fn commits_renamed_path_with_spaces_from_status() {
+        let repo = create_temp_repo();
+        fs::write(repo.join("old name.rs"), "fn old() {}\n").unwrap();
+        run_git_test(&repo, &["add", "--", "old name.rs"]);
+        run_git_test(&repo, &["commit", "-m", "initial"]);
+        run_git_test(&repo, &["mv", "old name.rs", "new name.rs"]);
+
+        let status = LocalGitRepository.status(&repo).unwrap();
+        assert_eq!(status.files.len(), 1);
+        assert_eq!(status.files[0].status_label, "renamed");
+        assert_eq!(status.files[0].path, "new name.rs");
+        assert_eq!(
+            status.files[0].previous_path.as_deref(),
+            Some("old name.rs")
+        );
+
+        LocalGitRepository
+            .commit(&repo, "rename file", &[status.files[0].path.clone()])
+            .unwrap();
+        assert!(LocalGitRepository.status(&repo).unwrap().files.is_empty());
+    }
+
+    fn create_temp_repo() -> std::path::PathBuf {
+        let repo =
+            std::env::temp_dir().join(format!("acp-status-{}", uuid::Uuid::new_v4().simple()));
+        fs::create_dir_all(&repo).unwrap();
+        run_git_test(&repo, &["init"]);
+        run_git_test(&repo, &["config", "user.email", "test@example.com"]);
+        run_git_test(&repo, &["config", "user.name", "Test User"]);
+        repo
+    }
+
+    fn run_git_test(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src-tauri/src/domain/git.rs
+++ b/src-tauri/src/domain/git.rs
@@ -14,6 +14,7 @@ pub struct WorkspaceGitStatus {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceGitFileStatus {
     pub path: String,
+    pub previous_path: Option<String>,
     pub status_code: String,
     pub status_label: String,
 }

--- a/src/entities/workspace/model.ts
+++ b/src/entities/workspace/model.ts
@@ -32,6 +32,7 @@ export type RegisteredWorkspace = {
 
 export type WorkspaceGitFileStatus = {
   path: string;
+  previousPath?: string | null;
   statusCode: string;
   statusLabel: string;
 };


### PR DESCRIPTION
## Summary
- parse workspace git status with NUL-delimited porcelain output and rename detection
- expose previousPath for rename/copy entries while keeping the commit selection path valid
- stage selected paths with git add -A so renamed and deleted paths commit reliably

Fixes #80

## Tests
- npm test -- --run
- npm run build
- npm run check:fsd && npm run check:backend-boundaries
- cargo test
- git diff --check