### PR TITLE
Add Spec Writer run scenario

### DIFF
--- a/src/features/agent-run/api.test.ts
+++ b/src/features/agent-run/api.test.ts
@@ -76,6 +76,7 @@ describe("agent-run api", () => {
       workspaceId: "workspace-1",
       checkoutId: "checkout-1",
       selectedAgentId: "codex",
+      scenario: "default",
       goal: "review the diff",
       cwd: "/repo",
       customCommand: "",

--- a/src/features/agent-run/index.ts
+++ b/src/features/agent-run/index.ts
@@ -18,6 +18,7 @@ export {
 } from "./tabApi";
 export { useAgentRun } from "./useAgentRun";
 export { type FollowUpQueueItem, type LocalTaskRunSource } from "./model";
+export { RUN_SCENARIOS, type RunScenarioId } from "./scenario";
 export {
   cleanupWorkspaceTaskWorktree,
   clearAcpSession,

--- a/src/features/agent-run/model.test.ts
+++ b/src/features/agent-run/model.test.ts
@@ -49,6 +49,7 @@ describe("workspace-scoped run state", () => {
       checkoutId: "checkout-1",
       cwd: "/repo/workbench",
       goal: "implement workspace tabs",
+      scenario: "spec-writer",
       selectedAgentId: "claude-code",
       sourceTask: {
         id: "bd-123",
@@ -82,6 +83,7 @@ describe("workspace-scoped run state", () => {
     });
     expect(run?.request).toMatchObject({
       goal: "implement workspace tabs",
+      scenario: "spec-writer",
       selectedAgentId: "claude-code",
     });
   });
@@ -181,6 +183,7 @@ describe("workspace-scoped run state", () => {
       filter: "all" as const,
       error: null,
       sourceTask: null,
+      scenario: "default",
       unreadCount: 2,
       permissionPending: false,
       closing: true,

--- a/src/features/agent-run/model.ts
+++ b/src/features/agent-run/model.ts
@@ -8,6 +8,7 @@ import {
   type TimelineItem,
 } from "../../entities/message";
 import type { LocalTaskSummary, Workspace, WorkspaceCheckout } from "../../entities/workspace";
+import type { RunScenarioId } from "./scenario";
 
 const defaultGoal = "todo rest api 를 nodejs 로 작성해주세요. 데이터는 json 파일로 저장해주세요";
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
@@ -30,6 +31,7 @@ export type FollowUpQueueItem = {
 
 export type AgentRunDraft = {
   selectedAgentId: string;
+  scenario: RunScenarioId;
   goal: string;
   customCommand: string;
   stdioBufferLimitMb: number;
@@ -86,6 +88,7 @@ export type TabState = {
   workspaceId: string | null;
   checkoutId: string | null;
   selectedAgentId: string;
+  scenario: RunScenarioId;
   goal: string;
   cwd: string;
   customCommand: string;
@@ -156,6 +159,7 @@ export function createTabState(preset: Partial<TabState> = {}, index = 0): TabSt
     workspaceId: preset.workspaceId ?? null,
     checkoutId: preset.checkoutId ?? null,
     selectedAgentId: preset.selectedAgentId ?? "claude-code",
+    scenario: preset.scenario ?? "default",
     goal: preset.goal ?? defaultGoal,
     cwd: preset.cwd ?? "~/tmp/acp-tauri-agent-workspace",
     customCommand: preset.customCommand ?? "",
@@ -183,6 +187,7 @@ export function createTabState(preset: Partial<TabState> = {}, index = 0): TabSt
 function tabToDraft(tab: TabState): AgentRunDraft {
   return {
     selectedAgentId: tab.selectedAgentId,
+    scenario: tab.scenario,
     goal: tab.goal,
     customCommand: tab.customCommand,
     stdioBufferLimitMb: tab.stdioBufferLimitMb,
@@ -527,6 +532,7 @@ export const useWorkbenchStore = create<WorkbenchState>((set, get) => ({
         next.draft = {
           ...next.draft,
           selectedAgentId: patch.selectedAgentId ?? next.draft.selectedAgentId,
+          scenario: patch.scenario ?? next.draft.scenario,
           goal: patch.goal ?? next.draft.goal,
           customCommand: patch.customCommand ?? next.draft.customCommand,
           stdioBufferLimitMb: patch.stdioBufferLimitMb ?? next.draft.stdioBufferLimitMb,
@@ -1020,6 +1026,7 @@ function workspaceViewToTabState(
     workspaceId: view.workspaceId,
     checkoutId: view.checkoutId,
     selectedAgentId: view.draft.selectedAgentId,
+    scenario: view.draft.scenario,
     goal: view.draft.goal,
     cwd: view.cwd,
     customCommand: view.draft.customCommand,

--- a/src/features/agent-run/scenario.test.ts
+++ b/src/features/agent-run/scenario.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { composeScenarioPrompt } from "./scenario";
+
+describe("run scenarios", () => {
+  it("keeps the default scenario prompt unchanged", () => {
+    expect(composeScenarioPrompt("default", "Ship the feature")).toBe("Ship the feature");
+  });
+
+  it("wraps spec writer runs in Spec-Kit style guidance", () => {
+    const prompt = composeScenarioPrompt("spec-writer", "Add workspace task orchestration", {
+      workdir: "/repo/workbench",
+    });
+
+    expect(prompt).toContain("Spec Writer");
+    expect(prompt).toContain("Feature request:\nAdd workspace task orchestration");
+    expect(prompt).toContain("Functional requirements must use stable IDs such as FR-001");
+    expect(prompt).toContain("at most 3 questions");
+    expect(prompt).toContain("Do not include implementation details");
+    expect(prompt).toContain("Workspace context: /repo/workbench");
+  });
+});

--- a/src/features/agent-run/scenario.ts
+++ b/src/features/agent-run/scenario.ts
@@ -1,0 +1,65 @@
+export type RunScenarioId = "default" | "spec-writer";
+
+export type RunScenarioOption = {
+  id: RunScenarioId;
+  label: string;
+  description: string;
+};
+
+export const RUN_SCENARIOS: RunScenarioOption[] = [
+  {
+    id: "default",
+    label: "Direct run",
+    description: "Send the goal to the selected agent unchanged.",
+  },
+  {
+    id: "spec-writer",
+    label: "Spec Writer",
+    description: "Generate a Spec-Kit style feature specification from the goal.",
+  },
+];
+
+type ScenarioPromptContext = {
+  workdir?: string | null;
+};
+
+export function composeScenarioPrompt(
+  scenario: RunScenarioId,
+  goal: string,
+  context: ScenarioPromptContext = {},
+) {
+  if (scenario === "default") return goal;
+  return composeSpecWriterPrompt(goal, context);
+}
+
+function composeSpecWriterPrompt(goal: string, context: ScenarioPromptContext) {
+  const workdir = context.workdir?.trim();
+  return [
+    "You are the Spec Writer for ACP Agent Workbench.",
+    "",
+    "Create a GitHub Spec-Kit compatible feature specification from the user's feature request.",
+    "Focus on WHAT users need and WHY. Do not include implementation details, technology choices, file paths, API designs, database schemas, or task checklists inside spec.md.",
+    "",
+    "Feature request:",
+    goal,
+    "",
+    "Required output:",
+    "- Generate a concise action-noun feature short name, 2-4 words when possible.",
+    "- Propose a target spec path using specs/<number>-<short-name>/spec.md. If the next number is unknown, use 001 as a safe placeholder and state that it should be reconciled with existing specs before writing.",
+    "- Draft the spec.md content with these sections when relevant: Feature Overview, User Scenarios / User Stories, Acceptance Scenarios, Functional Requirements, Edge Cases, Key Entities, Assumptions, and Success Criteria.",
+    "- Functional requirements must use stable IDs such as FR-001, FR-002, and be testable.",
+    "- Success criteria must be measurable, user-focused, and technology-agnostic.",
+    "- Use informed assumptions for ordinary gaps and list them under Assumptions.",
+    "- Ask clarification questions only when no safe assumption exists. Use at most 3 questions, prioritized by scope, security/privacy, then user experience.",
+    "- Keep the response ready for a later plan/tasks workflow; do not generate plan.md or tasks.md.",
+    "",
+    "Quality checklist to apply before finalizing:",
+    "- No implementation details in spec.md.",
+    "- Requirements are unambiguous and testable.",
+    "- Success criteria are measurable and technology-agnostic.",
+    "- Primary user scenarios and edge cases are covered.",
+    "- No unresolved placeholders remain except approved clarification markers.",
+    "",
+    workdir ? `Workspace context: ${workdir}` : "Workspace context: not selected.",
+  ].join("\n");
+}

--- a/src/features/agent-run/useAgentRun.ts
+++ b/src/features/agent-run/useAgentRun.ts
@@ -29,6 +29,7 @@ import {
   type TabState,
   type FollowUpQueueItem,
 } from "./model";
+import { composeScenarioPrompt, type RunScenarioId } from "./scenario";
 
 const EMPTY_FOLLOW_UP_QUEUE: FollowUpQueueItem[] = [];
 const EMPTY_ITEMS: TimelineItem[] = [];
@@ -97,6 +98,9 @@ export function useAgentRun(tabId: string) {
     const current = selectTab(useWorkbenchStore.getState(), tabId);
     if (!current) return;
     const trimmedGoal = (options.goal ?? current.goal).trim();
+    const submittedGoal = composeScenarioPrompt(current.scenario, trimmedGoal, {
+      workdir: current.cwd,
+    });
     const sourceTask = options.sourceTask ? localTaskRunSource(options.sourceTask) : current.sourceTask;
     if (!trimmedGoal) {
       patch({ error: "Goal is empty." });
@@ -142,6 +146,12 @@ export function useAgentRun(tabId: string) {
         message: sourceTaskRunMessage(options.sourceTask ?? sourceTask, Boolean(options.allowBlockedTask)),
       });
     }
+    if (current.scenario === "spec-writer") {
+      store.dispatchRunEvent(runId, {
+        type: "diagnostic",
+        message: "Spec Writer scenario selected; the run goal was composed as a Spec-Kit style specification prompt.",
+      });
+    }
 
     const originalCheckoutId = current.checkoutId ?? null;
     const originalCwd = current.cwd;
@@ -151,7 +161,7 @@ export function useAgentRun(tabId: string) {
 
     const request: AgentRunRequest = {
       runId,
-      goal: trimmedGoal,
+      goal: submittedGoal,
       agentId: current.selectedAgentId,
       workspaceId: current.workspaceId ?? undefined,
       checkoutId,
@@ -258,6 +268,7 @@ export function useAgentRun(tabId: string) {
     (value: string) => patch({ selectedAgentId: value }),
     [patch],
   );
+  const setScenario = useCallback((value: RunScenarioId) => patch({ scenario: value }), [patch]);
   const setGoal = useCallback((value: string) => patch({ goal: value, sourceTask: null }), [patch]);
   const setGoalFromTask = useCallback(
     (value: string, task?: LocalTaskSummary) =>
@@ -315,6 +326,8 @@ export function useAgentRun(tabId: string) {
     checkoutId: tab?.checkoutId ?? null,
     selectedAgentId: tab?.selectedAgentId ?? "",
     setSelectedAgentId,
+    scenario: tab?.scenario ?? "default",
+    setScenario,
     goal: tab?.goal ?? "",
     setGoal,
     setGoalFromTask,

--- a/src/pages/agent-workbench/index.tsx
+++ b/src/pages/agent-workbench/index.tsx
@@ -66,6 +66,8 @@ export function AgentWorkbenchPage() {
             agents={state.agents}
             selectedAgentId={state.selectedAgentId}
             onSelectAgent={state.setSelectedAgentId}
+            scenario={state.scenario}
+            onScenarioChange={state.setScenario}
             selectedAgent={state.selectedAgent}
             cwd={state.cwd}
             onCwdChange={state.setCwd}

--- a/src/widgets/run-panel/RunPanel.tsx
+++ b/src/widgets/run-panel/RunPanel.tsx
@@ -2,7 +2,7 @@ import { Octagon, Play, ShieldCheck, Trash2 } from "lucide-react";
 import type { AcpSessionRecord } from "../../entities/acp-session";
 import type { AgentDescriptor } from "../../entities/agent";
 import type { RalphLoopSettings, ResumePolicy } from "../../entities/message";
-import type { LocalTaskRunSource } from "../../features/agent-run";
+import { RUN_SCENARIOS, type LocalTaskRunSource, type RunScenarioId } from "../../features/agent-run";
 import { cn } from "../../shared/lib";
 import { Button, Card, CardContent, CardHeader, CardTitle, CardTitleBlock, Input, NativeSelect } from "../../shared/ui";
 
@@ -10,6 +10,8 @@ type RunPanelProps = {
   agents: AgentDescriptor[];
   selectedAgentId: string;
   onSelectAgent: (id: string) => void;
+  scenario: RunScenarioId;
+  onScenarioChange: (id: RunScenarioId) => void;
   selectedAgent?: AgentDescriptor;
   cwd: string;
   onCwdChange: (value: string) => void;
@@ -40,6 +42,8 @@ export function RunPanel({
   agents,
   selectedAgentId,
   onSelectAgent,
+  scenario,
+  onScenarioChange,
   selectedAgent,
   cwd,
   onCwdChange,
@@ -91,6 +95,24 @@ export function RunPanel({
               </option>
             ))}
           </NativeSelect>
+        </label>
+
+        <label className="grid gap-2">
+          <span className="text-sm font-medium">Scenario</span>
+          <NativeSelect
+            value={scenario}
+            onChange={(event) => onScenarioChange(event.target.value as RunScenarioId)}
+            disabled={isRunning}
+          >
+            {RUN_SCENARIOS.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </NativeSelect>
+          <span className="text-xs leading-relaxed text-muted-foreground">
+            {RUN_SCENARIOS.find((option) => option.id === scenario)?.description}
+          </span>
         </label>
 
         <label className="grid gap-2">


### PR DESCRIPTION
## Summary
- add a tab-aware run scenario model with `default` and `spec-writer`
- add a Spec-Kit style prompt composer focused on WHAT/WHY, FR IDs, measurable success criteria, and at most 3 clarification questions
- expose scenario selection in the execution panel while keeping direct runs unchanged by default

## Validation
- `cargo fmt --check && cargo test`
- `npm test`
- `npm run build`
- `npm run check:fsd`
- `npm run check:backend-boundaries`
- `git diff --check`

Refs #3