### PR TITLE
Guard closing workbench windows with active runs

### DIFF
--- a/src-tauri/src/adapters/session_registry.rs
+++ b/src-tauri/src/adapters/session_registry.rs
@@ -1,5 +1,9 @@
 use anyhow::{Result, anyhow};
-use std::{collections::HashMap, env, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    sync::Arc,
+};
 use tokio::{sync::Mutex, task::JoinHandle};
 
 use crate::{
@@ -21,6 +25,7 @@ pub struct AppState {
     runs: Arc<Mutex<HashMap<String, RunSlot>>>,
     run_owners: Arc<Mutex<HashMap<String, String>>>,
     window_bootstraps: Arc<Mutex<HashMap<String, serde_json::Value>>>,
+    approved_window_closes: Arc<Mutex<HashSet<String>>>,
     permissions: PermissionBroker,
     max_concurrent_runs: Option<usize>,
 }
@@ -37,6 +42,7 @@ impl AppState {
             runs: Arc::default(),
             run_owners: Arc::default(),
             window_bootstraps: Arc::default(),
+            approved_window_closes: Arc::default(),
             permissions: PermissionBroker::default(),
             max_concurrent_runs,
         }
@@ -79,6 +85,20 @@ impl AppState {
 
     pub async fn take_window_bootstrap(&self, window_label: &str) -> Option<serde_json::Value> {
         self.window_bootstraps.lock().await.remove(window_label)
+    }
+
+    pub async fn approve_window_close(&self, window_label: String) {
+        self.approved_window_closes
+            .lock()
+            .await
+            .insert(window_label);
+    }
+
+    pub async fn take_window_close_approval(&self, window_label: &str) -> bool {
+        self.approved_window_closes
+            .lock()
+            .await
+            .remove(window_label)
     }
 }
 
@@ -272,5 +292,14 @@ mod tests {
         );
         assert!(state.cancel_run("run-a").await);
         assert_eq!(state.owner_of("run-a").await, None);
+    }
+
+    #[tokio::test]
+    async fn window_close_approval_is_consumed_once() {
+        let state = AppState::default();
+        state.approve_window_close("workbench-a".into()).await;
+
+        assert!(state.take_window_close_approval("workbench-a").await);
+        assert!(!state.take_window_close_approval("workbench-a").await);
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -102,6 +102,15 @@ pub fn open_workbench_window(app: AppHandle) -> Result<WorkbenchWindowInfo, Stri
 }
 
 #[tauri::command]
