### PR TITLE
Start runs from local tasks

### DIFF
--- a/src/features/agent-run/api.test.ts
+++ b/src/features/agent-run/api.test.ts
@@ -99,6 +99,7 @@ describe("agent-run api", () => {
       items: [],
       filter: "all",
       error: null,
+      sourceTask: null,
       unreadCount: 0,
       permissionPending: false,
       closing: false,

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -17,7 +17,7 @@ export {
   type WorkbenchTabListItem,
 } from "./tabApi";
 export { useAgentRun } from "./useAgentRun";
-export { type FollowUpQueueItem } from "./model";
+export { type FollowUpQueueItem, type LocalTaskRunSource } from "./model";
 export {
   cleanupWorkspaceTaskWorktree,
   clearAcpSession,

--- a/src/features/agent-run/model.test.ts
+++ b/src/features/agent-run/model.test.ts
@@ -50,6 +50,12 @@ describe("workspace-scoped run state", () => {
       cwd: "/repo/workbench",
       goal: "implement workspace tabs",
       selectedAgentId: "claude-code",
+      sourceTask: {
+        id: "bd-123",
+        title: "Implement workspace tabs",
+        status: "todo",
+        blocked: false,
+      },
     });
 
     useWorkbenchStore.getState().beginRun(tabId, "run-1");
@@ -69,6 +75,10 @@ describe("workspace-scoped run state", () => {
       cwd: "/repo/workbench",
       sessionActive: true,
       awaitingResponse: true,
+      sourceTask: {
+        id: "bd-123",
+        title: "Implement workspace tabs",
+      },
     });
     expect(run?.request).toMatchObject({
       goal: "implement workspace tabs",
@@ -170,6 +180,7 @@ describe("workspace-scoped run state", () => {
       ],
       filter: "all" as const,
       error: null,
+      sourceTask: null,
       unreadCount: 2,
       permissionPending: false,
       closing: true,

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -7,7 +7,7 @@ import {
   type RunEvent,
   type TimelineItem,
 } from "../../entities/message";
-import type { Workspace, WorkspaceCheckout } from "../../entities/workspace";
+import type { LocalTaskSummary, Workspace, WorkspaceCheckout } from "../../entities/workspace";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
@@ -39,6 +39,13 @@ export type AgentRunDraft = {
   idleTimeoutSec: number;
 };
 
+export type LocalTaskRunSource = {
+  id: string;
+  title: string;
+  status: string | null;
+  blocked: boolean;
+};
+
 export type WorkspaceViewState = {
   id: string;
   title: string;
@@ -68,6 +75,7 @@ export type AgentRunState = {
   followUpQueue: FollowUpQueueItem[];
   items: TimelineItem[];
   runError: string | null;
+  sourceTask: LocalTaskRunSource | null;
   createdAt: number;
   completedAt: number | null;
 };
@@ -95,6 +103,7 @@ export type TabState = {
   items: TimelineItem[];
   filter: EventGroup | "all";
   error: string | null;
+  sourceTask: LocalTaskRunSource | null;
   unreadCount: number;
   permissionPending: boolean;
   closing: boolean;
@@ -164,6 +173,7 @@ export function createTabState(preset: Partial<TabState> = {}, index = 0): TabSt
     items: preset.items ?? [],
     filter: preset.filter ?? "all",
     error: preset.error ?? null,
+    sourceTask: preset.sourceTask ?? null,
     unreadCount: preset.unreadCount ?? 0,
     permissionPending: preset.permissionPending ?? false,
     closing: preset.closing ?? false,
@@ -222,6 +232,7 @@ function runStateFromTab(tab: TabState, runId: string): AgentRunState {
     followUpQueue: [],
     items: [],
     runError: null,
+    sourceTask: tab.sourceTask,
     createdAt: Date.now(),
     completedAt: null,
   };
@@ -237,7 +248,17 @@ function runStateFromDetachedTab(tab: TabState, runId: string): AgentRunState {
     followUpQueue: tab.followUpQueue,
     items: tab.items,
     runError: tab.error,
+    sourceTask: tab.sourceTask,
     completedAt: tab.sessionActive ? null : Date.now(),
+  };
+}
+
+export function localTaskRunSource(task: LocalTaskSummary): LocalTaskRunSource {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status ?? null,
+    blocked: task.blocked,
   };
 }
 
@@ -270,6 +291,7 @@ function patchRunForTab(
   if (patch.followUpQueue !== undefined) next.followUpQueue = patch.followUpQueue;
   if (patch.items !== undefined) next.items = patch.items;
   if (patch.error !== undefined) next.runError = patch.error;
+  if (patch.sourceTask !== undefined) next.sourceTask = patch.sourceTask;
   return { ...state.runsById, [run.id]: next };
 }
 
@@ -1015,6 +1037,7 @@ function workspaceViewToTabState(
     items: run?.items ?? fallback?.items ?? EMPTY_TIMELINE_ITEMS,
     filter: view.filter,
     error: run?.runError ?? view.viewError,
+    sourceTask: run?.sourceTask ?? fallback?.sourceTask ?? null,
     unreadCount: view.unreadCount,
     permissionPending: run?.permissionPending ?? fallback?.permissionPending ?? false,
     closing: view.closing,

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -21,12 +21,14 @@ import type {
 import type { SavedPromptRunMode } from "../../entities/saved-prompt";
 import {
   defaultRalphLoopSettings,
+  localTaskRunSource,
   selectTab,
   selectTabList,
   useWorkbenchStore,
   type TabState,
   type FollowUpQueueItem,
 } from "./model";
+import type { LocalTaskSummary } from "../../entities/workspace";
 
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
 const EMPTY_ITEMS: TimelineItem[] = [];
@@ -140,7 +142,9 @@ export function useAgentRun(tabId: string) {
         const worktree = await provisionWorkspaceTaskWorktree({
           workspaceId: current.workspaceId,
           checkoutId,
-          taskSlug: trimmedGoal,
+          taskSlug: current.sourceTask
+            ? `${current.sourceTask.id}-${current.sourceTask.title}`
+            : trimmedGoal,
         });
         checkoutId = worktree.id;
         provisionedCheckoutId = worktree.id;
@@ -178,6 +182,30 @@ export function useAgentRun(tabId: string) {
     }
   }, [acpSessionsQuery, tabId, patch]);
 
+  const runLocalTask = useCallback(
+    async (task: LocalTaskSummary, goal: string) => {
+      if (
+        task.blocked &&
+        !window.confirm(
+          `Task ${task.id} is blocked by unfinished dependencies. Start it anyway?`,
+        )
+      ) {
+        return;
+      }
+      const trimmed = goal.trim();
+      if (!trimmed) {
+        patch({ error: "Task goal is empty." });
+        return;
+      }
+      useWorkbenchStore.getState().patchTab(tabId, {
+        goal: trimmed,
+        sourceTask: localTaskRunSource(task),
+      });
+      await run();
+    },
+    [patch, run, tabId],
+  );
+
   const cancel = useCallback(async () => {
     const current = selectTab(useWorkbenchStore.getState(), tabId);
     if (!current?.activeRunId) return;
@@ -207,7 +235,7 @@ export function useAgentRun(tabId: string) {
       const trimmed = body.trim();
       if (!current || !trimmed) return;
       if (!current.sessionActive) {
-        store.patchTab(tabId, { goal: trimmed });
+        store.patchTab(tabId, { goal: trimmed, sourceTask: null });
         return;
       }
       if (runMode === "insert") {
@@ -228,7 +256,15 @@ export function useAgentRun(tabId: string) {
     (value: string) => patch({ selectedAgentId: value }),
     [patch],
   );
-  const setGoal = useCallback((value: string) => patch({ goal: value }), [patch]);
+  const setGoal = useCallback((value: string) => patch({ goal: value, sourceTask: null }), [patch]);
+  const setGoalFromTask = useCallback(
+    (value: string, task?: LocalTaskSummary) =>
+      patch({
+        goal: value,
+        sourceTask: task ? localTaskRunSource(task) : null,
+      }),
+    [patch],
+  );
   const setCwd = useCallback((value: string) => patch({ cwd: value }), [patch]);
   const setCustomCommand = useCallback(
     (value: string) => patch({ customCommand: value }),
@@ -279,6 +315,7 @@ export function useAgentRun(tabId: string) {
     setSelectedAgentId,
     goal: tab?.goal ?? "",
     setGoal,
+    setGoalFromTask,
     cwd: tab?.cwd ?? "",
     setCwd,
     customCommand: tab?.customCommand ?? "",
@@ -298,6 +335,7 @@ export function useAgentRun(tabId: string) {
     setIdleTimeoutSec,
     idleRemainingSec: tab?.idleRemainingSec ?? null,
     activeRunId: tab?.activeRunId ?? null,
+    sourceTask: tab?.sourceTask ?? null,
     sessionActive: tab?.sessionActive ?? false,
     awaitingResponse: tab?.awaitingResponse ?? false,
     isRunning: tab?.sessionActive ?? false,
@@ -308,6 +346,7 @@ export function useAgentRun(tabId: string) {
     error: tab?.error ?? (agentsQuery.error ? String(agentsQuery.error) : null),
     setError,
     run,
+    runLocalTask,
     cancel,
     send,
     applySavedPrompt,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -40,7 +40,8 @@ export function AgentWorkbenchPage() {
         workspaceId={state.workspaceId}
         checkoutId={state.checkoutId}
         sessionActive={state.sessionActive}
-        onApplyTaskGoal={state.setGoal}
+        onApplyTaskGoal={state.setGoalFromTask}
+        onRunTask={(task, goal) => void state.runLocalTask(task, goal)}
         onError={state.setError}
       />
       <WorkspacePrPublishPanel workspaceId={state.workspaceId} checkoutId={state.checkoutId} />
@@ -84,6 +85,7 @@ export function AgentWorkbenchPage() {
             idleRemainingSec={state.idleRemainingSec}
             isRunning={state.isRunning}
             activeRunId={state.activeRunId}
+            sourceTask={state.sourceTask}
             onRun={state.run}
             onCancel={state.cancel}
           />

--- a/src/widgets/local-tasks/LocalTasksPanel.tsx
+++ b/src/widgets/local-tasks/LocalTasksPanel.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, CheckCircle2, ListChecks, RefreshCw, SendToBack } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ListChecks, Play, RefreshCw, SendToBack } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { LocalTaskList, LocalTaskSummary } from "../../entities/workspace";
 import { listLocalTasks } from "../../features/agent-run";
@@ -8,7 +8,8 @@ type LocalTasksPanelProps = {
   workspaceId: string | null;
   checkoutId: string | null;
   sessionActive?: boolean;
-  onApplyTaskGoal: (goal: string) => void;
+  onApplyTaskGoal: (goal: string, task: LocalTaskSummary) => void;
+  onRunTask: (task: LocalTaskSummary, goal: string) => void;
   onError: (error: string | null) => void;
 };
 
@@ -19,6 +20,7 @@ export function LocalTasksPanel({
   checkoutId,
   sessionActive = false,
   onApplyTaskGoal,
+  onRunTask,
   onError,
 }: LocalTasksPanelProps) {
   const [result, setResult] = useState<LocalTaskList | null>(null);
@@ -186,6 +188,7 @@ export function LocalTasksPanel({
                 task={selectedTask}
                 sessionActive={sessionActive}
                 onApplyTaskGoal={onApplyTaskGoal}
+                onRunTask={onRunTask}
               />
             ) : null}
           </div>
@@ -198,10 +201,11 @@ export function LocalTasksPanel({
 type TaskDetailsProps = {
   task: LocalTaskSummary;
   sessionActive: boolean;
-  onApplyTaskGoal: (goal: string) => void;
+  onApplyTaskGoal: (goal: string, task: LocalTaskSummary) => void;
+  onRunTask: (task: LocalTaskSummary, goal: string) => void;
 };
 
-function TaskDetails({ task, sessionActive, onApplyTaskGoal }: TaskDetailsProps) {
+function TaskDetails({ task, sessionActive, onApplyTaskGoal, onRunTask }: TaskDetailsProps) {
   const goal = useMemo(() => composeTaskGoal(task), [task]);
 
   return (
@@ -230,9 +234,20 @@ function TaskDetails({ task, sessionActive, onApplyTaskGoal }: TaskDetailsProps)
           size="sm"
           icon={<SendToBack size={14} />}
           disabled={sessionActive}
-          onClick={() => onApplyTaskGoal(goal)}
+          onClick={() => onApplyTaskGoal(goal, task)}
         >
           Use as goal
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          icon={<Play size={14} />}
+          disabled={sessionActive}
+          onClick={() => onRunTask(task, goal)}
+          title={task.blocked ? "Blocked tasks require confirmation before running" : undefined}
+        >
+          Run task
         </Button>
       </div>
 

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -2,6 +2,7 @@ import { Octagon, Play, ShieldCheck, Trash2 } from "lucide-react";
 import type { AcpSessionRecord } from "../../entities/acp-session";
 import type { AgentDescriptor } from "../../entities/agent";
 import type { RalphLoopSettings, ResumePolicy } from "../../entities/message";
+import type { LocalTaskRunSource } from "../../features/agent-run";
 import { cn } from "../../shared/lib";
 import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect } from "../../shared/ui";
 
@@ -30,6 +31,7 @@ type RunPanelProps = {
   idleRemainingSec: number | null;
   isRunning: boolean;
   activeRunId: string | null;
+  sourceTask: LocalTaskRunSource | null;
   onRun: () => void;
   onCancel: () => void;
 };
@@ -59,6 +61,7 @@ export function RunPanel({
   idleRemainingSec,
   isRunning,
   activeRunId,
+  sourceTask,
   onRun,
   onCancel,
 }: RunPanelProps) {
@@ -266,6 +269,21 @@ export function RunPanel({
             Stop
           </Button>
         </div>
+
+        {sourceTask ? (
+          <div className="grid gap-1 rounded-md border border-border bg-muted/25 px-3 py-2 text-sm">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Source task
+            </span>
+            <span className="truncate font-medium text-foreground">
+              {sourceTask.id} · {sourceTask.title}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {sourceTask.status ?? "no status"}
+              {sourceTask.blocked ? " · blocked override" : ""}
+            </span>
+          </div>
+        ) : null}
 
         {idleRemainingSec !== null ? (
           <p className="m-0 text-xs font-medium text-amber-700" role="status">


### PR DESCRIPTION
## Summary
- add source task metadata to tab/run state so task-backed runs remain identifiable
- add a Run task action from the local task panel with blocked-task confirmation
- show the linked source task in the execution panel and use task identity for worktree slugs

Part of #6

## Validation
- npm run check:fsd
- npm run build
- npm run test --if-present
- npm run check:backend-boundaries
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check