### PR TITLE
Add local task status updates

### DIFF
--- a/src-tauri/src/adapters/beads.rs
+++ b/src-tauri/src/adapters/beads.rs
@@ -6,7 +6,10 @@ use std::{
     process::{Command, Output},
 };
 
-use crate::{domain::local_task::LocalTaskSummary, ports::local_task_source::LocalTaskSource};
+use crate::{
+    domain::local_task::{LocalTaskStatus, LocalTaskSummary},
+    ports::local_task_source::LocalTaskSource,
+};
 
 #[derive(Clone)]
 pub struct BeadsCliTaskSource;
@@ -17,22 +20,63 @@ impl LocalTaskSource for BeadsCliTaskSource {
     }
 
     fn list_tasks(&self, workdir: &Path) -> Result<Vec<LocalTaskSummary>> {
-        let output = Command::new("bd")
-            .args(["list", "--json"])
-            .current_dir(workdir)
-            .output()
-            .map_err(|err| {
-                if err.kind() == ErrorKind::NotFound {
-                    anyhow!("beads CLI not found; install `bd` to list local tasks")
-                } else {
-                    anyhow!("failed to run beads CLI: {err}")
-                }
-            })?;
+        let output = run_bd(workdir, ["list", "--json"])?;
         parse_beads_list_output(output)
+    }
+
+    fn update_status(
+        &self,
+        workdir: &Path,
+        task_id: &str,
+        status: LocalTaskStatus,
+    ) -> Result<LocalTaskSummary> {
+        let output = run_bd(
+            workdir,
+            [
+                "update",
+                task_id,
+                "--status",
+                status.as_beads_status(),
+                "--json",
+            ],
+        )?;
+        parse_beads_update_output(output)
     }
 }
 
+fn run_bd<const N: usize>(workdir: &Path, args: [&str; N]) -> Result<Output> {
+    Command::new("bd")
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .map_err(|err| {
+            if err.kind() == ErrorKind::NotFound {
+                anyhow!("beads CLI not found; install `bd` to manage local tasks")
+            } else {
+                anyhow!("failed to run beads CLI: {err}")
+            }
+        })
+}
+
 fn parse_beads_list_output(output: Output) -> Result<Vec<LocalTaskSummary>> {
+    let value = parse_beads_json_output(output)?;
+    parse_beads_tasks(&value)
+}
+
+fn parse_beads_update_output(output: Output) -> Result<LocalTaskSummary> {
+    let value = parse_beads_json_output(output)?;
+    if let Some(task) = parse_beads_task(&value) {
+        return Ok(task);
+    }
+    for key in ["issue", "task"] {
+        if let Some(task) = value.get(key).and_then(parse_beads_task) {
+            return Ok(task);
+        }
+    }
+    bail!("beads JSON output did not contain an updated task");
+}
+
+fn parse_beads_json_output(output: Output) -> Result<Value> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let message = stderr.trim();
@@ -42,9 +86,8 @@ fn parse_beads_list_output(output: Output) -> Result<Vec<LocalTaskSummary>> {
         bail!("beads CLI failed: {message}");
     }
 
-    let value: Value = serde_json::from_slice(&output.stdout)
-        .map_err(|err| anyhow!("failed to parse beads JSON output: {err}"))?;
-    parse_beads_tasks(&value)
+    serde_json::from_slice(&output.stdout)
+        .map_err(|err| anyhow!("failed to parse beads JSON output: {err}"))
 }
 
 fn parse_beads_tasks(value: &Value) -> Result<Vec<LocalTaskSummary>> {
@@ -155,8 +198,9 @@ fn string_array(value: &Value) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_beads_tasks;
+    use super::{parse_beads_tasks, parse_beads_update_output};
     use serde_json::json;
+    use std::{os::unix::process::ExitStatusExt, process::Output};
 
     #[test]
     fn parses_array_output_from_bd_list_json() {
@@ -212,5 +256,19 @@ mod tests {
         assert_eq!(tasks[0].priority.as_deref(), Some("P2"));
         assert_eq!(tasks[0].dependencies, vec!["bd-2"]);
         assert!(tasks[0].blocked);
+    }
+
+    #[test]
+    fn parses_updated_issue_output() {
+        let task = parse_beads_update_output(Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: br#"{"issue":{"id":"bd-4","title":"Update status","status":"in_progress"}}"#
+                .to_vec(),
+            stderr: vec![],
+        })
+        .unwrap();
+
+        assert_eq!(task.id, "bd-4");
+        assert_eq!(task.status.as_deref(), Some("in_progress"));
     }
 }

