### PR TITLE
Run agents from local tasks

### DIFF
--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -19,6 +19,7 @@ import type {
   TimelineItem,
 } from "../../entities/message";
 import type { SavedPromptRunMode } from "../../entities/saved-prompt";
+import type { LocalTaskSummary } from "../../entities/workspace";
 import {
   defaultRalphLoopSettings,
   selectTab,
@@ -30,6 +31,12 @@ import {
 
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
 const EMPTY_ITEMS: TimelineItem[] = [];
+
+export type RunAgentOptions = {
+  goal?: string;
+  sourceTask?: LocalTaskSummary;
+  allowBlockedTask?: boolean;
+};
 
 export function useAgentRun(tabId: string) {
   const agentsQuery = useQuery({ queryKey: ["agents"], queryFn: listAgents });
@@ -85,12 +92,18 @@ export function useAgentRun(tabId: string) {
     [filter, items],
   );
 
-  const run = useCallback(async () => {
+  const run = useCallback(async (options: RunAgentOptions = {}) => {
     const current = selectTab(useWorkbenchStore.getState(), tabId);
     if (!current) return;
-    const trimmedGoal = current.goal.trim();
+    const trimmedGoal = (options.goal ?? current.goal).trim();
     if (!trimmedGoal) {
       patch({ error: "Goal is empty." });
+      return;
+    }
+    if (options.sourceTask?.blocked && !options.allowBlockedTask) {
+      patch({
+        error: `Task ${options.sourceTask.id} is blocked by dependencies and requires explicit override.`,
+      });
       return;
     }
     const sameWorkdirRuns = selectTabList(useWorkbenchStore.getState()).filter(
@@ -113,7 +126,14 @@ export function useAgentRun(tabId: string) {
       return;
     }
     const runId = crypto.randomUUID();
-    useWorkbenchStore.getState().beginRun(tabId, runId);
+    const store = useWorkbenchStore.getState();
+    store.beginRun(tabId, runId);
+    if (options.sourceTask) {
+      store.dispatchRunEvent(runId, {
+        type: "diagnostic",
+        message: sourceTaskRunMessage(options.sourceTask, Boolean(options.allowBlockedTask)),
+      });
+    }
 
     const originalCheckoutId = current.checkoutId ?? null;
     const originalCwd = current.cwd;
@@ -140,7 +160,9 @@ export function useAgentRun(tabId: string) {
         const worktree = await provisionWorkspaceTaskWorktree({
           workspaceId: current.workspaceId,
           checkoutId,
-          taskSlug: trimmedGoal,
+          taskSlug: options.sourceTask
+            ? `${options.sourceTask.id}-${options.sourceTask.title}`
+            : trimmedGoal,
         });
         checkoutId = worktree.id;
         provisionedCheckoutId = worktree.id;
@@ -316,4 +338,17 @@ export function useAgentRun(tabId: string) {
     filter,
     setFilter,
   };
+}
+
+function sourceTaskRunMessage(task: LocalTaskSummary, allowBlockedTask: boolean) {
+  const parts = [`Source task ${task.id}: ${task.title}`];
+  if (task.status) parts.push(`status ${task.status}`);
+  if (task.priority) parts.push(`priority ${task.priority}`);
+  if (task.blocked) {
+    parts.push(allowBlockedTask ? "blocked override approved" : "blocked");
+  }
+  if (task.dependencies.length > 0) {
+    parts.push(`dependencies ${task.dependencies.join(", ")}`);
+  }
+  return parts.join(" | ");
 }

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -41,6 +41,9 @@ export function AgentWorkbenchPage() {
         checkoutId={state.checkoutId}
         sessionActive={state.sessionActive}
         onApplyTaskGoal={state.setGoal}
+        onRunTaskGoal={(goal, task, allowBlockedTask) =>
+          void state.run({ goal, sourceTask: task, allowBlockedTask })
+        }
         onError={state.setError}
       />
       <WorkspacePrPublishPanel workspaceId={state.workspaceId} checkoutId={state.checkoutId} />

--- a/src/widgets/local-tasks/LocalTasksPanel.tsx
+++ b/src/widgets/local-tasks/LocalTasksPanel.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, CheckCircle2, ListChecks, RefreshCw, SendToBack } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ListChecks, Play, RefreshCw, SendToBack } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { LocalTaskList, LocalTaskSummary } from "../../entities/workspace";
 import { listLocalTasks } from "../../features/agent-run";
@@ -9,6 +9,7 @@ type LocalTasksPanelProps = {
   checkoutId: string | null;
   sessionActive?: boolean;
   onApplyTaskGoal: (goal: string) => void;
+  onRunTaskGoal: (goal: string, task: LocalTaskSummary, allowBlockedTask: boolean) => void;
   onError: (error: string | null) => void;
 };
 
@@ -19,6 +20,7 @@ export function LocalTasksPanel({
   checkoutId,
   sessionActive = false,
   onApplyTaskGoal,
+  onRunTaskGoal,
   onError,
 }: LocalTasksPanelProps) {
   const [result, setResult] = useState<LocalTaskList | null>(null);
@@ -186,6 +188,7 @@ export function LocalTasksPanel({
                 task={selectedTask}
                 sessionActive={sessionActive}
                 onApplyTaskGoal={onApplyTaskGoal}
+                onRunTaskGoal={onRunTaskGoal}
               />
             ) : null}
           </div>
@@ -199,10 +202,24 @@ type TaskDetailsProps = {
   task: LocalTaskSummary;
   sessionActive: boolean;
   onApplyTaskGoal: (goal: string) => void;
+  onRunTaskGoal: (goal: string, task: LocalTaskSummary, allowBlockedTask: boolean) => void;
 };
 
-function TaskDetails({ task, sessionActive, onApplyTaskGoal }: TaskDetailsProps) {
+function TaskDetails({ task, sessionActive, onApplyTaskGoal, onRunTaskGoal }: TaskDetailsProps) {
   const goal = useMemo(() => composeTaskGoal(task), [task]);
+  const handleRun = useCallback(() => {
+    if (
+      task.blocked &&
+      !window.confirm(
+        `Task ${task.id} is blocked by ${task.dependencies.length || "unknown"} dependenc${
+          task.dependencies.length === 1 ? "y" : "ies"
+        }. Start it anyway?`,
+      )
+    ) {
+      return;
+    }
+    onRunTaskGoal(goal, task, task.blocked);
+  }, [goal, onRunTaskGoal, task]);
 
   return (
     <div className="grid gap-3 rounded-md border bg-background p-3">
@@ -224,16 +241,27 @@ function TaskDetails({ task, sessionActive, onApplyTaskGoal }: TaskDetailsProps)
           </div>
           <h2 className="m-0 text-base font-semibold leading-snug text-foreground">{task.title}</h2>
         </div>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          icon={<SendToBack size={14} />}
-          disabled={sessionActive}
-          onClick={() => onApplyTaskGoal(goal)}
-        >
-          Use as goal
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            icon={<SendToBack size={14} />}
+            disabled={sessionActive}
+            onClick={() => onApplyTaskGoal(goal)}
+          >
+            Use as goal
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            icon={<Play size={14} />}
+            disabled={sessionActive}
+            onClick={handleRun}
+          >
+            Run task
+          </Button>
+        </div>
       </div>
 
       {task.description ? (


### PR DESCRIPTION
## Summary
- add a Run task action to the local task browser
- compose and submit the selected task goal through the existing agent run path while preserving agent/run settings
- require explicit confirmation before running blocked tasks and add a source-task diagnostic to the run timeline

## Validation
- cargo fmt --check && cargo test
- npm test
- npm run build
- npm run check:fsd
- npm run check:backend-boundaries
- git diff --check

Continues #6