### PR TITLE
Add detachable workbench tabs

### DIFF
--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -20,6 +20,7 @@ fn read_max_runs_from_env() -> Option<usize> {
 pub struct AppState {
     runs: Arc<Mutex<HashMap<String, RunSlot>>>,
     run_owners: Arc<Mutex<HashMap<String, String>>>,
+    window_bootstraps: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     permissions: PermissionBroker,
     max_concurrent_runs: Option<usize>,
 }
@@ -35,6 +36,7 @@ impl AppState {
         Self {
             runs: Arc::default(),
             run_owners: Arc::default(),
+            window_bootstraps: Arc::default(),
             permissions: PermissionBroker::default(),
             max_concurrent_runs,
         }
@@ -66,6 +68,17 @@ impl AppState {
             .iter()
             .filter_map(|(run_id, owner)| (owner == owner_window_label).then(|| run_id.clone()))
             .collect()
+    }
+
+    pub async fn set_window_bootstrap(&self, window_label: String, bootstrap: serde_json::Value) {
+        self.window_bootstraps
+            .lock()
+            .await
+            .insert(window_label, bootstrap);
+    }
+
+    pub async fn take_window_bootstrap(&self, window_label: &str) -> Option<serde_json::Value> {
+        self.window_bootstraps.lock().await.remove(window_label)
     }
 }
 

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use serde_json::Value;
 use tauri::{AppHandle, Manager, State, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 use uuid::Uuid;
 
@@ -60,8 +61,13 @@ pub fn load_goal_file(path: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn get_window_bootstrap(window: WebviewWindow) -> WorkbenchWindowBootstrap {
-    WorkbenchWindowBootstrap::new(window.label())
+pub async fn get_window_bootstrap(
+    window: WebviewWindow,
+    state: State<'_, AppState>,
+) -> Result<WorkbenchWindowBootstrap, String> {
+    let label = window.label().to_string();
+    let detached_tab = state.take_window_bootstrap(&label).await;
+    Ok(WorkbenchWindowBootstrap::new(label, detached_tab))
 }
 
 #[tauri::command]
@@ -92,6 +98,41 @@ pub fn open_workbench_window(app: AppHandle) -> Result<WorkbenchWindowInfo, Stri
             .map_err(|err| err.to_string())?;
     window.set_focus().map_err(|err| err.to_string())?;
 
+    Ok(WorkbenchWindowInfo::new(label, title))
+}
+
+#[tauri::command]
+pub async fn detach_tab(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    tab: Value,
+    run_id: Option<String>,
+) -> Result<WorkbenchWindowInfo, String> {
+    let label = next_workbench_window_label(&app);
+    let title = "ACP Agent Workbench".to_string();
+    state.set_window_bootstrap(label.clone(), tab).await;
+
+    let window =
+        match WebviewWindowBuilder::new(&app, label.clone(), WebviewUrl::App("index.html".into()))
+            .title(&title)
+            .build()
+        {
+            Ok(window) => window,
+            Err(err) => {
+                state.take_window_bootstrap(&label).await;
+                return Err(err.to_string());
+            }
+        };
+
+    if let Some(run_id) = run_id.as_deref().filter(|value| !value.is_empty()) {
+        if let Err(err) = state.transfer_run_owner(run_id, label.clone()).await {
+            state.take_window_bootstrap(&label).await;
+            let _ = window.close();
+            return Err(err.to_string());
+        }
+    }
+
+    window.set_focus().map_err(|err| err.to_string())?;
     Ok(WorkbenchWindowInfo::new(label, title))
 }
 

--- a/src-tauri/src/domain/workbench_window.rs
+++ b/src-tauri/src/domain/workbench_window.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 pub const MAIN_WORKBENCH_WINDOW_LABEL: &str = "main";
 
@@ -15,6 +16,8 @@ pub struct WorkbenchWindowInfo {
 pub struct WorkbenchWindowBootstrap {
     pub label: String,
     pub is_main: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detached_tab: Option<Value>,
 }
 
 impl WorkbenchWindowInfo {
@@ -29,11 +32,12 @@ impl WorkbenchWindowInfo {
 }
 
 impl WorkbenchWindowBootstrap {
-    pub fn new(label: impl Into<String>) -> Self {
+    pub fn new(label: impl Into<String>, detached_tab: Option<Value>) -> Self {
         let label = label.into();
         Self {
             is_main: label == MAIN_WORKBENCH_WINDOW_LABEL,
             label,
+            detached_tab,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use adapters::{
     tauri::commands::{
         cancel_agent_run, cleanup_workspace_task_worktree, clear_acp_session,
         create_github_pull_request, create_pull_request_review_draft, create_saved_prompt,
-        create_workspace_commit, delete_pull_request_review_draft, delete_saved_prompt,
+        create_workspace_commit, delete_pull_request_review_draft, delete_saved_prompt, detach_tab,
         get_github_pull_request_context, get_window_bootstrap, get_workspace_git_status,
         list_acp_sessions, list_agents, list_pull_request_review_drafts, list_saved_prompts,
         list_workbench_windows, list_workspace_checkouts, list_workspaces, load_goal_file,
@@ -53,6 +53,7 @@ pub fn run() {
             get_window_bootstrap,
             list_workbench_windows,
             open_workbench_window,
+            detach_tab,
             start_agent_run,
             send_prompt_to_run,
             cancel_agent_run,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,13 +1,20 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { AgentWorkbenchPage } from "../pages/agent-workbench";
-import { installAgentRuntime } from "../features/agent-run";
+import { hydrateDetachedWorkbenchTab, installAgentRuntime } from "../features/agent-run";
+import { getWindowBootstrap } from "../features/workbench-window";
 
 const queryClient = new QueryClient();
 
 export function App() {
   useEffect(() => {
-    void installAgentRuntime();
+    void (async () => {
+      const bootstrap = await getWindowBootstrap();
+      if (bootstrap.detachedTab) {
+        hydrateDetachedWorkbenchTab(bootstrap.detachedTab);
+      }
+      await installAgentRuntime();
+    })();
   }, []);
 
   return (

--- a/src/entities/workbench-window/model.ts
+++ b/src/entities/workbench-window/model.ts
@@ -7,4 +7,5 @@ export type WorkbenchWindowInfo = {
 export type WorkbenchWindowBootstrap = {
   label: string;
   isMain: boolean;
+  detachedTab?: unknown;
 };

--- a/src/features/agent-run/api.test.ts
+++ b/src/features/agent-run/api.test.ts
@@ -14,6 +14,7 @@ import {
   createPullRequestReviewDraft,
   createWorkspaceCommit,
   deletePullRequestReviewDraft,
+  detachAgentRunTab,
   getGitHubPullRequestContext,
   getWorkspaceGitStatus,
   listAcpSessions,
@@ -57,6 +58,54 @@ describe("agent-run api", () => {
     expect(mockedInvoke).toHaveBeenNthCalledWith(2, "send_prompt_to_run", {
       runId: "run-1",
       prompt: "follow up",
+    });
+  });
+
+  it("detachAgentRunTab forwards the tab snapshot and active run id", async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      label: "workbench-1",
+      isMain: false,
+      title: "ACP Agent Workbench",
+    });
+
+    await detachAgentRunTab({
+      id: "tab-1",
+      title: "Review",
+      workspaceId: "workspace-1",
+      checkoutId: "checkout-1",
+      selectedAgentId: "codex",
+      goal: "review the diff",
+      cwd: "/repo",
+      customCommand: "",
+      stdioBufferLimitMb: 50,
+      autoAllow: true,
+      resumePolicy: "fresh",
+      ralphLoop: {
+        enabled: false,
+        maxIterations: 3,
+        promptTemplate: "Continue",
+        stopOnError: true,
+        stopOnPermission: true,
+        delayMs: 0,
+      },
+      idleTimeoutSec: 60,
+      idleRemainingSec: null,
+      activeRunId: "run-1",
+      sessionActive: true,
+      awaitingResponse: false,
+      followUpDraft: "",
+      followUpQueue: [],
+      items: [],
+      filter: "all",
+      error: null,
+      unreadCount: 0,
+      permissionPending: false,
+      closing: false,
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("detach_tab", {
+      tab: expect.objectContaining({ id: "tab-1" }),
+      runId: "run-1",
     });
   });
 

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -2,6 +2,7 @@ import type { AgentDescriptor } from "../../entities/agent";
 import type { AcpSessionListQuery, AcpSessionRecord } from "../../entities/acp-session";
 import type { AgentRun, AgentRunRequest, RunEventEnvelope } from "../../entities/message";
 import type { CreateSavedPromptInput, SavedPrompt, UpdateSavedPromptPatch } from "../../entities/saved-prompt";
+import type { WorkbenchWindowInfo } from "../../entities/workbench-window";
 import type {
   CreatePullRequestReviewDraftInput,
   GitHubPullRequestCreateRequest,
@@ -23,6 +24,7 @@ import type {
   WorkspacePushResult,
 } from "../../entities/workspace";
 import { invokeCommand, listenEvent } from "../../shared/api";
+import type { TabState } from "./model";
 
 export function listAgents() {
   return invokeCommand<AgentDescriptor[]>("list_agents");
@@ -38,6 +40,13 @@ export function cancelAgentRun(runId: string) {
 
 export function sendPromptToRun(runId: string, prompt: string) {
   return invokeCommand<void>("send_prompt_to_run", { runId, prompt });
+}
+
+export function detachAgentRunTab(tab: TabState) {
+  return invokeCommand<WorkbenchWindowInfo>("detach_tab", {
+    tab,
+    runId: tab.sessionActive ? tab.activeRunId : null,
+  });
 }
 
 export function listenRunEvents(callback: (event: RunEventEnvelope) => void) {

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -3,6 +3,8 @@ export {
   activateWorkbenchTab,
   closeWorkbenchTab,
   createWorkbenchTab,
+  detachWorkbenchTab,
+  hydrateDetachedWorkbenchTab,
   setTabWorkdir,
   setTabWorkspace,
   setWorkbenchWorkspaces,

--- a/src/features/agent-run/model.test.ts
+++ b/src/features/agent-run/model.test.ts
@@ -4,6 +4,7 @@ import {
   selectWorkspaceView,
   selectWorkspaceViewRuns,
   useWorkbenchStore,
+  type TabState,
 } from "./model";
 
 describe("workspace-scoped run state", () => {
@@ -124,5 +125,72 @@ describe("workspace-scoped run state", () => {
       runError: "failed to start",
     });
     expect(run.completedAt).toEqual(expect.any(Number));
+  });
+
+  it("hydrates a detached running tab with its timeline state", () => {
+    const sourceTab: TabState = {
+      id: "tab-detached",
+      title: "Detached",
+      workspaceId: "workspace-1",
+      checkoutId: "checkout-1",
+      selectedAgentId: "codex",
+      goal: "continue in another window",
+      cwd: "/repo",
+      customCommand: "",
+      stdioBufferLimitMb: 50,
+      autoAllow: true,
+      resumePolicy: "fresh" as const,
+      ralphLoop: {
+        enabled: false,
+        maxIterations: 3,
+        promptTemplate: "Continue",
+        stopOnError: true,
+        stopOnPermission: true,
+        delayMs: 0,
+      },
+      idleTimeoutSec: 60,
+      idleRemainingSec: 12,
+      activeRunId: "run-detached",
+      sessionActive: true,
+      awaitingResponse: false,
+      followUpDraft: "next prompt",
+      followUpQueue: [
+        { id: "follow-up-1", runId: "run-detached", text: "ship it", createdAt: 1 },
+      ],
+      items: [
+        {
+          id: "item-1",
+          runId: "run-detached",
+          group: "assistant/message" as const,
+          title: "assistant/message",
+          body: "progress",
+          createdAt: 1,
+          event: { type: "agentMessage" as const, text: "progress" },
+        },
+      ],
+      filter: "all" as const,
+      error: null,
+      unreadCount: 2,
+      permissionPending: false,
+      closing: true,
+    };
+
+    useWorkbenchStore.getState().hydrateDetachedTab(sourceTab);
+
+    const state = useWorkbenchStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]).toMatchObject({ id: "tab-detached", closing: false });
+    expect(state.workspaceViews[0]).toMatchObject({
+      id: "tab-detached",
+      activeRunId: "run-detached",
+      followUpDraft: "next prompt",
+    });
+    expect(state.runsById["run-detached"]).toMatchObject({
+      id: "run-detached",
+      workspaceViewId: "tab-detached",
+      idleRemainingSec: 12,
+      items: sourceTab.items,
+      followUpQueue: sourceTab.followUpQueue,
+    });
   });
 });

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -116,6 +116,7 @@ type WorkbenchState = {
   addTab: (preset?: Partial<TabState>) => string;
   closeTab: (tabId: string) => string | null;
   forceCloseTab: (tabId: string) => string | null;
+  hydrateDetachedTab: (tab: TabState) => void;
   activateTab: (tabId: string) => void;
   renameTab: (tabId: string, title: string) => void;
   patchTab: (tabId: string, patch: Partial<TabState>) => void;
@@ -223,6 +224,20 @@ function runStateFromTab(tab: TabState, runId: string): AgentRunState {
     runError: null,
     createdAt: Date.now(),
     completedAt: null,
+  };
+}
+
+function runStateFromDetachedTab(tab: TabState, runId: string): AgentRunState {
+  return {
+    ...runStateFromTab(tab, runId),
+    sessionActive: tab.sessionActive,
+    awaitingResponse: tab.awaitingResponse,
+    idleRemainingSec: tab.idleRemainingSec,
+    permissionPending: tab.permissionPending,
+    followUpQueue: tab.followUpQueue,
+    items: tab.items,
+    runError: tab.error,
+    completedAt: tab.sessionActive ? null : Date.now(),
   };
 }
 
@@ -396,7 +411,13 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
 
   forceCloseTab: (tabId) => {
     const state = get();
-    if (!state.tabs.some((t) => t.id === tabId)) return state.activeTabId;
+    const target = state.tabs.find((t) => t.id === tabId);
+    if (!target) return state.activeTabId;
+    const runsById = target.activeRunId
+      ? Object.fromEntries(
+          Object.entries(state.runsById).filter(([runId]) => runId !== target.activeRunId),
+        )
+      : state.runsById;
     if (state.tabs.length <= 1) {
       const replacement = createTabState({}, 0);
       const replacementView = tabToWorkspaceView(replacement);
@@ -405,6 +426,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
         activeTabId: replacement.id,
         workspaceViews: [replacementView],
         activeWorkspaceViewId: replacementView.id,
+        runsById,
       });
       return replacement.id;
     }
@@ -420,8 +442,23 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
       activeTabId: nextActive,
       workspaceViews: state.workspaceViews.filter((view) => view.id !== tabId),
       activeWorkspaceViewId: nextActive,
+      runsById,
     });
     return nextActive;
+  },
+
+  hydrateDetachedTab: (snapshot) => {
+    const tab = createTabState({ ...snapshot, closing: false }, 0);
+    const workspaceView = tabToWorkspaceView(tab);
+    set({
+      tabs: [tab],
+      activeTabId: tab.id,
+      workspaceViews: [workspaceView],
+      activeWorkspaceViewId: workspaceView.id,
+      runsById: tab.activeRunId
+        ? { [tab.activeRunId]: runStateFromDetachedTab(tab, tab.activeRunId) }
+        : {},
+    });
   },
 
   activateTab: (tabId) =>
@@ -937,6 +974,17 @@ export function selectTabList(state: WorkbenchState): TabState[] {
     result,
   };
   return result;
+}
+
+export function isTabState(value: unknown): value is TabState {
+  if (!value || typeof value !== "object") return false;
+  const tab = value as Partial<TabState>;
+  return (
+    typeof tab.id === "string" &&
+    typeof tab.title === "string" &&
+    typeof tab.goal === "string" &&
+    typeof tab.cwd === "string"
+  );
 }
 
 function workspaceViewToTabState(

--- a/src/features/agent-run/tabActions.test.ts
+++ b/src/features/agent-run/tabActions.test.ts
@@ -6,8 +6,8 @@ vi.mock("../../shared/api", () => ({
 }));
 
 import { invokeCommand } from "../../shared/api";
-import { closeWorkbenchTab } from "./tabActions";
-import { createTabState, useWorkbenchStore } from "./model";
+import { closeWorkbenchTab, detachWorkbenchTab } from "./tabActions";
+import { createTabState, createWorkspaceViewState, useWorkbenchStore } from "./model";
 
 const mockedInvoke = vi.mocked(invokeCommand);
 
@@ -18,6 +18,9 @@ function resetWorkbench(tabs = [createTabState({ id: "tab-1" }, 0)], activeTabId
     workspaceError: null,
     tabs,
     activeTabId,
+    workspaceViews: tabs.map((tab, index) => createWorkspaceViewState(tab, index)),
+    activeWorkspaceViewId: activeTabId,
+    runsById: {},
   });
 }
 
@@ -90,5 +93,54 @@ describe("closeWorkbenchTab", () => {
 
     expect(useWorkbenchStore.getState().tabs.map((tab) => tab.id)).toEqual(["tab-2"]);
     expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("detachWorkbenchTab", () => {
+  beforeEach(() => {
+    resetWorkbench();
+  });
+
+  it("opens a detached window and removes the local tab without cancelling the run", async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      label: "workbench-1",
+      isMain: false,
+      title: "ACP Agent Workbench",
+    });
+    resetWorkbench([
+      createTabState(
+        {
+          id: "tab-1",
+          activeRunId: "run-1",
+          sessionActive: true,
+        },
+        0,
+      ),
+      createTabState({ id: "tab-2" }, 1),
+    ]);
+    useWorkbenchStore.getState().beginRun("tab-1", "run-1");
+
+    await detachWorkbenchTab("tab-1");
+
+    expect(mockedInvoke).toHaveBeenCalledWith("detach_tab", {
+      tab: expect.objectContaining({ id: "tab-1", activeRunId: "run-1" }),
+      runId: "run-1",
+    });
+    expect(useWorkbenchStore.getState().tabs.map((tab) => tab.id)).toEqual(["tab-2"]);
+    expect(useWorkbenchStore.getState().runsById["run-1"]).toBeUndefined();
+  });
+
+  it("keeps the tab and records an error when detach fails", async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error("window failed"));
+    resetWorkbench([
+      createTabState({ id: "tab-1" }, 0),
+      createTabState({ id: "tab-2" }, 1),
+    ]);
+
+    await detachWorkbenchTab("tab-1");
+
+    const tab = useWorkbenchStore.getState().tabs.find((entry) => entry.id === "tab-1");
+    expect(tab?.error).toContain("탭 분리 실패");
+    expect(useWorkbenchStore.getState().tabs.map((entry) => entry.id)).toEqual(["tab-1", "tab-2"]);
   });
 });

--- a/src/features/agent-run/tabActions.ts
+++ b/src/features/agent-run/tabActions.ts
@@ -1,4 +1,4 @@
-import { cancelAgentRun } from "./api";
+import { cancelAgentRun, detachAgentRunTab } from "./api";
 import { selectTab, useWorkbenchStore } from "./model";
 
 const CLOSE_FALLBACK_MS = 5000;
@@ -36,4 +36,19 @@ export async function closeWorkbenchTab(tabId: string) {
   }
 
   store.closeTab(tabId);
+}
+
+export async function detachWorkbenchTab(tabId: string) {
+  const store = useWorkbenchStore.getState();
+  const tab = selectTab(store, tabId);
+  if (!tab || tab.closing) return;
+
+  try {
+    await detachAgentRunTab(tab);
+    useWorkbenchStore.getState().forceCloseTab(tabId);
+  } catch (err) {
+    useWorkbenchStore.getState().patchTab(tabId, {
+      error: `탭 분리 실패: ${String(err)}`,
+    });
+  }
 }

--- a/src/features/agent-run/tabApi.ts
+++ b/src/features/agent-run/tabApi.ts
@@ -1,7 +1,13 @@
 import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
 import { useShallow } from "zustand/react/shallow";
-import { selectTab, selectTabList, useWorkbenchStore, type TabState } from "./model";
-import { closeWorkbenchTab } from "./tabActions";
+import {
+  isTabState,
+  selectTab,
+  selectTabList,
+  useWorkbenchStore,
+  type TabState,
+} from "./model";
+import { closeWorkbenchTab, detachWorkbenchTab } from "./tabActions";
 
 const EMPTY_CHECKOUTS: WorkspaceCheckout[] = [];
 
@@ -40,7 +46,13 @@ export function activateWorkbenchTab(tabId: string) {
   useWorkbenchStore.getState().activateTab(tabId);
 }
 
-export { closeWorkbenchTab };
+export { closeWorkbenchTab, detachWorkbenchTab };
+
+export function hydrateDetachedWorkbenchTab(tab: unknown) {
+  if (!isTabState(tab)) return false;
+  useWorkbenchStore.getState().hydrateDetachedTab(tab);
+  return true;
+}
 
 export function useWorkspaceState(tabId: string) {
   return useWorkbenchStore(useShallow((state) => {

--- a/src/widgets/workbench-tabs/TabBar.tsx
+++ b/src/widgets/workbench-tabs/TabBar.tsx
@@ -3,6 +3,7 @@ import {
   activateWorkbenchTab,
   closeWorkbenchTab,
   createWorkbenchTab,
+  detachWorkbenchTab,
   useActiveTabId,
   useTabList,
   type WorkbenchTabListItem,
@@ -83,6 +84,10 @@ export function TabBar() {
     void closeWorkbenchTab(tabId);
   }, []);
 
+  const handleDetach = useCallback((tabId: string) => {
+    void detachWorkbenchTab(tabId);
+  }, []);
+
   return (
     <div
       className="mb-4 flex items-center gap-1.5 overflow-x-auto rounded-lg border bg-card/80 p-1 shadow-sm"
@@ -122,6 +127,21 @@ export function TabBar() {
                 {tab.unreadCount > 99 ? "99+" : tab.unreadCount}
               </Badge>
             ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+              aria-label="탭을 새 창으로 분리"
+              disabled={tab.closing}
+              onClick={(event) => {
+                event.stopPropagation();
+                void handleDetach(tab.id);
+              }}
+              title="탭을 새 창으로 분리"
+            >
+              ↗
+            </Button>
             <Button
               type="button"
               variant="ghost"


### PR DESCRIPTION
## Summary
- add a detach_tab backend command that creates a new workbench window, stores a one-shot tab bootstrap payload, and transfers the active run owner
- hydrate detached tabs in new windows before installing the run event runtime
- add a tab-bar detach action that removes the local tab without cancelling its run
- preserve detached run timeline, follow-up queue, and session state in the target window store

Part of #8

## Tests
- cargo test
- npm test
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- git diff --check