--- a/src-tauri/src/adapters/tauri/commands.rs
+++ b/src-tauri/src/adapters/tauri/commands.rs
@@ -17,7 +17,8 @@ use crate::{
         list_local_tasks::ListLocalTasksUseCase, load_goal_file::LoadGoalFileUseCase,
         resolve_workdir::ResolveWorkdirUseCase, respond_permission::RespondPermissionUseCase,
         send_prompt::SendPromptUseCase, start_agent_run::StartAgentRunUseCase,
-        workspace_git::WorkspaceGitUseCase, workspace_worktree::WorkspaceTaskWorktreeUseCase,
+        update_local_task_status::UpdateLocalTaskStatusUseCase, workspace_git::WorkspaceGitUseCase,
+        workspace_worktree::WorkspaceTaskWorktreeUseCase,
     },
     domain::{
         acp_session::{
@@ -31,7 +32,7 @@ use crate::{
             WorkspaceCommitResult, WorkspaceDiffSummary, WorkspaceGitStatus, WorkspacePushRequest,
             WorkspacePushResult,
         },
-        local_task::LocalTaskList,
+        local_task::{LocalTaskList, LocalTaskStatus, LocalTaskSummary},
         pull_request_review::{
             CreatePullRequestReviewDraftInput, PullRequestReviewDraft, PullRequestReviewDraftId,
             UpdatePullRequestReviewDraftPatch,
@@ -433,6 +434,20 @@ pub async fn list_local_tasks(
 ) -> Result<LocalTaskList, String> {
     ListLocalTasksUseCase::new(storage.workspace_store(), BeadsCliTaskSource)
         .execute(&workspace_id, checkout_id.as_deref())
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn update_local_task_status(
+    storage: State<'_, StorageState>,
+    workspace_id: String,
+    checkout_id: Option<String>,
+    task_id: String,
+    status: LocalTaskStatus,
+) -> Result<LocalTaskSummary, String> {
+    UpdateLocalTaskStatusUseCase::new(storage.workspace_store(), BeadsCliTaskSource)
+        .execute(&workspace_id, checkout_id.as_deref(), &task_id, status)
         .await
         .map_err(|err| err.to_string())
 }

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -7,5 +7,6 @@ pub mod resolve_workdir;
 pub mod respond_permission;
 pub mod send_prompt;
 pub mod start_agent_run;
+pub mod update_local_task_status;
 pub mod workspace_git;
 pub mod workspace_worktree;

--- a/src-tauri/src/application/update_local_task_status.rs
+++ b/src-tauri/src/application/update_local_task_status.rs
@@ -1,12 +1,15 @@
 use anyhow::{Result, anyhow, bail};
 
 use crate::{
-    domain::{local_task::LocalTaskList, workspace::WorkspaceCheckout},
+    domain::{
+        local_task::{LocalTaskStatus, LocalTaskSummary},
+        workspace::WorkspaceCheckout,
+    },
     ports::{local_task_source::LocalTaskSource, workspace_store::WorkspaceStore},
 };
 
 #[derive(Clone)]
-pub struct ListLocalTasksUseCase<S, T>
+pub struct UpdateLocalTaskStatusUseCase<S, T>
 where
     S: WorkspaceStore,
     T: LocalTaskSource,
@@ -15,7 +18,7 @@ where
     task_source: T,
 }
 
-impl<S, T> ListLocalTasksUseCase<S, T>
+impl<S, T> UpdateLocalTaskStatusUseCase<S, T>
 where
     S: WorkspaceStore,
     T: LocalTaskSource,
@@ -28,35 +31,21 @@ where
         &self,
         workspace_id: &str,
         checkout_id: Option<&str>,
-    ) -> Result<LocalTaskList> {
-        let checkout = self.resolve_checkout(workspace_id, checkout_id).await?;
-        let workdir = checkout.path.to_string_lossy().to_string();
-        let detected = self.task_source.has_task_data(&checkout.path);
-        if !detected {
-            return Ok(LocalTaskList::unavailable(
-                workspace_id.trim().to_string(),
-                checkout.id,
-                workdir,
-                false,
-                "beads task data not found in workspace",
-            ));
+        task_id: &str,
+        status: LocalTaskStatus,
+    ) -> Result<LocalTaskSummary> {
+        let task_id = task_id.trim();
+        if task_id.is_empty() {
+            bail!("task id is required");
         }
 
-        match self.task_source.list_tasks(&checkout.path) {
-            Ok(tasks) => Ok(LocalTaskList::available(
-                workspace_id.trim().to_string(),
-                checkout.id,
-                workdir,
-                tasks,
-            )),
-            Err(err) => Ok(LocalTaskList::unavailable(
-                workspace_id.trim().to_string(),
-                checkout.id,
-                workdir,
-                true,
-                err.to_string(),
-            )),
+        let checkout = self.resolve_checkout(workspace_id, checkout_id).await?;
+        if !self.task_source.has_task_data(&checkout.path) {
+            bail!("beads task data not found in workspace");
         }
+
+        self.task_source
+            .update_status(&checkout.path, task_id, status)
     }
 
     async fn resolve_checkout(
@@ -100,13 +89,16 @@ mod tests {
     use super::*;
     use crate::{
         domain::{
-            local_task::{LocalTaskStatus, LocalTaskSummary},
+            local_task::LocalTaskSummary,
             workspace::{CheckoutId, GitOrigin, Workspace, WorkspaceCheckout, WorkspaceId},
         },
         ports::{local_task_source::LocalTaskSource, workspace_store::WorkspaceStore},
     };
     use anyhow::Result;
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex},
+    };
 
     #[derive(Clone)]
     struct FakeWorkspaceStore;
@@ -175,6 +167,7 @@ mod tests {
     #[derive(Clone)]
     struct FakeTaskSource {
         detected: bool,
+        updated: Arc<Mutex<Vec<(String, LocalTaskStatus)>>>,
     }
 
     impl LocalTaskSource for FakeTaskSource {
@@ -183,57 +176,69 @@ mod tests {
         }
 
         fn list_tasks(&self, _workdir: &Path) -> Result<Vec<LocalTaskSummary>> {
-            Ok(vec![LocalTaskSummary {
-                id: "bd-1".into(),
-                title: "Wire task list".into(),
-                description: Some("Show tasks".into()),
-                status: Some("open".into()),
-                priority: Some("1".into()),
-                labels: vec!["backend".into()],
-                dependencies: vec![],
-                blocked: false,
-                acceptance_criteria: Some("Tasks render".into()),
-            }])
+            Ok(vec![])
         }
 
         fn update_status(
             &self,
             _workdir: &Path,
-            _task_id: &str,
-            _status: LocalTaskStatus,
+            task_id: &str,
+            status: LocalTaskStatus,
         ) -> Result<LocalTaskSummary> {
-            unimplemented!("list tests do not update task status")
+            self.updated
+                .lock()
+                .unwrap()
+                .push((task_id.to_string(), status.clone()));
+            Ok(LocalTaskSummary {
+                id: task_id.into(),
+                title: "Wire task status".into(),
+                description: None,
+                status: Some(status.as_beads_status().into()),
+                priority: None,
+                labels: vec![],
+                dependencies: vec![],
+                blocked: false,
+                acceptance_criteria: None,
+            })
         }
     }
 
     #[tokio::test]
-    async fn returns_tasks_for_detected_workspace_data() {
-        let result =
-            ListLocalTasksUseCase::new(FakeWorkspaceStore, FakeTaskSource { detected: true })
-                .execute("workspace-1", None)
-                .await
-                .unwrap();
+    async fn updates_status_for_detected_workspace_data() {
+        let updates = Arc::new(Mutex::new(vec![]));
+        let result = UpdateLocalTaskStatusUseCase::new(
+            FakeWorkspaceStore,
+            FakeTaskSource {
+                detected: true,
+                updated: updates.clone(),
+            },
+        )
+        .execute("workspace-1", None, "bd-1", LocalTaskStatus::InProgress)
+        .await
+        .unwrap();
 
-        assert!(result.detected);
-        assert!(result.available);
-        assert_eq!(result.checkout_id, "checkout-1");
-        assert_eq!(result.tasks[0].id, "bd-1");
+        assert_eq!(result.status.as_deref(), Some("in_progress"));
+        assert_eq!(
+            updates.lock().unwrap().as_slice(),
+            &[("bd-1".into(), LocalTaskStatus::InProgress)]
+        );
     }
 
     #[tokio::test]
-    async fn reports_recoverable_missing_task_data() {
-        let result =
-            ListLocalTasksUseCase::new(FakeWorkspaceStore, FakeTaskSource { detected: false })
-                .execute("workspace-1", None)
-                .await
-                .unwrap();
+    async fn rejects_missing_task_data() {
+        let result = UpdateLocalTaskStatusUseCase::new(
+            FakeWorkspaceStore,
+            FakeTaskSource {
+                detected: false,
+                updated: Arc::new(Mutex::new(vec![])),
+            },
+        )
+        .execute("workspace-1", None, "bd-1", LocalTaskStatus::Closed)
+        .await;
 
-        assert!(!result.detected);
-        assert!(!result.available);
-        assert_eq!(result.tasks, Vec::<LocalTaskSummary>::new());
         assert_eq!(
-            result.error.as_deref(),
-            Some("beads task data not found in workspace")
+            result.unwrap_err().to_string(),
+            "beads task data not found in workspace"
         );
     }
 }

--- a/src-tauri/src/domain/local_task.rs
+++ b/src-tauri/src/domain/local_task.rs
@@ -1,6 +1,24 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalTaskStatus {
+    Open,
+    InProgress,
+    Closed,
+}
+
+impl LocalTaskStatus {
+    pub fn as_beads_status(&self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::InProgress => "in_progress",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalTaskSummary {
     pub id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,7 +18,7 @@ use adapters::{
         refresh_workspace_checkout, register_workspace_from_path, remove_workspace,
         resolve_workspace_workdir, respond_agent_permission, send_prompt_to_run, start_agent_run,
         submit_github_pull_request_review, summarize_workspace_diff, transfer_run_owner,
-        update_pull_request_review_draft, update_saved_prompt,
+        update_local_task_status, update_pull_request_review_draft, update_saved_prompt,
     },
 };
 use domain::workbench_window::{WorkbenchWindowCloseRequest, should_confirm_last_window_close};
@@ -90,6 +90,7 @@ pub fn run() {
             refresh_workspace_checkout,
             resolve_workspace_workdir,
             list_local_tasks,
+            update_local_task_status,
             get_workspace_git_status,
             summarize_workspace_diff,
             create_workspace_commit,

--- a/src-tauri/src/ports/local_task_source.rs
+++ b/src-tauri/src/ports/local_task_source.rs
@@ -1,10 +1,17 @@
 use anyhow::Result;
 use std::path::Path;
 
-use crate::domain::local_task::LocalTaskSummary;
+use crate::domain::local_task::{LocalTaskStatus, LocalTaskSummary};
 
 pub trait LocalTaskSource: Clone + Send + Sync + 'static {
     fn has_task_data(&self, workdir: &Path) -> bool;
 
     fn list_tasks(&self, workdir: &Path) -> Result<Vec<LocalTaskSummary>>;
+
+    fn update_status(
+        &self,
+        workdir: &Path,
+        task_id: &str,
+        status: LocalTaskStatus,
+    ) -> Result<LocalTaskSummary>;
 }

--- a/src/entities/workspace/index.ts
+++ b/src/entities/workspace/index.ts
@@ -10,6 +10,7 @@ export type {
   GitHubPullRequestSummary,
   GitOrigin,
   LocalTaskList,
+  LocalTaskStatus,
   LocalTaskSummary,
   PullRequestReviewComment,
   PullRequestReviewCommentSide,

--- a/src/entities/workspace/model.ts
+++ b/src/entities/workspace/model.ts
@@ -42,6 +42,8 @@ export type LocalTaskSummary = {
   acceptanceCriteria?: string | null;
 };
 
+export type LocalTaskStatus = "open" | "in_progress" | "closed";
+
 export type LocalTaskList = {
   workspaceId: string;
   checkoutId: string;

--- a/src/features/agent-run/api.test.ts
+++ b/src/features/agent-run/api.test.ts
@@ -27,6 +27,7 @@ import {
   startAgentRun,
   submitGitHubPullRequestReview,
   summarizeWorkspaceDiff,
+  updateLocalTaskStatus,
   updatePullRequestReviewDraft,
 } from "./api";
 import { setupTauriListeners } from "../../test/tauri";
@@ -132,6 +133,12 @@ describe("agent-run api", () => {
     mockedInvoke.mockResolvedValue(undefined);
 
     await listLocalTasks("ws-1", "co-1");
+    await updateLocalTaskStatus({
+      workspaceId: "ws-1",
+      checkoutId: "co-1",
+      taskId: "bd-1",
+      status: "in_progress",
+    });
     await getWorkspaceGitStatus("ws-1", "co-1");
     await summarizeWorkspaceDiff("ws-1", "co-1");
 
@@ -139,11 +146,17 @@ describe("agent-run api", () => {
       workspaceId: "ws-1",
       checkoutId: "co-1",
     });
-    expect(mockedInvoke).toHaveBeenNthCalledWith(2, "get_workspace_git_status", {
+    expect(mockedInvoke).toHaveBeenNthCalledWith(2, "update_local_task_status", {
+      workspaceId: "ws-1",
+      checkoutId: "co-1",
+      taskId: "bd-1",
+      status: "in_progress",
+    });
+    expect(mockedInvoke).toHaveBeenNthCalledWith(3, "get_workspace_git_status", {
       workspaceId: "ws-1",
       checkoutId: "co-1",
     });
-    expect(mockedInvoke).toHaveBeenNthCalledWith(3, "summarize_workspace_diff", {
+    expect(mockedInvoke).toHaveBeenNthCalledWith(4, "summarize_workspace_diff", {
       workspaceId: "ws-1",
       checkoutId: "co-1",
     });

--- a/src/features/agent-run/api.ts
+++ b/src/features/agent-run/api.ts
@@ -12,6 +12,8 @@ import type {
   GitHubPullRequestReviewResult,
   GitHubPullRequestSummary,
   LocalTaskList,
+  LocalTaskStatus,
+  LocalTaskSummary,
   PullRequestReviewDraft,
   RegisteredWorkspace,
   UpdatePullRequestReviewDraftPatch,
@@ -88,6 +90,15 @@ export function resolveWorkspaceWorkdir(args: {
 
 export function listLocalTasks(workspaceId: string, checkoutId?: string | null) {
   return invokeCommand<LocalTaskList>("list_local_tasks", { workspaceId, checkoutId });
+}
+
+export function updateLocalTaskStatus(args: {
+  workspaceId: string;
+  checkoutId?: string | null;
+  taskId: string;
+  status: LocalTaskStatus;
+}) {
+  return invokeCommand<LocalTaskSummary>("update_local_task_status", args);
 }
 
 export function getWorkspaceGitStatus(workspaceId: string, checkoutId?: string | null) {

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -43,6 +43,7 @@ export {
   resolveWorkspaceWorkdir,
   submitGitHubPullRequestReview,
   summarizeWorkspaceDiff,
+  updateLocalTaskStatus,
   updatePullRequestReviewDraft,
   updateSavedPrompt,
 } from "./api";

--- a/src/widgets/local-tasks/LocalTasksPanel.tsx
+++ b/src/widgets/local-tasks/LocalTasksPanel.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, CheckCircle2, ListChecks, Play, RefreshCw, SendToBack } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { LocalTaskList, LocalTaskSummary } from "../../entities/workspace";
-import { listLocalTasks } from "../../features/agent-run";
+import type { LocalTaskList, LocalTaskStatus, LocalTaskSummary } from "../../entities/workspace";
+import { listLocalTasks, updateLocalTaskStatus } from "../../features/agent-run";
 import { Badge, Button, NativeSelect, Textarea } from "../../shared/ui";
 
 type LocalTasksPanelProps = {
@@ -29,6 +29,7 @@ export function LocalTasksPanel({
   const [blockedFilter, setBlockedFilter] = useState("all");
   const [labelFilter, setLabelFilter] = useState("");
   const [loading, setLoading] = useState(false);
+  const [updatingTaskId, setUpdatingTaskId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -60,6 +61,30 @@ export function LocalTasksPanel({
   useEffect(() => {
     void load();
   }, [load]);
+
+  const updateStatus = useCallback(
+    async (task: LocalTaskSummary, status: LocalTaskStatus) => {
+      if (!workspaceId) return;
+      setUpdatingTaskId(task.id);
+      setError(null);
+      try {
+        await updateLocalTaskStatus({
+          workspaceId,
+          checkoutId,
+          taskId: task.id,
+          status,
+        });
+        await load();
+      } catch (err) {
+        const message = String(err);
+        setError(message);
+        onError(message);
+      } finally {
+        setUpdatingTaskId(null);
+      }
+    },
+    [checkoutId, load, onError, workspaceId],
+  );
 
   const tasks = result?.tasks ?? EMPTY_TASKS;
   const statusOptions = useMemo(
@@ -187,8 +212,10 @@ export function LocalTasksPanel({
               <TaskDetails
                 task={selectedTask}
                 sessionActive={sessionActive}
+                statusUpdating={updatingTaskId === selectedTask.id}
                 onApplyTaskGoal={onApplyTaskGoal}
                 onRunTaskGoal={onRunTaskGoal}
+                onUpdateStatus={updateStatus}
               />
             ) : null}
           </div>
@@ -201,12 +228,22 @@ export function LocalTasksPanel({
 type TaskDetailsProps = {
   task: LocalTaskSummary;
   sessionActive: boolean;
+  statusUpdating: boolean;
   onApplyTaskGoal: (goal: string, task: LocalTaskSummary) => void;
   onRunTaskGoal: (goal: string, task: LocalTaskSummary, allowBlockedTask: boolean) => void;
+  onUpdateStatus: (task: LocalTaskSummary, status: LocalTaskStatus) => void;
 };
 
-function TaskDetails({ task, sessionActive, onApplyTaskGoal, onRunTaskGoal }: TaskDetailsProps) {
+function TaskDetails({
+  task,
+  sessionActive,
+  statusUpdating,
+  onApplyTaskGoal,
+  onRunTaskGoal,
+  onUpdateStatus,
+}: TaskDetailsProps) {
   const goal = useMemo(() => composeTaskGoal(task), [task]);
+  const normalizedStatus = task.status?.toLowerCase();
   const handleRun = useCallback(() => {
     if (
       task.blocked &&
@@ -295,6 +332,43 @@ function TaskDetails({ task, sessionActive, onApplyTaskGoal, onRunTaskGoal }: Ta
           </p>
         </div>
       ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        {normalizedStatus !== "in_progress" ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={statusUpdating}
+            onClick={() => onUpdateStatus(task, "in_progress")}
+          >
+            Mark started
+          </Button>
+        ) : null}
+        {normalizedStatus !== "closed" ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            icon={<CheckCircle2 size={14} />}
+            disabled={statusUpdating}
+            onClick={() => onUpdateStatus(task, "closed")}
+          >
+            Mark done
+          </Button>
+        ) : null}
+        {normalizedStatus === "closed" ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={statusUpdating}
+            onClick={() => onUpdateStatus(task, "open")}
+          >
+            Reopen
+          </Button>
+        ) : null}
+      </div>
 
       <Textarea value={goal} readOnly aria-label="Generated task goal preview" rows={5} />
     </div>


### PR DESCRIPTION
## Summary
- add a Beads-backed local task status update command using `bd update <id> --status ... --json`
- expose explicit task actions in the local task panel for marking started, done, and reopening
- refresh task data after write-back and cover the new backend/API paths with tests

## Validation
- `cargo fmt --check && cargo test`
- `npm test`
- `npm run build`
- `npm run check:fsd`
- `npm run check:backend-boundaries`
- `git diff --check`

Refs #6