### PR TITLE
Route run events to owning workbench windows

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,6 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Default desktop capability set",
-  "windows": ["main"],
+  "windows": ["main", "workbench-*"],
   "permissions": ["core:default", "dialog:default"]
 }

--- a/src-tauri/gen/schemas/capabilities.json
+++ b/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default desktop capability set","local":true,"windows":["main"],"permissions":["core:default","dialog:default"]}}
+{"default":{"identifier":"default","description":"Default desktop capability set","local":true,"windows":["main","workbench-*"],"permissions":["core:default","dialog:default"]}}

--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -19,6 +19,7 @@ fn read_max_runs_from_env() -> Option<usize> {
 #[derive(Clone)]
 pub struct AppState {
     runs: Arc<Mutex<HashMap<String, RunSlot>>>,
+    run_owners: Arc<Mutex<HashMap<String, String>>>,
     permissions: PermissionBroker,
     max_concurrent_runs: Option<usize>,
 }
@@ -33,6 +34,7 @@ impl AppState {
     pub fn with_max_concurrent_runs(max_concurrent_runs: Option<usize>) -> Self {
         Self {
             runs: Arc::default(),
+            run_owners: Arc::default(),
             permissions: PermissionBroker::default(),
             max_concurrent_runs,
         }
@@ -40,6 +42,10 @@ impl AppState {
 
     pub fn permissions(&self) -> PermissionBroker {
         self.permissions.clone()
+    }
+
+    pub async fn owner_of(&self, run_id: &str) -> Option<String> {
+        self.run_owners.lock().await.get(run_id).cloned()
     }
 }
 
@@ -56,7 +62,11 @@ struct RunContext {
 impl SessionRegistry for AppState {
     type Session = AcpSession;
 
-    async fn reserve_run(&self, run_id: String) -> Result<(), ReserveRunError> {
+    async fn reserve_run(
+        &self,
+        run_id: String,
+        owner_window_label: Option<String>,
+    ) -> Result<(), ReserveRunError> {
         let mut runs = self.runs.lock().await;
         if runs.contains_key(&run_id) {
             return Err(ReserveRunError::DuplicateRunId { run_id });
@@ -66,7 +76,10 @@ impl SessionRegistry for AppState {
                 return Err(ReserveRunError::ConcurrentLimit { limit });
             }
         }
-        runs.insert(run_id, RunSlot::Reserved);
+        runs.insert(run_id.clone(), RunSlot::Reserved);
+        if let Some(owner) = owner_window_label {
+            self.run_owners.lock().await.insert(run_id, owner);
+        }
         Ok(())
     }
 
@@ -106,6 +119,7 @@ impl SessionRegistry for AppState {
 
     async fn finish_run(&self, run_id: &str) {
         self.runs.lock().await.remove(run_id);
+        self.run_owners.lock().await.remove(run_id);
         self.permissions.clear_run(run_id).await;
     }
 
@@ -119,6 +133,7 @@ impl SessionRegistry for AppState {
             None => false,
         };
         if cancelled {
+            self.run_owners.lock().await.remove(run_id);
             self.permissions.clear_run(run_id).await;
         }
         cancelled
@@ -141,11 +156,11 @@ mod tests {
     async fn reserve_run_allows_multiple_distinct_run_ids() {
         let state = AppState::default();
         state
-            .reserve_run("run-a".into())
+            .reserve_run("run-a".into(), None)
             .await
             .expect("first run should reserve");
         state
-            .reserve_run("run-b".into())
+            .reserve_run("run-b".into(), None)
             .await
             .expect("second concurrent run should reserve");
         assert_eq!(state.active_run_count().await, 2);
@@ -154,9 +169,9 @@ mod tests {
     #[tokio::test]
     async fn reserve_run_rejects_duplicate_run_id() {
         let state = AppState::default();
-        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
         let err = state
-            .reserve_run("run-a".into())
+            .reserve_run("run-a".into(), None)
             .await
             .expect_err("duplicate reservation must fail");
         assert_eq!(
@@ -170,8 +185,8 @@ mod tests {
     #[tokio::test]
     async fn cancel_run_does_not_affect_other_runs() {
         let state = AppState::default();
-        state.reserve_run("run-a".into()).await.unwrap();
-        state.reserve_run("run-b".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
+        state.reserve_run("run-b".into(), None).await.unwrap();
         assert!(state.cancel_run("run-a").await);
         assert_eq!(state.active_run_count().await, 1);
         assert!(state.cancel_run("run-b").await);
@@ -181,15 +196,15 @@ mod tests {
     #[tokio::test]
     async fn reserve_run_respects_injected_concurrent_limit() {
         let state = AppState::with_max_concurrent_runs(Some(1));
-        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
         let err = state
-            .reserve_run("run-b".into())
+            .reserve_run("run-b".into(), None)
             .await
             .expect_err("second run should be rejected by the limit");
         assert_eq!(err, ReserveRunError::ConcurrentLimit { limit: 1 });
         assert!(state.cancel_run("run-a").await);
         state
-            .reserve_run("run-b".into())
+            .reserve_run("run-b".into(), None)
             .await
             .expect("limit should free up after cancel");
     }
@@ -197,9 +212,9 @@ mod tests {
     #[tokio::test]
     async fn reserve_run_duplicate_id_is_rejected_before_limit_check() {
         let state = AppState::with_max_concurrent_runs(Some(2));
-        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
         let err = state
-            .reserve_run("run-a".into())
+            .reserve_run("run-a".into(), None)
             .await
             .expect_err("duplicate id must fail");
         assert_eq!(
@@ -208,5 +223,21 @@ mod tests {
                 run_id: "run-a".into()
             }
         );
+    }
+
+    #[tokio::test]
+    async fn tracks_and_clears_run_owner() {
+        let state = AppState::default();
+        state
+            .reserve_run("run-a".into(), Some("workbench-a".into()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            state.owner_of("run-a").await.as_deref(),
+            Some("workbench-a")
+        );
+        assert!(state.cancel_run("run-a").await);
+        assert_eq!(state.owner_of("run-a").await, None);
     }
 }

--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -47,6 +47,26 @@ impl AppState {
     pub async fn owner_of(&self, run_id: &str) -> Option<String> {
         self.run_owners.lock().await.get(run_id).cloned()
     }
+
+    pub async fn transfer_run_owner(&self, run_id: &str, owner_window_label: String) -> Result<()> {
+        if !self.runs.lock().await.contains_key(run_id) {
+            return Err(anyhow!("agent run not found: {run_id}"));
+        }
+        self.run_owners
+            .lock()
+            .await
+            .insert(run_id.to_string(), owner_window_label);
+        Ok(())
+    }
+
+    pub async fn runs_owned_by(&self, owner_window_label: &str) -> Vec<String> {
+        self.run_owners
+            .lock()
+            .await
+            .iter()
+            .filter_map(|(run_id, owner)| (owner == owner_window_label).then(|| run_id.clone()))
+            .collect()
+    }
 }
 
 enum RunSlot {

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -108,6 +108,7 @@ fn next_workbench_window_label(app: &AppHandle) -> String {
 #[tauri::command]
 pub async fn start_agent_run(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, AppState>,
     storage: State<'_, StorageState>,
     mut request: AgentRunRequest,
@@ -139,7 +140,11 @@ pub async fn start_agent_run(
         .await
         .map_err(|err| err.to_string())?;
 
-    let sink = TauriRunEventSink::new(app);
+    if request.run_id.as_deref().is_none_or(str::is_empty) {
+        request.run_id = Some(Uuid::new_v4().to_string());
+    }
+    let owner_window_label = window.label().to_string();
+    let sink = TauriRunEventSink::new(app, state.inner().clone());
     let permissions = state.permissions();
     let registry = state.inner().clone();
     let runner = AcpAgentRunner::new(
@@ -149,7 +154,7 @@ pub async fn start_agent_run(
     );
 
     StartAgentRunUseCase::new(registry)
-        .execute(runner, sink, request)
+        .execute(runner, sink, request, Some(owner_window_label))
         .await
         .map_err(String::from)
 }
@@ -206,11 +211,12 @@ fn has_resume_session_id(request: &AgentRunRequest) -> bool {
 #[tauri::command]
 pub async fn send_prompt_to_run(
     app: AppHandle,
+    _window: WebviewWindow,
     state: State<'_, AppState>,
     run_id: String,
     prompt: String,
 ) -> Result<(), String> {
-    let sink = TauriRunEventSink::new(app);
+    let sink = TauriRunEventSink::new(app, state.inner().clone());
     let registry = state.inner().clone();
     SendPromptUseCase::new(registry)
         .execute(sink, run_id, prompt)
@@ -221,10 +227,11 @@ pub async fn send_prompt_to_run(
 #[tauri::command]
 pub async fn cancel_agent_run(
     app: AppHandle,
+    _window: WebviewWindow,
     state: State<'_, AppState>,
     run_id: String,
 ) -> Result<(), String> {
-    let sink = TauriRunEventSink::new(app);
+    let sink = TauriRunEventSink::new(app, state.inner().clone());
     let registry = state.inner().clone();
     CancelAgentRunUseCase::new(registry)
         .execute(sink, run_id)

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -240,6 +240,22 @@ pub async fn cancel_agent_run(
 }
 
 #[tauri::command]
+pub async fn transfer_run_owner(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    run_id: String,
+    owner_window_label: String,
+) -> Result<(), String> {
+    if app.get_webview_window(&owner_window_label).is_none() {
+        return Err(format!("workbench window not found: {owner_window_label}"));
+    }
+    state
+        .transfer_run_owner(&run_id, owner_window_label)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
 pub async fn respond_agent_permission(
     state: State<'_, AppState>,
     permission_id: String,

--- a/src-tauri/src/adapters/tauri/event_sink.rs
+++ b/src-tauri/src/adapters/tauri/event_sink.rs
@@ -1,6 +1,7 @@
 use tauri::{AppHandle, Emitter};
 
 use crate::{
+    adapters::session_registry::AppState,
     domain::events::{RunEvent, RunEventEnvelope},
     ports::event_sink::RunEventSink,
 };
@@ -10,22 +11,31 @@ pub const AGENT_RUN_EVENT: &str = "agent-run-event";
 #[derive(Clone)]
 pub struct TauriRunEventSink {
     app: AppHandle,
+    state: AppState,
 }
 
 impl TauriRunEventSink {
-    pub fn new(app: AppHandle) -> Self {
-        Self { app }
+    pub fn new(app: AppHandle, state: AppState) -> Self {
+        Self { app, state }
     }
 }
 
 impl RunEventSink for TauriRunEventSink {
     fn emit(&self, run_id: &str, event: RunEvent) {
-        let _ = self.app.emit(
-            AGENT_RUN_EVENT,
-            RunEventEnvelope {
-                run_id: run_id.to_string(),
-                event,
-            },
-        );
+        let envelope = RunEventEnvelope {
+            run_id: run_id.to_string(),
+            event,
+        };
+        let app = self.app.clone();
+        let state = self.state.clone();
+        let run_id = run_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            if let Some(owner) = state.owner_of(&run_id).await {
+                if app.emit_to(&owner, AGENT_RUN_EVENT, &envelope).is_ok() {
+                    return;
+                }
+            }
+            let _ = app.emit(AGENT_RUN_EVENT, envelope);
+        });
     }
 }

--- a/src-tauri/src/application/cancel_agent_run.rs
+++ b/src-tauri/src/application/cancel_agent_run.rs
@@ -62,7 +62,7 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, _: String) -> Result<(), ReserveRunError> {
+        async fn reserve_run(&self, _: String, _: Option<String>) -> Result<(), ReserveRunError> {
             Ok(())
         }
         async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -121,7 +121,7 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, _: String) -> Result<(), ReserveRunError> {
+        async fn reserve_run(&self, _: String, _: Option<String>) -> Result<(), ReserveRunError> {
             Ok(())
         }
         async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -37,6 +37,7 @@ where
         launcher: L,
         sink: S,
         request: AgentRunRequest,
+        owner_window_label: Option<String>,
     ) -> Result<AgentRun, StartAgentRunError>
     where
         L: SessionLauncher<Session = R::Session>,
@@ -44,7 +45,7 @@ where
     {
         let run = build_run(&request);
         self.registry
-            .reserve_run(run.id.clone())
+            .reserve_run(run.id.clone(), owner_window_label)
             .await
             .map_err(StartAgentRunError::ReserveRun)?;
 
@@ -133,6 +134,7 @@ mod tests {
     #[derive(Default)]
     struct FakeRegistryState {
         reserved: Vec<String>,
+        owners: HashMap<String, Option<String>>,
         finished: Vec<String>,
         sessions: HashMap<String, Arc<FakeSession>>,
         handles: HashMap<String, JoinHandle<()>>,
@@ -164,11 +166,16 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, run_id: String) -> Result<(), ReserveRunError> {
+        async fn reserve_run(
+            &self,
+            run_id: String,
+            owner_window_label: Option<String>,
+        ) -> Result<(), ReserveRunError> {
             let mut state = self.inner.lock().await;
             if let Some(error) = state.reserve_run_error.clone() {
                 return Err(error);
             }
+            state.owners.insert(run_id.clone(), owner_window_label);
             state.reserved.push(run_id);
             Ok(())
         }
@@ -327,18 +334,23 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink.clone(), make_request())
+            .execute(
+                launcher,
+                sink.clone(),
+                make_request(),
+                Some("workbench-a".into()),
+            )
             .await
             .expect("start should succeed");
 
         c.2.notified().await;
-        let handle = registry
-            .inner
-            .lock()
-            .await
-            .handles
-            .remove(&run.id)
-            .expect("handle stored");
+        let mut state = registry.inner.lock().await;
+        assert_eq!(
+            state.owners.get(&run.id).and_then(|value| value.as_deref()),
+            Some("workbench-a")
+        );
+        let handle = state.handles.remove(&run.id).expect("handle stored");
+        drop(state);
         handle.await.expect("task should finish");
 
         assert_eq!(c.1.load(Ordering::SeqCst), 1);
@@ -359,7 +371,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let result = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink, make_request())
+            .execute(launcher, sink, make_request(), None)
             .await;
 
         assert!(matches!(
@@ -382,7 +394,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let result = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink, make_request())
+            .execute(launcher, sink, make_request(), None)
             .await;
 
         assert!(matches!(
@@ -404,7 +416,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let result = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink, make_request())
+            .execute(launcher, sink, make_request(), None)
             .await;
 
         assert!(matches!(
@@ -425,7 +437,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink.clone(), make_request())
+            .execute(launcher, sink.clone(), make_request(), None)
             .await
             .expect("start call itself should succeed");
 
@@ -457,7 +469,7 @@ mod tests {
         let launcher = FakeLauncher::failing(done.clone());
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink.clone(), make_request())
+            .execute(launcher, sink.clone(), make_request(), None)
             .await
             .expect("start call itself should succeed");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,12 +17,16 @@ use adapters::{
         record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
         remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
         start_agent_run, submit_github_pull_request_review, summarize_workspace_diff,
-        update_pull_request_review_draft, update_saved_prompt,
+        transfer_run_owner, update_pull_request_review_draft, update_saved_prompt,
     },
 };
+use ports::session_registry::SessionRegistry;
 use tauri::Manager;
 
 pub fn run() {
+    let app_state = AppState::default();
+    let cleanup_state = app_state.clone();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
@@ -31,7 +35,18 @@ pub fn run() {
             app.manage(storage);
             Ok(())
         })
-        .manage(AppState::default())
+        .on_window_event(move |window, event| {
+            if matches!(event, tauri::WindowEvent::Destroyed) {
+                let label = window.label().to_string();
+                let state = cleanup_state.clone();
+                tauri::async_runtime::spawn(async move {
+                    for run_id in state.runs_owned_by(&label).await {
+                        state.cancel_run(&run_id).await;
+                    }
+                });
+            }
+        })
+        .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             list_agents,
             load_goal_file,
@@ -41,6 +56,7 @@ pub fn run() {
             start_agent_run,
             send_prompt_to_run,
             cancel_agent_run,
+            transfer_run_owner,
             respond_agent_permission,
             list_acp_sessions,
             clear_acp_session,

--- a/src-tauri/src/ports/session_registry.rs
+++ b/src-tauri/src/ports/session_registry.rs
@@ -36,6 +36,7 @@ pub trait SessionRegistry: Clone + Send + Sync + 'static {
     fn reserve_run(
         &self,
         run_id: String,
+        owner_window_label: Option<String>,
     ) -> impl Future<Output = Result<(), ReserveRunError>> + Send;
 
     fn attach_run_handle(


### PR DESCRIPTION
## Summary
- record the owning Tauri window label when reserving an agent run
- route run events through app.emit_to(owner, ...) with broadcast fallback
- add a backend transfer_run_owner command for future detach/move flows
- cancel runs owned by a window when that window is destroyed
- allow dynamically created workbench-* windows to use the default Tauri capability

Part of #8

## Tests
- cargo fmt && cargo test
- npm test
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- git diff --check