+pub async fn close_workbench_window(
+    window: WebviewWindow,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    state.approve_window_close(window.label().to_string()).await;
+    window.close().map_err(|err| err.to_string())
+}
+
+#[tauri::command]
 pub async fn detach_tab(
     app: AppHandle,
     state: State<'_, AppState>,

--- a/src-tauri/src/domain/workbench_window.rs
+++ b/src-tauri/src/domain/workbench_window.rs
@@ -20,6 +20,12 @@ pub struct WorkbenchWindowBootstrap {
     pub detached_tab: Option<Value>,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkbenchWindowCloseRequest {
+    pub active_run_count: usize,
+}
+
 impl WorkbenchWindowInfo {
     pub fn new(label: impl Into<String>, title: impl Into<String>) -> Self {
         let label = label.into();
@@ -39,5 +45,11 @@ impl WorkbenchWindowBootstrap {
             label,
             detached_tab,
         }
+    }
+}
+
+impl WorkbenchWindowCloseRequest {
+    pub fn new(active_run_count: usize) -> Self {
+        Self { active_run_count }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,20 +8,24 @@ use adapters::{
     storage_state::StorageState,
     tauri::commands::{
         cancel_agent_run, cleanup_workspace_task_worktree, clear_acp_session,
-        create_github_pull_request, create_pull_request_review_draft, create_saved_prompt,
-        create_workspace_commit, delete_pull_request_review_draft, delete_saved_prompt, detach_tab,
-        get_github_pull_request_context, get_window_bootstrap, get_workspace_git_status,
-        list_acp_sessions, list_agents, list_pull_request_review_drafts, list_saved_prompts,
-        list_workbench_windows, list_workspace_checkouts, list_workspaces, load_goal_file,
-        open_workbench_window, provision_workspace_task_worktree, push_workspace_branch,
-        record_saved_prompt_used, refresh_workspace_checkout, register_workspace_from_path,
-        remove_workspace, resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run,
-        start_agent_run, submit_github_pull_request_review, summarize_workspace_diff,
-        transfer_run_owner, update_pull_request_review_draft, update_saved_prompt,
+        close_workbench_window, create_github_pull_request, create_pull_request_review_draft,
+        create_saved_prompt, create_workspace_commit, delete_pull_request_review_draft,
+        delete_saved_prompt, detach_tab, get_github_pull_request_context, get_window_bootstrap,
+        get_workspace_git_status, list_acp_sessions, list_agents, list_pull_request_review_drafts,
+        list_saved_prompts, list_workbench_windows, list_workspace_checkouts, list_workspaces,
+        load_goal_file, open_workbench_window, provision_workspace_task_worktree,
+        push_workspace_branch, record_saved_prompt_used, refresh_workspace_checkout,
+        register_workspace_from_path, remove_workspace, resolve_workspace_workdir,
+        respond_agent_permission, send_prompt_to_run, start_agent_run,
+        submit_github_pull_request_review, summarize_workspace_diff, transfer_run_owner,
+        update_pull_request_review_draft, update_saved_prompt,
     },
 };
+use domain::workbench_window::WorkbenchWindowCloseRequest;
 use ports::session_registry::SessionRegistry;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
+
+const WORKBENCH_WINDOW_CLOSE_REQUESTED_EVENT: &str = "workbench-window-close-requested";
 
 pub fn run() {
     let app_state = AppState::default();
@@ -36,14 +40,30 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(move |window, event| {
-            if matches!(event, tauri::WindowEvent::Destroyed) {
-                let label = window.label().to_string();
-                let state = cleanup_state.clone();
-                tauri::async_runtime::spawn(async move {
-                    for run_id in state.runs_owned_by(&label).await {
-                        state.cancel_run(&run_id).await;
+            let label = window.label().to_string();
+            match event {
+                tauri::WindowEvent::CloseRequested { api, .. } => {
+                    let state = cleanup_state.clone();
+                    let approved =
+                        tauri::async_runtime::block_on(state.take_window_close_approval(&label));
+                    let owned_runs = tauri::async_runtime::block_on(state.runs_owned_by(&label));
+                    if !approved && !owned_runs.is_empty() {
+                        api.prevent_close();
+                        let _ = window.emit(
+                            WORKBENCH_WINDOW_CLOSE_REQUESTED_EVENT,
+                            WorkbenchWindowCloseRequest::new(owned_runs.len()),
+                        );
                     }
-                });
+                }
+                tauri::WindowEvent::Destroyed => {
+                    let state = cleanup_state.clone();
+                    tauri::async_runtime::spawn(async move {
+                        for run_id in state.runs_owned_by(&label).await {
+                            state.cancel_run(&run_id).await;
+                        }
+                    });
+                }
+                _ => {}
             }
         })
         .manage(app_state)
@@ -53,6 +73,7 @@ pub fn run() {
             get_window_bootstrap,
             list_workbench_windows,
             open_workbench_window,
+            close_workbench_window,
             detach_tab,
             start_agent_run,
             send_prompt_to_run,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,7 +2,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { AgentWorkbenchPage } from "../pages/agent-workbench";
 import { hydrateDetachedWorkbenchTab, installAgentRuntime } from "../features/agent-run";
-import { getWindowBootstrap } from "../features/workbench-window";
+import {
+  closeWorkbenchWindow,
+  getWindowBootstrap,
+  listenWorkbenchWindowCloseRequests,
+} from "../features/workbench-window";
 
 const queryClient = new QueryClient();
 
@@ -15,6 +19,33 @@ export function App() {
       }
       await installAgentRuntime();
     })();
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let mounted = true;
+
+    void listenWorkbenchWindowCloseRequests((request) => {
+      const runLabel = request.activeRunCount === 1 ? "run" : "runs";
+      if (
+        window.confirm(
+          `This window owns ${request.activeRunCount} active ${runLabel}. Close it and cancel those runs?`,
+        )
+      ) {
+        void closeWorkbenchWindow();
+      }
+    }).then((dispose) => {
+      if (mounted) {
+        unlisten = dispose;
+      } else {
+        dispose();
+      }
+    });
+
+    return () => {
+      mounted = false;
+      unlisten?.();
+    };
   }, []);
 
   return (

--- a/src/entities/workbench-window/index.ts
+++ b/src/entities/workbench-window/index.ts
@@ -1,1 +1,5 @@
-export type { WorkbenchWindowBootstrap, WorkbenchWindowInfo } from "./model";
+export type {
+  WorkbenchWindowBootstrap,
+  WorkbenchWindowCloseRequest,
+  WorkbenchWindowInfo,
+} from "./model";

--- a/src/entities/workbench-window/model.ts
+++ b/src/entities/workbench-window/model.ts
@@ -9,3 +9,7 @@ export type WorkbenchWindowBootstrap = {
   isMain: boolean;
   detachedTab?: unknown;
 };
+
+export type WorkbenchWindowCloseRequest = {
+  activeRunCount: number;
+};

--- a/src/features/workbench-window/api.test.ts
+++ b/src/features/workbench-window/api.test.ts
@@ -2,26 +2,47 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/api", () => ({
   invokeCommand: vi.fn(),
+  listenEvent: vi.fn(),
 }));
 
-import { invokeCommand } from "../../shared/api";
-import { getWindowBootstrap, listWorkbenchWindows, openWorkbenchWindow } from "./api";
+import { invokeCommand, listenEvent } from "../../shared/api";
+import {
+  closeWorkbenchWindow,
+  getWindowBootstrap,
+  listenWorkbenchWindowCloseRequests,
+  listWorkbenchWindows,
+  openWorkbenchWindow,
+} from "./api";
 
 const mockedInvoke = vi.mocked(invokeCommand);
+const mockedListen = vi.mocked(listenEvent);
 
 describe("workbench-window api", () => {
   it("forwards window bootstrap and registry commands", async () => {
     mockedInvoke
       .mockResolvedValueOnce({ label: "main", isMain: true })
       .mockResolvedValueOnce([{ label: "main", isMain: true, title: "ACP Agent Workbench" }])
-      .mockResolvedValueOnce({ label: "workbench-1", isMain: false, title: "ACP Agent Workbench" });
+      .mockResolvedValueOnce({ label: "workbench-1", isMain: false, title: "ACP Agent Workbench" })
+      .mockResolvedValueOnce(undefined);
 
     await expect(getWindowBootstrap()).resolves.toEqual({ label: "main", isMain: true });
     await expect(listWorkbenchWindows()).resolves.toHaveLength(1);
     await expect(openWorkbenchWindow()).resolves.toMatchObject({ label: "workbench-1" });
+    await expect(closeWorkbenchWindow()).resolves.toBeUndefined();
 
     expect(mockedInvoke).toHaveBeenNthCalledWith(1, "get_window_bootstrap");
     expect(mockedInvoke).toHaveBeenNthCalledWith(2, "list_workbench_windows");
     expect(mockedInvoke).toHaveBeenNthCalledWith(3, "open_workbench_window");
+    expect(mockedInvoke).toHaveBeenNthCalledWith(4, "close_workbench_window");
+  });
+
+  it("subscribes to close request events", async () => {
+    const dispose = vi.fn();
+    const callback = vi.fn();
+    mockedListen.mockResolvedValueOnce(dispose);
+
+    await expect(listenWorkbenchWindowCloseRequests(callback)).resolves.toBe(dispose);
+
+    expect(mockedListen).toHaveBeenCalledWith("workbench-window-close-requested", callback);
   });
 });

--- a/src/features/workbench-window/api.ts
+++ b/src/features/workbench-window/api.ts
@@ -1,5 +1,9 @@
-import type { WorkbenchWindowBootstrap, WorkbenchWindowInfo } from "../../entities/workbench-window";
-import { invokeCommand } from "../../shared/api";
+import type {
+  WorkbenchWindowBootstrap,
+  WorkbenchWindowCloseRequest,
+  WorkbenchWindowInfo,
+} from "../../entities/workbench-window";
+import { invokeCommand, listenEvent } from "../../shared/api";
 
 export function getWindowBootstrap() {
   return invokeCommand<WorkbenchWindowBootstrap>("get_window_bootstrap");
@@ -11,4 +15,14 @@ export function listWorkbenchWindows() {
 
 export function openWorkbenchWindow() {
   return invokeCommand<WorkbenchWindowInfo>("open_workbench_window");
+}
+
+export function closeWorkbenchWindow() {
+  return invokeCommand<void>("close_workbench_window");
+}
+
+export function listenWorkbenchWindowCloseRequests(
+  callback: (request: WorkbenchWindowCloseRequest) => void,
+) {
+  return listenEvent<WorkbenchWindowCloseRequest>("workbench-window-close-requested", callback);
 }

--- a/src/features/workbench-window/index.ts
+++ b/src/features/workbench-window/index.ts
@@ -1,1 +1,7 @@
-export { getWindowBootstrap, listWorkbenchWindows, openWorkbenchWindow } from "./api";
+export {
+  closeWorkbenchWindow,
+  getWindowBootstrap,
+  listenWorkbenchWindowCloseRequests,
+  listWorkbenchWindows,
+  openWorkbenchWindow,
+} from "./api";


### PR DESCRIPTION
## Summary\n- intercept workbench window close requests when the window owns active runs\n- emit a typed close-request event to the owning webview and add a frontend confirmation flow\n- add an approved close command so confirmed closes proceed and existing destroyed-window cleanup cancels owned runs\n\n## Validation\n- npm test -- --run\n- npm run build\n- npm run check:fsd && npm run check:backend-boundaries\n- cargo fmt --check && cargo test\n\nPart of #8