### PR TITLE
Confirm platform last-window close

### DIFF
--- a/src-tauri/src/domain/workbench_window.rs
+++ b/src-tauri/src/domain/workbench_window.rs
@@ -24,6 +24,7 @@ pub struct WorkbenchWindowBootstrap {
 #[serde(rename_all = "camelCase")]
 pub struct WorkbenchWindowCloseRequest {
     pub active_run_count: usize,
+    pub last_window: bool,
 }
 
 impl WorkbenchWindowInfo {
@@ -49,7 +50,63 @@ impl WorkbenchWindowBootstrap {
 }
 
 impl WorkbenchWindowCloseRequest {
-    pub fn new(active_run_count: usize) -> Self {
-        Self { active_run_count }
+    pub fn new(active_run_count: usize, last_window: bool) -> Self {
+        Self {
+            active_run_count,
+            last_window,
+        }
+    }
+}
+
+pub fn should_confirm_last_window_close(label: &str, open_window_count: usize) -> bool {
+    should_protect_last_window() && label == MAIN_WORKBENCH_WINDOW_LABEL && open_window_count <= 1
+}
+
+#[cfg(target_os = "macos")]
+fn should_protect_last_window() -> bool {
+    false
+}
+
+#[cfg(not(target_os = "macos"))]
+fn should_protect_last_window() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAIN_WORKBENCH_WINDOW_LABEL, WorkbenchWindowCloseRequest, should_confirm_last_window_close,
+    };
+
+    #[test]
+    fn close_request_tracks_last_window_context() {
+        assert_eq!(
+            WorkbenchWindowCloseRequest::new(2, true),
+            WorkbenchWindowCloseRequest {
+                active_run_count: 2,
+                last_window: true,
+            }
+        );
+    }
+
+    #[test]
+    fn last_window_close_confirmation_is_platform_dependent() {
+        #[cfg(target_os = "macos")]
+        assert!(!should_confirm_last_window_close(
+            MAIN_WORKBENCH_WINDOW_LABEL,
+            1
+        ));
+
+        #[cfg(not(target_os = "macos"))]
+        assert!(should_confirm_last_window_close(
+            MAIN_WORKBENCH_WINDOW_LABEL,
+            1
+        ));
+
+        assert!(!should_confirm_last_window_close("workbench-detached", 1));
+        assert!(!should_confirm_last_window_close(
+            MAIN_WORKBENCH_WINDOW_LABEL,
+            2
+        ));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ use adapters::{
         update_pull_request_review_draft, update_saved_prompt,
     },
 };
-use domain::workbench_window::WorkbenchWindowCloseRequest;
+use domain::workbench_window::{WorkbenchWindowCloseRequest, should_confirm_last_window_close};
 use tauri::{Emitter, Manager};
 
 const WORKBENCH_WINDOW_CLOSE_REQUESTED_EVENT: &str = "workbench-window-close-requested";
@@ -46,11 +46,15 @@ pub fn run() {
                     let approved =
                         tauri::async_runtime::block_on(state.take_window_close_approval(&label));
                     let owned_runs = tauri::async_runtime::block_on(state.runs_owned_by(&label));
-                    if !approved && !owned_runs.is_empty() {
+                    let last_window = should_confirm_last_window_close(
+                        &label,
+                        window.app_handle().webview_windows().len(),
+                    );
+                    if !approved && (!owned_runs.is_empty() || last_window) {
                         api.prevent_close();
                         let _ = window.emit(
                             WORKBENCH_WINDOW_CLOSE_REQUESTED_EVENT,
-                            WorkbenchWindowCloseRequest::new(owned_runs.len()),
+                            WorkbenchWindowCloseRequest::new(owned_runs.len(), last_window),
                         );
                     }
                 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -26,12 +26,7 @@ export function App() {
     let mounted = true;
 
     void listenWorkbenchWindowCloseRequests((request) => {
-      const runLabel = request.activeRunCount === 1 ? "run" : "runs";
-      if (
-        window.confirm(
-          `This window owns ${request.activeRunCount} active ${runLabel}. Close it and cancel those runs?`,
-        )
-      ) {
+      if (window.confirm(closeRequestMessage(request))) {
         void closeWorkbenchWindow();
       }
     }).then((dispose) => {
@@ -53,4 +48,15 @@ export function App() {
       <AgentWorkbenchPage />
     </QueryClientProvider>
   );
+}
+
+function closeRequestMessage(request: { activeRunCount: number; lastWindow: boolean }) {
+  const runLabel = request.activeRunCount === 1 ? "run" : "runs";
+  if (request.activeRunCount > 0 && request.lastWindow) {
+    return `This is the last workbench window and it owns ${request.activeRunCount} active ${runLabel}. Close it and cancel those runs?`;
+  }
+  if (request.activeRunCount > 0) {
+    return `This window owns ${request.activeRunCount} active ${runLabel}. Close it and cancel those runs?`;
+  }
+  return "This is the last workbench window. Close it and quit the app?";
 }

--- a/src/entities/workbench-window/model.ts
+++ b/src/entities/workbench-window/model.ts
@@ -12,4 +12,5 @@ export type WorkbenchWindowBootstrap = {
 
 export type WorkbenchWindowCloseRequest = {
   activeRunCount: number;
+  lastWindow: boolean;
 };


### PR DESCRIPTION
## Summary
- extend workbench close requests with last-window context
- request confirmation for closing the last main window on non-macOS platforms
- keep macOS behavior aligned with the documented empty-app-state allowance

## Validation
- cargo fmt && cargo test
- npm test
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- git diff --check

Closes #8