### PR TITLE
Route run events to owner window

### DIFF
--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -1,5 +1,9 @@
 use anyhow::{Result, anyhow};
-use std::{collections::HashMap, env, sync::Arc};
+use std::{
+    collections::HashMap,
+    env,
+    sync::{Arc, Mutex as StdMutex},
+};
 use tokio::{sync::Mutex, task::JoinHandle};
 
 use crate::{
@@ -19,6 +23,7 @@ fn read_max_runs_from_env() -> Option<usize> {
 #[derive(Clone)]
 pub struct AppState {
     runs: Arc<Mutex<HashMap<String, RunSlot>>>,
+    run_owners: Arc<StdMutex<HashMap<String, String>>>,
     permissions: PermissionBroker,
     max_concurrent_runs: Option<usize>,
 }
@@ -33,6 +38,7 @@ impl AppState {
     pub fn with_max_concurrent_runs(max_concurrent_runs: Option<usize>) -> Self {
         Self {
             runs: Arc::default(),
+            run_owners: Arc::default(),
             permissions: PermissionBroker::default(),
             max_concurrent_runs,
         }
@@ -40,6 +46,39 @@ impl AppState {
 
     pub fn permissions(&self) -> PermissionBroker {
         self.permissions.clone()
+    }
+
+    pub fn owner_of(&self, run_id: &str) -> Option<String> {
+        self.run_owners
+            .lock()
+            .expect("run owner mutex poisoned")
+            .get(run_id)
+            .cloned()
+    }
+
+    #[allow(dead_code)]
+    pub async fn transfer_run(&self, run_id: &str, new_owner: String) -> Result<()> {
+        if !self.runs.lock().await.contains_key(run_id) {
+            return Err(anyhow!("agent run not found: {run_id}"));
+        }
+        self.run_owners
+            .lock()
+            .expect("run owner mutex poisoned")
+            .insert(run_id.to_string(), new_owner);
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub async fn runs_owned_by(&self, owner: &str) -> Vec<String> {
+        let mut runs: Vec<_> = self
+            .run_owners
+            .lock()
+            .expect("run owner mutex poisoned")
+            .iter()
+            .filter_map(|(run_id, label)| (label == owner).then(|| run_id.clone()))
+            .collect();
+        runs.sort();
+        runs
     }
 }
 
@@ -56,7 +95,11 @@ struct RunContext {
 impl SessionRegistry for AppState {
     type Session = AcpSession;
 
-    async fn reserve_run(&self, run_id: String) -> Result<(), ReserveRunError> {
+    async fn reserve_run(
+        &self,
+        run_id: String,
+        owner: Option<String>,
+    ) -> Result<(), ReserveRunError> {
         let mut runs = self.runs.lock().await;
         if runs.contains_key(&run_id) {
             return Err(ReserveRunError::DuplicateRunId { run_id });
@@ -66,7 +109,17 @@ impl SessionRegistry for AppState {
                 return Err(ReserveRunError::ConcurrentLimit { limit });
             }
         }
-        runs.insert(run_id, RunSlot::Reserved);
+        runs.insert(run_id.clone(), RunSlot::Reserved);
+        drop(runs);
+        if let Some(owner) = owner
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        {
+            self.run_owners
+                .lock()
+                .expect("run owner mutex poisoned")
+                .insert(run_id, owner);
+        }
         Ok(())
     }
 
@@ -106,6 +159,10 @@ impl SessionRegistry for AppState {
 
     async fn finish_run(&self, run_id: &str) {
         self.runs.lock().await.remove(run_id);
+        self.run_owners
+            .lock()
+            .expect("run owner mutex poisoned")
+            .remove(run_id);
         self.permissions.clear_run(run_id).await;
     }
 
@@ -118,6 +175,12 @@ impl SessionRegistry for AppState {
             Some(RunSlot::Reserved) => true,
             None => false,
         };
+        if cancelled {
+            self.run_owners
+                .lock()
+                .expect("run owner mutex poisoned")
+                .remove(run_id);
+        }
         if cancelled {
             self.permissions.clear_run(run_id).await;
         }
@@ -141,11 +204,11 @@ mod tests {
     async fn reserve_run_allows_multiple_distinct_run_ids() {
         let state = AppState::default();
         state
-            .reserve_run("run-a".into())
+            .reserve_run("run-a".into(), None)
             .await
             .expect("first run should reserve");
         state
-            .reserve_run("run-b".into())
+            .reserve_run("run-b".into(), None)
             .await
             .expect("second concurrent run should reserve");
         assert_eq!(state.active_run_count().await, 2);
@@ -154,9 +217,9 @@ mod tests {
     #[tokio::test]
     async fn reserve_run_rejects_duplicate_run_id() {
         let state = AppState::default();
-        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
         let err = state
-            .reserve_run("run-a".into())
+            .reserve_run("run-a".into(), None)
             .await
             .expect_err("duplicate reservation must fail");
         assert_eq!(
@@ -170,8 +233,8 @@ mod tests {
     #[tokio::test]
     async fn cancel_run_does_not_affect_other_runs() {
         let state = AppState::default();
-        state.reserve_run("run-a".into()).await.unwrap();
-        state.reserve_run("run-b".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
+        state.reserve_run("run-b".into(), None).await.unwrap();
         assert!(state.cancel_run("run-a").await);
         assert_eq!(state.active_run_count().await, 1);
         assert!(state.cancel_run("run-b").await);
@@ -181,15 +244,15 @@ mod tests {
     #[tokio::test]
     async fn reserve_run_respects_injected_concurrent_limit() {
         let state = AppState::with_max_concurrent_runs(Some(1));
-        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
         let err = state
-            .reserve_run("run-b".into())
+            .reserve_run("run-b".into(), None)
             .await
             .expect_err("second run should be rejected by the limit");
         assert_eq!(err, ReserveRunError::ConcurrentLimit { limit: 1 });
         assert!(state.cancel_run("run-a").await);
         state
-            .reserve_run("run-b".into())
+            .reserve_run("run-b".into(), None)
             .await
             .expect("limit should free up after cancel");
     }
@@ -197,9 +260,9 @@ mod tests {
     #[tokio::test]
     async fn reserve_run_duplicate_id_is_rejected_before_limit_check() {
         let state = AppState::with_max_concurrent_runs(Some(2));
-        state.reserve_run("run-a".into()).await.unwrap();
+        state.reserve_run("run-a".into(), None).await.unwrap();
         let err = state
-            .reserve_run("run-a".into())
+            .reserve_run("run-a".into(), None)
             .await
             .expect_err("duplicate id must fail");
         assert_eq!(
@@ -208,5 +271,30 @@ mod tests {
                 run_id: "run-a".into()
             }
         );
+    }
+
+    #[tokio::test]
+    async fn tracks_and_transfers_run_owners() {
+        let state = AppState::default();
+        state
+            .reserve_run("run-a".into(), Some("workbench-a".into()))
+            .await
+            .unwrap();
+
+        assert_eq!(state.owner_of("run-a").as_deref(), Some("workbench-a"));
+        assert_eq!(
+            state.runs_owned_by("workbench-a").await,
+            vec!["run-a".to_string()]
+        );
+
+        state
+            .transfer_run("run-a", "workbench-b".into())
+            .await
+            .unwrap();
+        assert_eq!(state.owner_of("run-a").as_deref(), Some("workbench-b"));
+        assert!(state.runs_owned_by("workbench-a").await.is_empty());
+
+        state.finish_run("run-a").await;
+        assert_eq!(state.owner_of("run-a"), None);
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -108,6 +108,7 @@ fn next_workbench_window_label(app: &AppHandle) -> String {
 #[tauri::command]
 pub async fn start_agent_run(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, AppState>,
     storage: State<'_, StorageState>,
     mut request: AgentRunRequest,
@@ -139,9 +140,10 @@ pub async fn start_agent_run(
         .await
         .map_err(|err| err.to_string())?;
 
-    let sink = TauriRunEventSink::new(app);
-    let permissions = state.permissions();
+    let owner = window.label().to_string();
     let registry = state.inner().clone();
+    let sink = TauriRunEventSink::new(app, registry.clone());
+    let permissions = state.permissions();
     let runner = AcpAgentRunner::new(
         ConfigurableAgentCatalog::from_env(),
         permissions,
@@ -149,7 +151,7 @@ pub async fn start_agent_run(
     );
 
     StartAgentRunUseCase::new(registry)
-        .execute(runner, sink, request)
+        .execute(runner, sink, request, Some(owner))
         .await
         .map_err(String::from)
 }
@@ -210,8 +212,8 @@ pub async fn send_prompt_to_run(
     run_id: String,
     prompt: String,
 ) -> Result<(), String> {
-    let sink = TauriRunEventSink::new(app);
     let registry = state.inner().clone();
+    let sink = TauriRunEventSink::new(app, registry.clone());
     SendPromptUseCase::new(registry)
         .execute(sink, run_id, prompt)
         .await
@@ -224,8 +226,9 @@ pub async fn cancel_agent_run(
     state: State<'_, AppState>,
     run_id: String,
 ) -> Result<(), String> {
-    let sink = TauriRunEventSink::new(app);
     let registry = state.inner().clone();
+    let owner = registry.owner_of(&run_id);
+    let sink = TauriRunEventSink::with_fallback_owner(app, registry.clone(), owner);
     CancelAgentRunUseCase::new(registry)
         .execute(sink, run_id)
         .await;

--- a/src-tauri/src/adapters/tauri/event_sink.rs
+++ b/src-tauri/src/adapters/tauri/event_sink.rs
@@ -1,6 +1,7 @@
 use tauri::{AppHandle, Emitter};
 
 use crate::{
+    adapters::session_registry::AppState,
     domain::events::{RunEvent, RunEventEnvelope},
     ports::event_sink::RunEventSink,
 };
@@ -10,22 +11,43 @@ pub const AGENT_RUN_EVENT: &str = "agent-run-event";
 #[derive(Clone)]
 pub struct TauriRunEventSink {
     app: AppHandle,
+    state: AppState,
+    fallback_owner: Option<String>,
 }
 
 impl TauriRunEventSink {
-    pub fn new(app: AppHandle) -> Self {
-        Self { app }
+    pub fn new(app: AppHandle, state: AppState) -> Self {
+        Self {
+            app,
+            state,
+            fallback_owner: None,
+        }
+    }
+
+    pub fn with_fallback_owner(app: AppHandle, state: AppState, owner: Option<String>) -> Self {
+        Self {
+            app,
+            state,
+            fallback_owner: owner,
+        }
     }
 }
 
 impl RunEventSink for TauriRunEventSink {
     fn emit(&self, run_id: &str, event: RunEvent) {
-        let _ = self.app.emit(
-            AGENT_RUN_EVENT,
-            RunEventEnvelope {
-                run_id: run_id.to_string(),
-                event,
-            },
-        );
+        let envelope = RunEventEnvelope {
+            run_id: run_id.to_string(),
+            event,
+        };
+        if let Some(owner) = self
+            .state
+            .owner_of(run_id)
+            .or_else(|| self.fallback_owner.clone())
+        {
+            if self.app.emit_to(&owner, AGENT_RUN_EVENT, &envelope).is_ok() {
+                return;
+            }
+        }
+        let _ = self.app.emit(AGENT_RUN_EVENT, envelope);
     }
 }

--- a/src-tauri/src/application/cancel_agent_run.rs
+++ b/src-tauri/src/application/cancel_agent_run.rs
@@ -62,7 +62,11 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, _: String) -> Result<(), ReserveRunError> {
+        async fn reserve_run(
+            &self,
+            _: String,
+            _owner: Option<String>,
+        ) -> Result<(), ReserveRunError> {
             Ok(())
         }
         async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {

--- a/src-tauri/src/application/send_prompt.rs
+++ b/src-tauri/src/application/send_prompt.rs
@@ -121,7 +121,11 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, _: String) -> Result<(), ReserveRunError> {
+        async fn reserve_run(
+            &self,
+            _: String,
+            _owner: Option<String>,
+        ) -> Result<(), ReserveRunError> {
             Ok(())
         }
         async fn attach_run_handle(&self, _: &str, handle: JoinHandle<()>) -> Result<()> {

--- a/src-tauri/src/application/start_agent_run.rs
+++ b/src-tauri/src/application/start_agent_run.rs
@@ -37,6 +37,7 @@ where
         launcher: L,
         sink: S,
         request: AgentRunRequest,
+        owner: Option<String>,
     ) -> Result<AgentRun, StartAgentRunError>
     where
         L: SessionLauncher<Session = R::Session>,
@@ -44,7 +45,7 @@ where
     {
         let run = build_run(&request);
         self.registry
-            .reserve_run(run.id.clone())
+            .reserve_run(run.id.clone(), owner)
             .await
             .map_err(StartAgentRunError::ReserveRun)?;
 
@@ -164,7 +165,11 @@ mod tests {
     impl SessionRegistry for FakeRegistry {
         type Session = FakeSession;
 
-        async fn reserve_run(&self, run_id: String) -> Result<(), ReserveRunError> {
+        async fn reserve_run(
+            &self,
+            run_id: String,
+            _owner: Option<String>,
+        ) -> Result<(), ReserveRunError> {
             let mut state = self.inner.lock().await;
             if let Some(error) = state.reserve_run_error.clone() {
                 return Err(error);
@@ -327,7 +332,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink.clone(), make_request())
+            .execute(launcher, sink.clone(), make_request(), Some("main".into()))
             .await
             .expect("start should succeed");
 
@@ -359,7 +364,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let result = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink, make_request())
+            .execute(launcher, sink, make_request(), None)
             .await;
 
         assert!(matches!(
@@ -382,7 +387,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let result = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink, make_request())
+            .execute(launcher, sink, make_request(), None)
             .await;
 
         assert!(matches!(
@@ -404,7 +409,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let result = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink, make_request())
+            .execute(launcher, sink, make_request(), None)
             .await;
 
         assert!(matches!(
@@ -425,7 +430,7 @@ mod tests {
         let launcher = FakeLauncher::success(&c);
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink.clone(), make_request())
+            .execute(launcher, sink.clone(), make_request(), None)
             .await
             .expect("start call itself should succeed");
 
@@ -457,7 +462,7 @@ mod tests {
         let launcher = FakeLauncher::failing(done.clone());
 
         let run = StartAgentRunUseCase::new(registry.clone())
-            .execute(launcher, sink.clone(), make_request())
+            .execute(launcher, sink.clone(), make_request(), None)
             .await
             .expect("start call itself should succeed");
 

--- a/src-tauri/src/ports/session_registry.rs
+++ b/src-tauri/src/ports/session_registry.rs
@@ -36,6 +36,7 @@ pub trait SessionRegistry: Clone + Send + Sync + 'static {
     fn reserve_run(
         &self,
         run_id: String,
+        owner: Option<String>,
     ) -> impl Future<Output = Result<(), ReserveRunError>> + Send;
 
     fn attach_run_handle(


### PR DESCRIPTION
## Summary
- track a window owner for each reserved agent run
- route Tauri agent-run-event payloads with emit_to when an owner is known
- preserve targeted delivery for cancel events with a fallback owner

Part of #8

## Validation
- npm run check:backend-boundaries
- npm run check:fsd
- npm run build
- npm run test --if-present
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check